### PR TITLE
Fix architectural issues, wire up config, lock deps

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,5 +67,8 @@ where = ["src"]
 target-version = "py310"
 line-length = 100
 
+[tool.ruff.lint.per-file-ignores]
+"tests/fixtures/*" = ["F401", "F841", "E402"]
+
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/requirements-lock.txt
+++ b/requirements-lock.txt
@@ -1,0 +1,13 @@
+click==8.3.2
+colorama==0.4.6
+coverage==7.13.5
+iniconfig==2.3.0
+markdown-it-py==4.0.0
+mdurl==0.1.2
+packaging==26.0
+pluggy==1.6.0
+Pygments==2.20.0
+pytest==9.0.2
+pytest-cov==7.1.0
+rich==14.3.3
+ruff==0.15.9

--- a/src/gaudi/__init__.py
+++ b/src/gaudi/__init__.py
@@ -4,7 +4,9 @@ Gaudí — Not just structurally sound. Beautiful.
 A universal architecture linter for AI-assisted development.
 """
 
-__version__ = "0.1.0"
+from importlib.metadata import version as _version
+
+__version__ = _version("gaudi")
 
 from gaudi.core import Finding, Rule, Severity, Category
 from gaudi.engine import Engine

--- a/src/gaudi/cli.py
+++ b/src/gaudi/cli.py
@@ -18,6 +18,7 @@ import click
 from rich.console import Console
 from rich.text import Text
 
+from gaudi.config import load_config
 from gaudi.core import Severity
 from gaudi.engine import Engine
 
@@ -75,14 +76,17 @@ def check(
 ):
     """Check a project or file for architectural issues."""
     project_path = Path(path).resolve()
-    min_severity = Severity(severity)
+
+    # Load config from gaudi.toml, then let CLI flags override
+    config = load_config(project_path)
+    min_severity = Severity(severity or config.get("severity", "info"))
 
     # Initialize engine and discover packs
     engine = Engine()
     engine.discover_packs()
 
-    # Determine which packs to use
-    pack_names = list(pack) if pack else None
+    # CLI --pack flags override config; config packs override auto-detect
+    pack_names = list(pack) if pack else (config["packs"] or None)
 
     if pack_names:
         missing = [p for p in pack_names if p not in engine.packs]
@@ -96,8 +100,10 @@ def check(
 
     # Output results
     if output_format == "json":
+        from gaudi import __version__
+
         output = {
-            "version": "0.1.0",
+            "version": __version__,
             "path": str(project_path),
             "findings": [f.to_dict() for f in findings],
             "summary": engine.format_summary(findings),
@@ -134,7 +140,7 @@ def check(
 
                 # Recommendation
                 if finding.recommendation:
-                    console.print(f"  [dim]→ {finding.recommendation}[/dim]")
+                    console.print(f"  [dim]-> {finding.recommendation}[/dim]")
 
                 console.print()
 

--- a/src/gaudi/core.py
+++ b/src/gaudi/core.py
@@ -7,7 +7,7 @@ These are the building blocks that every language pack uses.
 from __future__ import annotations
 
 import json
-from dataclasses import dataclass, field, asdict
+from dataclasses import dataclass, field
 from enum import Enum
 from typing import Any
 
@@ -101,7 +101,7 @@ class Finding:
 
         lines = [f"{self.code} [{severity_tag}]{location} - {self.message}"]
         if self.recommendation:
-            lines.append(f"  → {self.recommendation}")
+            lines.append(f"  -> {self.recommendation}")
         return "\n".join(lines)
 
 

--- a/src/gaudi/engine.py
+++ b/src/gaudi/engine.py
@@ -4,12 +4,15 @@ The Gaudí engine — orchestrates pack discovery, loading, and execution.
 
 from __future__ import annotations
 
+import logging
 import sys
 from importlib.metadata import entry_points
 from pathlib import Path
 
 from gaudi.core import Finding, Severity
 from gaudi.pack import Pack
+
+logger = logging.getLogger(__name__)
 
 
 class Engine:
@@ -34,7 +37,7 @@ class Engine:
                 pack = pack_class()
                 self._packs[ep.name] = pack
             except Exception as e:
-                print(f"Warning: Failed to load pack '{ep.name}': {e}")
+                logger.warning("Failed to load pack '%s': %s", ep.name, e)
 
     def register_pack(self, pack: Pack) -> None:
         """Manually register a language pack."""

--- a/src/gaudi/pack.py
+++ b/src/gaudi/pack.py
@@ -26,7 +26,7 @@ class Pack:
 
     name: str = ""
     description: str = ""
-    extensions: list[str] = []  # File extensions this pack handles
+    extensions: tuple[str, ...] = ()  # File extensions this pack handles
 
     def __init__(self) -> None:
         self._rules: list[Rule] = []
@@ -45,11 +45,9 @@ class Pack:
         if path.is_file():
             return path.suffix in self.extensions
         if path.is_dir():
-            return any(
-                f.suffix in self.extensions
-                for f in path.rglob("*")
-                if f.is_file()
-            )
+            for ext in self.extensions:
+                if next(path.rglob(f"*{ext}"), None) is not None:
+                    return True
         return False
 
     def parse(self, path: Path) -> Any:

--- a/src/gaudi/packs/cpp/__init__.py
+++ b/src/gaudi/packs/cpp/__init__.py
@@ -122,7 +122,7 @@ CPP_RULES = [RawNewDelete(), MissingHeaderGuard(), UnsafeFunctions(), GodFile(),
 class CppPack(Pack):
     name = "cpp"
     description = "Memory management, header structure, safety patterns, and C/C++ idioms"
-    extensions = [".c", ".cpp", ".cc", ".cxx", ".h", ".hpp", ".hxx"]
+    extensions = (".c", ".cpp", ".cc", ".cxx", ".h", ".hpp", ".hxx")
     def __init__(self) -> None:
         super().__init__()
         for rule in CPP_RULES:

--- a/src/gaudi/packs/csharp/__init__.py
+++ b/src/gaudi/packs/csharp/__init__.py
@@ -113,7 +113,7 @@ CS_RULES = [AsyncVoidMethod(), DisposableNotDisposed(), EFNoAsNoTracking(), Catc
 class CSharpPack(Pack):
     name = "csharp"
     description = ".NET, Entity Framework, ASP.NET architecture"
-    extensions = [".cs"]
+    extensions = (".cs",)
     def __init__(self) -> None:
         super().__init__()
         for rule in CS_RULES:

--- a/src/gaudi/packs/go/__init__.py
+++ b/src/gaudi/packs/go/__init__.py
@@ -9,8 +9,6 @@ from __future__ import annotations
 
 import re
 from pathlib import Path
-from typing import Any
-
 from gaudi.core import Rule, Finding, Severity, Category
 from gaudi.pack import Pack
 
@@ -211,7 +209,7 @@ GO_RULES = [IgnoredError(), PanicInLibrary(), InitFunctionAbuse(), GodStruct(), 
 class GoPack(Pack):
     name = "go"
     description = "Error handling, interface design, package structure, and Go idioms"
-    extensions = [".go"]
+    extensions = (".go",)
 
     def __init__(self) -> None:
         super().__init__()

--- a/src/gaudi/packs/java/__init__.py
+++ b/src/gaudi/packs/java/__init__.py
@@ -133,7 +133,7 @@ JAVA_RULES = [CatchGenericException(), GodClass(), FieldInjection(), MissingTran
 class JavaPack(Pack):
     name = "java"
     description = "Spring Boot, Hibernate/JPA, and general Java architecture"
-    extensions = [".java"]
+    extensions = (".java",)
 
     def __init__(self) -> None:
         super().__init__()

--- a/src/gaudi/packs/javascript/__init__.py
+++ b/src/gaudi/packs/javascript/__init__.py
@@ -9,8 +9,6 @@ from __future__ import annotations
 import json
 import re
 from pathlib import Path
-from typing import Any
-
 from gaudi.core import Rule, Finding, Severity, Category
 from gaudi.pack import Pack
 
@@ -295,7 +293,7 @@ JS_RULES = [
 class JavaScriptPack(Pack):
     name = "javascript"
     description = "Express, Next.js, Prisma, React, and general JS/TS architecture"
-    extensions = [".js", ".ts", ".jsx", ".tsx", ".mjs", ".cjs"]
+    extensions = (".js", ".ts", ".jsx", ".tsx", ".mjs", ".cjs")
 
     def __init__(self) -> None:
         super().__init__()

--- a/src/gaudi/packs/kotlin/__init__.py
+++ b/src/gaudi/packs/kotlin/__init__.py
@@ -92,7 +92,7 @@ KT_RULES = [ForceNonNull(), GodActivity(), MutableStateExposed(), BlockingOnMain
 class KotlinPack(Pack):
     name = "kotlin"
     description = "Android, Spring, and Kotlin idioms"
-    extensions = [".kt", ".kts"]
+    extensions = (".kt", ".kts")
     def __init__(self) -> None:
         super().__init__()
         for rule in KT_RULES:

--- a/src/gaudi/packs/php/__init__.py
+++ b/src/gaudi/packs/php/__init__.py
@@ -101,7 +101,7 @@ PHP_RULES = [SQLInjection(), EloquentNPlusOne(), GodController(), EnvInCode()]
 class PHPPack(Pack):
     name = "php"
     description = "Laravel, Eloquent, and general PHP architecture"
-    extensions = [".php"]
+    extensions = (".php",)
     def __init__(self) -> None:
         super().__init__()
         for rule in PHP_RULES:

--- a/src/gaudi/packs/python/pack.py
+++ b/src/gaudi/packs/python/pack.py
@@ -9,7 +9,6 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from gaudi.core import Finding
 from gaudi.pack import Pack
 from gaudi.packs.python.context import PythonContext
 from gaudi.packs.python.parser import parse_project
@@ -27,8 +26,10 @@ class PythonPack(Pack):
     """
 
     name = "python"
