### PR TITLE
Phase 2: Framework enum, Severity display, eliminate file re-reads

### DIFF
--- a/src/gaudi/cli.py
+++ b/src/gaudi/cli.py
@@ -24,18 +24,6 @@ from gaudi.engine import Engine
 
 console = Console()
 
-SEVERITY_STYLES = {
-    Severity.ERROR: "bold red",
-    Severity.WARN: "bold yellow",
-    Severity.INFO: "bold blue",
-}
-
-SEVERITY_LABELS = {
-    Severity.ERROR: "ERROR",
-    Severity.WARN: "WARN",
-    Severity.INFO: "INFO",
-}
-
 
 @click.group()
 @click.version_option(package_name="gaudi-linter")
@@ -117,8 +105,8 @@ def check(
         else:
             console.print()
             for finding in findings:
-                style = SEVERITY_STYLES[finding.severity]
-                label = SEVERITY_LABELS[finding.severity]
+                style = finding.severity.style
+                label = finding.severity.label
 
                 # Code and severity
                 header = Text()

--- a/src/gaudi/core.py
+++ b/src/gaudi/core.py
@@ -15,13 +15,25 @@ from typing import Any
 class Severity(Enum):
     """Severity levels for architectural findings."""
 
-    ERROR = "error"  # Must fix — this will break at scale or cause data loss
-    WARN = "warn"  # Should fix — this will cause pain eventually
-    INFO = "info"  # Consider — there may be a better approach
+    ERROR = "error"
+    WARN = "warn"
+    INFO = "info"
 
     @property
     def priority(self) -> int:
         return {Severity.ERROR: 0, Severity.WARN: 1, Severity.INFO: 2}[self]
+
+    @property
+    def label(self) -> str:
+        return self.value.upper()
+
+    @property
+    def style(self) -> str:
+        return {
+            Severity.ERROR: "bold red",
+            Severity.WARN: "bold yellow",
+            Severity.INFO: "bold blue",
+        }[self]
 
     def __lt__(self, other: Severity) -> bool:
         return self.priority < other.priority

--- a/src/gaudi/packs/python/context.py
+++ b/src/gaudi/packs/python/context.py
@@ -8,7 +8,18 @@ Django models, SQLAlchemy tables, project structure, etc.
 from __future__ import annotations
 
 from dataclasses import dataclass, field
+from enum import Enum
 from pathlib import Path
+
+
+class Framework(Enum):
+    """Python web frameworks detected by the parser."""
+
+    DJANGO = "django"
+    SQLALCHEMY = "sqlalchemy"
+    FASTAPI = "fastapi"
+    FLASK = "flask"
+    UNKNOWN = "unknown"
 
 
 @dataclass
@@ -69,9 +80,14 @@ class FileInfo:
 
     path: Path
     relative_path: str
+    source: str = ""
     line_count: int = 0
     imports: list[str] = field(default_factory=list)
     has_models: bool = False
+
+    def has_import(self, name: str) -> bool:
+        """Check if this file imports a module containing the given name."""
+        return any(name in imp for imp in self.imports)
 
 
 @dataclass
@@ -85,7 +101,7 @@ class PythonContext:
     root: Path
     models: list[ModelInfo] = field(default_factory=list)
     files: list[FileInfo] = field(default_factory=list)
-    framework: str = ""  # "django", "sqlalchemy", "fastapi", "unknown"
+    framework: Framework = Framework.UNKNOWN
     has_settings: bool = False
     has_requirements: bool = False
     has_pyproject: bool = False

--- a/src/gaudi/packs/python/parser.py
+++ b/src/gaudi/packs/python/parser.py
@@ -13,6 +13,7 @@ from pathlib import Path
 from gaudi.packs.python.context import (
     ColumnInfo,
     FileInfo,
+    Framework,
     ModelInfo,
     PythonContext,
 )
@@ -101,18 +102,16 @@ def parse_project(path: Path) -> PythonContext:
         # Detect framework from imports
         for imp in file_info.imports:
             if any(d in imp for d in DJANGO_IMPORTS):
-                context.framework = "django"
+                context.framework = Framework.DJANGO
             elif any(s in imp for s in SQLALCHEMY_IMPORTS):
-                if context.framework != "django":
-                    context.framework = "sqlalchemy"
+                if context.framework != Framework.DJANGO:
+                    context.framework = Framework.SQLALCHEMY
 
         # Extract models if this looks like a models file
         if file_info.has_models:
-            models = _extract_models(py_file, root, context.framework or "django")
+            fw = context.framework if context.framework != Framework.UNKNOWN else Framework.DJANGO
+            models = _extract_models(py_file, root, fw.value)
             context.models.extend(models)
-
-    if not context.framework:
-        context.framework = "unknown"
 
     return context
 
@@ -127,6 +126,7 @@ def _parse_file(filepath: Path, root: Path) -> FileInfo:
     file_info = FileInfo(
         path=filepath,
         relative_path=str(filepath.relative_to(root)),
+        source=source,
         line_count=source.count("\n") + 1,
     )
 

--- a/src/gaudi/packs/python/rules/architecture.py
+++ b/src/gaudi/packs/python/rules/architecture.py
@@ -8,7 +8,7 @@ to be machine-readable by AI coding agents.
 from __future__ import annotations
 
 from gaudi.core import Rule, Finding, Severity, Category
-from gaudi.packs.python.context import PythonContext, ModelInfo
+from gaudi.packs.python.context import Framework, PythonContext, ModelInfo
 
 
 # ---------------------------------------------------------------------------
@@ -366,7 +366,7 @@ class NoMetaPermissions(Rule):
     )
 
     def check(self, context: PythonContext) -> list[Finding]:
-        if context.framework != "django":
+        if context.framework != Framework.DJANGO:
             return []
 
         findings = []

--- a/src/gaudi/packs/python/rules/celery.py
+++ b/src/gaudi/packs/python/rules/celery.py
@@ -19,11 +19,10 @@ class CeleryNoRetry(Rule):
     def check(self, context: PythonContext) -> list[Finding]:
         findings = []
         for f in context.files:
-            if "celery" not in str(f.imports):
+            if not f.has_import("celery"):
                 continue
-            try:
-                source = f.path.read_text(encoding="utf-8", errors="replace")
-            except Exception:
+            source = f.source
+            if not source:
                 continue
             for i, line in enumerate(source.splitlines(), 1):
                 if "@" in line and (".task" in line or "shared_task" in line):
@@ -45,11 +44,10 @@ class CeleryNoTimeLimit(Rule):
     def check(self, context: PythonContext) -> list[Finding]:
         findings = []
         for f in context.files:
-            if "celery" not in str(f.imports):
+            if not f.has_import("celery"):
                 continue
-            try:
-                source = f.path.read_text(encoding="utf-8", errors="replace")
-            except Exception:
+            source = f.source
+            if not source:
                 continue
             for i, line in enumerate(source.splitlines(), 1):
                 if "@" in line and (".task" in line or "shared_task" in line):

--- a/src/gaudi/packs/python/rules/django.py
+++ b/src/gaudi/packs/python/rules/django.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from gaudi.core import Rule, Finding, Severity, Category
-from gaudi.packs.python.context import PythonContext
+from gaudi.packs.python.context import Framework, PythonContext
 
 
 class DjangoSecretKeyExposed(Rule):
@@ -21,9 +21,8 @@ class DjangoSecretKeyExposed(Rule):
         for f in context.files:
             if "settings" not in f.relative_path.lower():
                 continue