-    description = "Full Python stack: Django, FastAPI, SQLAlchemy, Flask, Celery, Pandas, DRF, and 3.14 compat"
-    extensions = [".py"]
+    description = (
+        "Full Python stack: Django, FastAPI, SQLAlchemy, Flask, Celery, Pandas, DRF, and 3.14 compat"
+    )
+    extensions = (".py",)
 
     def __init__(self) -> None:
         super().__init__()

--- a/src/gaudi/packs/python/parser.py
+++ b/src/gaudi/packs/python/parser.py
@@ -8,7 +8,6 @@ and general Python project layout using AST parsing.
 from __future__ import annotations
 
 import ast
-import re
 from pathlib import Path
 
 from gaudi.packs.python.context import (

--- a/src/gaudi/packs/python/rules_libraries.py
+++ b/src/gaudi/packs/python/rules_libraries.py
@@ -8,7 +8,6 @@ Pandas, Requests/HTTPX, Pydantic, pytest, Django REST Framework.
 
 from __future__ import annotations
 
-import ast
 import re
 
 from gaudi.core import Rule, Finding, Severity, Category

--- a/src/gaudi/packs/python/rules_py314.py
+++ b/src/gaudi/packs/python/rules_py314.py
@@ -10,7 +10,6 @@ Reference: https://docs.python.org/3.14/whatsnew/3.14.html
 from __future__ import annotations
 
 import ast
-from pathlib import Path
 
 from gaudi.core import Rule, Finding, Severity, Category
 from gaudi.packs.python.context import PythonContext

--- a/src/gaudi/packs/ruby/__init__.py
+++ b/src/gaudi/packs/ruby/__init__.py
@@ -100,7 +100,7 @@ RB_RULES = [RailsNPlusOne(), FatModel(), CallbackHell(), UnscopedFind()]
 class RubyPack(Pack):
     name = "ruby"
     description = "Rails, ActiveRecord, and general Ruby architecture"
-    extensions = [".rb"]
+    extensions = (".rb",)
     def __init__(self) -> None:
         super().__init__()
         for rule in RB_RULES:

--- a/src/gaudi/packs/rust/__init__.py
+++ b/src/gaudi/packs/rust/__init__.py
@@ -170,7 +170,7 @@ RS_RULES = [UnsafeWithoutComment(), UnwrapInLibrary(), CloneOveruse(), StringErr
 class RustPack(Pack):
     name = "rust"
     description = "Module organization, error handling, unsafe usage, and Rust idioms"
-    extensions = [".rs"]
+    extensions = (".rs",)
 
     def __init__(self) -> None:
         super().__init__()

--- a/src/gaudi/packs/swift/__init__.py
+++ b/src/gaudi/packs/swift/__init__.py
@@ -81,7 +81,7 @@ SWIFT_RULES = [ForceUnwrap(), MassiveViewController(), RetainCycle()]
 class SwiftPack(Pack):
     name = "swift"
     description = "iOS architecture, SwiftUI, Core Data, and Swift idioms"
-    extensions = [".swift"]
+    extensions = (".swift",)
     def __init__(self) -> None:
         super().__init__()
         for rule in SWIFT_RULES:

--- a/tests/test_python_pack.py
+++ b/tests/test_python_pack.py
@@ -6,7 +6,6 @@ from pathlib import Path
 
 import pytest
 
-from gaudi.core import Severity, Category
 from gaudi.packs.python.pack import PythonPack
 from gaudi.packs.python.parser import parse_project
 from gaudi.engine import Engine
@@ -146,4 +145,4 @@ class TestFindingOutput:
         for f in findings:
             text = f.format_human()
             assert f.code in text
-            assert "→" in text
+            assert "->" in text


### PR DESCRIPTION
## Summary

- **Engine:** Replace `print()` with `logging` — middle-layer service shouldn't write to stdout directly
- **Pack:** Change `extensions` from mutable `list` to immutable `tuple` across all 11 packs to prevent shared-state bugs
- **Pack:** Early-exit in `can_handle()` to avoid scanning entire directory tree per pack during detection
- **CLI:** Wire up `gaudi.toml` config loading (config.py was dead code — now CLI reads it and uses it as defaults)
- **CLI:** Fix `UnicodeEncodeError` crash on Windows cp1252 consoles (replace `→` with `->`)
- **Version:** Derive `__version__` from package metadata via `importlib.metadata` instead of hardcoding in two places
- **Cleanup:** Remove unused imports across source and tests, add ruff `per-file-ignores` for test fixtures
- **Deps:** Add `requirements-lock.txt`

## Test plan

- [x] pytest: 17/17 passed
- [x] ruff: All checks passed
- [x] gaudi check src/: 2 warnings (false positives in rules_libraries.py example patterns)

🤖 Generated with [Claude Code](https://claude.com/claude-code)