-            try:
-                source = f.path.read_text(encoding="utf-8", errors="replace")
-            except Exception:
+            source = f.source
+            if not source:
                 continue
             for i, line in enumerate(source.splitlines(), 1):
                 if (
@@ -51,9 +50,8 @@ class DjangoDebugTrue(Rule):
         for f in context.files:
             if "settings" not in f.relative_path.lower():
                 continue
-            try:
-                source = f.path.read_text(encoding="utf-8", errors="replace")
-            except Exception:
+            source = f.source
+            if not source:
                 continue
             for i, line in enumerate(source.splitlines(), 1):
                 stripped = line.strip()
@@ -73,7 +71,7 @@ class DjangoFatView(Rule):
     THRESHOLD = 300
 
     def check(self, context: PythonContext) -> list[Finding]:
-        if context.framework != "django":
+        if context.framework != Framework.DJANGO:
             return []
         findings = []
         for f in context.files:

--- a/src/gaudi/packs/python/rules/drf.py
+++ b/src/gaudi/packs/python/rules/drf.py
@@ -19,11 +19,10 @@ class DRFNoPermissionClass(Rule):
     def check(self, context: PythonContext) -> list[Finding]:
         findings = []
         for f in context.files:
-            if "rest_framework" not in str(f.imports):
+            if not f.has_import("rest_framework"):
                 continue
-            try:
-                source = f.path.read_text(encoding="utf-8", errors="replace")
-            except Exception:
+            source = f.source
+            if not source:
                 continue
             if ("ViewSet" in source or "APIView" in source) and "permission_classes" not in source:
                 findings.append(self.finding(file=f.relative_path))
@@ -43,11 +42,10 @@ class DRFNoThrottling(Rule):
     def check(self, context: PythonContext) -> list[Finding]:
         findings = []
         for f in context.files:
-            if "rest_framework" not in str(f.imports):
+            if not f.has_import("rest_framework"):
                 continue
-            try:
-                source = f.path.read_text(encoding="utf-8", errors="replace")
-            except Exception:
+            source = f.source
+            if not source:
                 continue
             if ("ViewSet" in source or "APIView" in source) and "throttle_classes" not in source:
                 findings.append(self.finding(file=f.relative_path))

--- a/src/gaudi/packs/python/rules/fastapi.py
+++ b/src/gaudi/packs/python/rules/fastapi.py
@@ -21,11 +21,10 @@ class FastAPINoResponseModel(Rule):
     def check(self, context: PythonContext) -> list[Finding]:
         findings = []
         for f in context.files:
-            if "fastapi" not in str(f.imports):
+            if not f.has_import("fastapi"):
                 continue
-            try:
-                source = f.path.read_text(encoding="utf-8", errors="replace")
-            except Exception:
+            source = f.source
+            if not source:
                 continue
             pattern = re.compile(r"@\w+\.(get|post|put|patch|delete)\s*\(")
             for i, line in enumerate(source.splitlines(), 1):
@@ -50,11 +49,10 @@ class FastAPISyncEndpoint(Rule):
     def check(self, context: PythonContext) -> list[Finding]:
         findings = []
         for f in context.files:
-            if "fastapi" not in str(f.imports):
+            if not f.has_import("fastapi"):
                 continue
-            try:
-                source = f.path.read_text(encoding="utf-8", errors="replace")
-            except Exception:
+            source = f.source
+            if not source:
                 continue
             lines = source.splitlines()
             for i, line in enumerate(lines, 1):

--- a/src/gaudi/packs/python/rules/flask.py
+++ b/src/gaudi/packs/python/rules/flask.py
@@ -21,11 +21,10 @@ class FlaskNoAppFactory(Rule):
     def check(self, context: PythonContext) -> list[Finding]:
         findings = []
         for f in context.files:
-            if "flask" not in str(f.imports):
+            if not f.has_import("flask"):
                 continue
-            try:
-                source = f.path.read_text(encoding="utf-8", errors="replace")
-            except Exception:
+            source = f.source
+            if not source:
                 continue
             for i, line in enumerate(source.splitlines(), 1):
                 stripped = line.strip()

--- a/src/gaudi/packs/python/rules/pandas.py
+++ b/src/gaudi/packs/python/rules/pandas.py
@@ -19,11 +19,10 @@ class PandasInplaceAntiPattern(Rule):
     def check(self, context: PythonContext) -> list[Finding]:
         findings = []
         for f in context.files:
-            if "pandas" not in str(f.imports):
+            if not f.has_import("pandas"):
                 continue
-            try:
-                source = f.path.read_text(encoding="utf-8", errors="replace")
-            except Exception:
+            source = f.source
+            if not source:
                 continue
             for i, line in enumerate(source.splitlines(), 1):
                 if "inplace=True" in line:
@@ -44,9 +43,8 @@ class PandasIterrows(Rule):
     def check(self, context: PythonContext) -> list[Finding]:
         findings = []
         for f in context.files:
-            try:
-                source = f.path.read_text(encoding="utf-8", errors="replace")
-            except Exception:
+            source = f.source
+            if not source:
                 continue
             for i, line in enumerate(source.splitlines(), 1):
                 if ".iterrows()" in line:

--- a/src/gaudi/packs/python/rules/py314.py
+++ b/src/gaudi/packs/python/rules/py314.py
@@ -154,10 +154,12 @@ class RemovedIn314Import(Rule):
     def check(self, context: PythonContext) -> list[Finding]:
         findings = []
         for file_info in context.files:
+            source = file_info.source
+            if not source:
+                continue
             try:
-                source = file_info.path.read_text(encoding="utf-8", errors="replace")
                 tree = ast.parse(source)
-            except (SyntaxError, Exception):
+            except SyntaxError:
                 continue
 
             for node in ast.walk(tree):
@@ -193,10 +195,12 @@ class DeprecatedIn314Import(Rule):
     def check(self, context: PythonContext) -> list[Finding]:
         findings = []
         for file_info in context.files:
+            source = file_info.source
+            if not source:
+                continue
             try:
-                source = file_info.path.read_text(encoding="utf-8", errors="replace")
                 tree = ast.parse(source)
-            except (SyntaxError, Exception):
+            except SyntaxError:
                 continue
 
             for node in ast.walk(tree):
@@ -264,10 +268,12 @@ class DeferredAnnotationAccess(Rule):
     def check(self, context: PythonContext) -> list[Finding]:
         findings = []
         for file_info in context.files:
+            source = file_info.source
+            if not source:
+                continue
             try:
-                source = file_info.path.read_text(encoding="utf-8", errors="replace")
                 tree = ast.parse(source)
-            except (SyntaxError, Exception):
+            except SyntaxError:
                 continue
 
             for node in ast.walk(tree):
@@ -306,10 +312,12 @@ class FinallyControlFlow(Rule):
     def check(self, context: PythonContext) -> list[Finding]:
         findings = []
         for file_info in context.files:
+            source = file_info.source
+            if not source:
+                continue
             try:
-                source = file_info.path.read_text(encoding="utf-8", errors="replace")
                 tree = ast.parse(source)
-            except (SyntaxError, Exception):
+            except SyntaxError:
                 continue
 
             findings.extend(self._check_node(tree, file_info.relative_path))
@@ -370,10 +378,12 @@ class NotImplementedBoolContext(Rule):
     def check(self, context: PythonContext) -> list[Finding]:
         findings = []
         for file_info in context.files:
+            source = file_info.source
+            if not source:
+                continue
             try:
-                source = file_info.path.read_text(encoding="utf-8", errors="replace")
                 tree = ast.parse(source)
-            except (SyntaxError, Exception):
+            except SyntaxError:
                 continue
 
             for node in ast.walk(tree):
@@ -418,19 +428,14 @@ class TarfileNoFilter(Rule):
     def check(self, context: PythonContext) -> list[Finding]:
         findings = []
         for file_info in context.files:
-            if "tarfile" not in str(file_info.path):
-                # Quick check: only parse files that might use tarfile
-                try:
-                    source = file_info.path.read_text(encoding="utf-8", errors="replace")
-                    if "tarfile" not in source:
-                        continue
-                except Exception:
-                    continue
-
+            source = file_info.source
+            if not source:
+                continue
+            if "tarfile" not in source:
+                continue
             try:
-                source = file_info.path.read_text(encoding="utf-8", errors="replace")
                 tree = ast.parse(source)
-            except (SyntaxError, Exception):
+            except SyntaxError:
                 continue
 
             for node in ast.walk(tree):

--- a/src/gaudi/packs/python/rules/pydantic.py
+++ b/src/gaudi/packs/python/rules/pydantic.py
@@ -21,11 +21,10 @@ class PydanticMutableDefault(Rule):
     def check(self, context: PythonContext) -> list[Finding]:
         findings = []
         for f in context.files:
-            if "pydantic" not in str(f.imports):
+            if not f.has_import("pydantic"):
                 continue
-            try:
-                source = f.path.read_text(encoding="utf-8", errors="replace")
-            except Exception:
+            source = f.source
+            if not source:
                 continue
             for i, line in enumerate(source.splitlines(), 1):
                 if re.search(r"=\s*\[\s*\]|=\s*\{\s*\}", line) and "Field(" not in line:

--- a/src/gaudi/packs/python/rules/pytest_rules.py
+++ b/src/gaudi/packs/python/rules/pytest_rules.py
@@ -21,9 +21,8 @@ class PytestAssertMessage(Rule):
         for f in context.files:
             if "test_" not in f.relative_path:
                 continue
-            try:
-                source = f.path.read_text(encoding="utf-8", errors="replace")
-            except Exception:
+            source = f.source
+            if not source:
                 continue
             for i, line in enumerate(source.splitlines(), 1):
                 stripped = line.strip()
@@ -55,9 +54,8 @@ class PytestFixtureScope(Rule):
         for f in context.files:
             if "conftest" not in f.relative_path:
                 continue
-            try:
-                source = f.path.read_text(encoding="utf-8", errors="replace")
-            except Exception:
+            source = f.source
+            if not source:
                 continue
             for i, line in enumerate(source.splitlines(), 1):
                 if "@pytest.fixture" in line and "scope=" not in line:

--- a/src/gaudi/packs/python/rules/requests_rules.py
+++ b/src/gaudi/packs/python/rules/requests_rules.py
@@ -21,9 +21,8 @@ class RequestsNoTimeout(Rule):
     def check(self, context: PythonContext) -> list[Finding]:
         findings = []
         for f in context.files:
-            try:
-                source = f.path.read_text(encoding="utf-8", errors="replace")
-            except Exception:
+            source = f.source
+            if not source:
                 continue
             pattern = re.compile(r"requests\.(get|post|put|patch|delete|head|options)\s*\(")
             for i, line in enumerate(source.splitlines(), 1):
@@ -47,11 +46,10 @@ class RequestsNoRetry(Rule):
     def check(self, context: PythonContext) -> list[Finding]:
         findings = []
         for f in context.files:
-            if "requests" not in str(f.imports):
+            if not f.has_import("requests"):
                 continue
-            try:
-                source = f.path.read_text(encoding="utf-8", errors="replace")
-            except Exception:
+            source = f.source
+            if not source:
                 continue
             if "requests.get" in source or "requests.post" in source:
                 if "Retry" not in source and "retry" not in source and "tenacity" not in source:

--- a/src/gaudi/packs/python/rules/sqlalchemy.py
+++ b/src/gaudi/packs/python/rules/sqlalchemy.py
@@ -19,11 +19,10 @@ class SQLAlchemySessionLeak(Rule):
     def check(self, context: PythonContext) -> list[Finding]:
         findings = []
         for f in context.files:
-            if "sqlalchemy" not in str(f.imports):
+            if not f.has_import("sqlalchemy"):
                 continue
-            try:
-                source = f.path.read_text(encoding="utf-8", errors="replace")
-            except Exception:
+            source = f.source
+            if not source:
                 continue
             for i, line in enumerate(source.splitlines(), 1):
                 if "Session()" in line and "with " not in line and "yield" not in line:
@@ -45,9 +44,8 @@ class SQLAlchemyLazyDefault(Rule):
     def check(self, context: PythonContext) -> list[Finding]:
         findings = []
         for f in context.files:
-            try:
-                source = f.path.read_text(encoding="utf-8", errors="replace")
-            except Exception:
+            source = f.source
+            if not source:
                 continue
             for i, line in enumerate(source.splitlines(), 1):
                 if "relationship(" in line and "lazy=" not in line:

--- a/tests/test_python_pack.py
+++ b/tests/test_python_pack.py
@@ -6,6 +6,7 @@ from pathlib import Path
 
 import pytest
 
+from gaudi.packs.python.context import Framework
 from gaudi.packs.python.pack import PythonPack
 from gaudi.packs.python.parser import parse_project
 from gaudi.engine import Engine
@@ -20,7 +21,7 @@ class TestParser:
 
     def test_parse_sample_models(self):
         context = parse_project(SAMPLE_MODELS)
-        assert context.framework == "django"
+        assert context.framework == Framework.DJANGO
         assert len(context.models) == 9
 
     def test_model_names(self):


### PR DESCRIPTION
## Summary

Addresses code smells #9, #11, #12, #13, #20 from the Fowler audit.

### Primitive Obsession (#11)
- **Framework enum** with `DJANGO`, `SQLALCHEMY`, `FASTAPI`, `FLASK`, `UNKNOWN` members
- Replaced all `context.framework == "django"` string comparisons with enum

### Repeated Switches (#12)
- **`Severity.label`** and **`Severity.style`** properties added to the enum
- Removed `SEVERITY_STYLES` and `SEVERITY_LABELS` module-level dicts from cli.py

### Insider Trading (#13) + Feature Envy (#9)
- **`FileInfo.source`** field — parser stores source content during parsing
- Eliminated **18x `f.path.read_text()`** calls across all rule files (rules no longer bypass the parser to re-read files)
- **`FileInfo.has_import(name)`** method — eliminated **11x `str(f.imports)`** hack

### Data Class (#20)
- `FileInfo` now has behavior (`has_import`), not just data

## Test plan

- [x] pytest: 17/17 passed
- [x] ruff check: All checks passed
- [x] ruff format: All files already formatted
- [x] gaudi check src/: 2 expected warnings

Closes #11, #12, partially addresses #9, #13, #20

🤖 Generated with [Claude Code](https://claude.com/claude-code)