### PR TITLE
Add boto3 library rules

### DIFF
--- a/docs/rule-registry.md
+++ b/docs/rule-registry.md
@@ -117,6 +117,9 @@ All 24 rules map directly to Fowler's smell catalog in *Refactoring* (2nd ed.), 
 | PYD-ARCH-001    | PydanticMutableDefault   | Pydantic    | FWDOCS: Pydantic validators             |
 | TEST-STRUCT-001 | PytestAssertMessage      | pytest      | FWDOCS: pytest assertion introspection  |
 | TEST-SCALE-001  | PytestFixtureScope       | pytest      | FWDOCS: pytest fixture optimization     |
+| AWS-ARCH-001    | HardcodedRegion          | boto3       | FWDOCS: AWS Well-Architected Framework  |
+| AWS-ERR-001     | BareClientCall           | boto3       | FWDOCS: boto3 error handling            |
+| AWS-SCALE-001   | UnpaginatedList          | boto3       | FWDOCS: boto3 pagination                |
 | DRF-SEC-001     | DRFNoPermissionClass     | DRF         | FWDOCS: DRF permissions                 |
 | DRF-SCALE-001   | DRFNoThrottling          | DRF         | FWDOCS: DRF throttling                  |
 

--- a/src/gaudi/packs/python/parser.py
+++ b/src/gaudi/packs/python/parser.py
@@ -31,6 +31,8 @@ _IMPORT_TO_LIBRARY: dict[str, str] = {
     "httpx": "requests",
     "pydantic": "pydantic",
     "pytest": "pytest",
+    "boto3": "boto3",
+    "botocore": "boto3",
 }
 
 # Maps PyPI package names to library activation keys
@@ -46,6 +48,7 @@ _PACKAGE_TO_LIBRARY: dict[str, str] = {
     "httpx": "requests",
     "pydantic": "pydantic",
     "pytest": "pytest",
+    "boto3": "boto3",
 }
 
 # Django field types that map to database columns

--- a/src/gaudi/packs/python/rules/__init__.py
+++ b/src/gaudi/packs/python/rules/__init__.py
@@ -13,6 +13,7 @@ from gaudi.packs.python.rules.pandas import PANDAS_RULES
 from gaudi.packs.python.rules.requests_rules import REQUESTS_RULES
 from gaudi.packs.python.rules.pydantic import PYDANTIC_RULES
 from gaudi.packs.python.rules.pytest_rules import PYTEST_RULES
+from gaudi.packs.python.rules.boto3 import BOTO3_RULES
 from gaudi.packs.python.rules.drf import DRF_RULES
 from gaudi.packs.python.rules.smells import SMELL_RULES
 from gaudi.packs.python.rules.packaging import PACKAGING_RULES
@@ -37,6 +38,7 @@ ALL_RULES = (
     *REQUESTS_RULES,
     *PYDANTIC_RULES,
     *PYTEST_RULES,
+    *BOTO3_RULES,
     *DRF_RULES,
     *SMELL_RULES,
     *PACKAGING_RULES,

--- a/src/gaudi/packs/python/rules/boto3.py
+++ b/src/gaudi/packs/python/rules/boto3.py
@@ -1,0 +1,188 @@
+# ABOUTME: boto3 library rules for Gaudi Python pack.
+# ABOUTME: Covers hardcoded regions, bare client calls, and unpaginated list operations.
+from __future__ import annotations
+
+import ast
+
+from gaudi.core import Category, Finding, Rule, Severity
+from gaudi.packs.python.context import PythonContext
+
+_BOTO3_CONSTRUCTORS = frozenset({"client", "resource", "Session"})
+
+_PAGINATED_PREFIXES = ("list_", "describe_", "get_log_events", "scan")
+
+
+def _is_boto3_call(node: ast.Call) -> bool:
+    """Check if node is boto3.client/resource/Session(...)."""
+    func = node.func
+    return (
+        isinstance(func, ast.Attribute)
+        and func.attr in _BOTO3_CONSTRUCTORS
+        and isinstance(func.value, ast.Name)
+        and func.value.id == "boto3"
+    )
+
+
+def _find_boto3_client_names(tree: ast.Module) -> set[str]:
+    """Find variable names assigned from boto3.client() or boto3.resource()."""
+    names: set[str] = set()
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Assign):
+            continue
+        if not isinstance(node.value, ast.Call):
+            continue
+        if not _is_boto3_call(node.value):
+            continue
+        func = node.value.func
+        if isinstance(func, ast.Attribute) and func.attr in ("client", "resource"):
+            for target in node.targets:
+                if isinstance(target, ast.Name):
+                    names.add(target.id)
+    return names
+
+
+def _is_inside_try(node: ast.AST, parent_map: dict[ast.AST, ast.AST]) -> bool:
+    """Check if a node is inside a Try body (has exception handling)."""
+    current = node
+    while current in parent_map:
+        parent = parent_map[current]
+        if isinstance(parent, ast.Try):
+            if current in parent.body:
+                return True
+        current = parent
+    return False
+
+
+def _build_parent_map(tree: ast.Module) -> dict[ast.AST, ast.AST]:
+    """Build a child-to-parent map for the AST."""
+    parent_map: dict[ast.AST, ast.AST] = {}
+    for node in ast.walk(tree):
+        for child in ast.iter_child_nodes(node):
+            parent_map[child] = node
+    return parent_map
+
+
+class HardcodedRegion(Rule):
+    code = "AWS-ARCH-001"
+    severity = Severity.WARN
+    category = Category.ARCHITECTURE
+    requires_library = "boto3"
+    message_template = "Hardcoded AWS region_name at line {line}"
+    recommendation_template = (
+        "Inject region via configuration or environment variable instead of "
+        "hardcoding. Hardcoded regions make multi-region deployment impossible."
+    )
+
+    def check(self, context: PythonContext) -> list[Finding]:
+        findings = []
+        for f in context.files:
+            tree = f.ast_tree
+            if tree is None:
+                continue
+            for node in ast.walk(tree):
+                if not isinstance(node, ast.Call):
+                    continue
+                if not _is_boto3_call(node):
+                    continue
+                for kw in node.keywords:
+                    if kw.arg == "region_name" and isinstance(kw.value, ast.Constant):
+                        findings.append(self.finding(file=f.relative_path, line=node.lineno))
+        return findings
+
+
+class BareClientCall(Rule):
+    code = "AWS-ERR-001"
+    severity = Severity.WARN
+    category = Category.ERROR_HANDLING
+    requires_library = "boto3"
+    message_template = "boto3 API call without error handling at line {line}"
+    recommendation_template = (
+        "Wrap boto3 API calls in try/except for botocore.exceptions.ClientError. "
+        "AWS calls fail for many reasons (permissions, throttling, network)."
+    )
+
+    def check(self, context: PythonContext) -> list[Finding]:
+        findings = []
+        for f in context.files:
+            tree = f.ast_tree
+            if tree is None:
+                continue
+            client_names = _find_boto3_client_names(tree)
+            if not client_names:
+                continue
+            parent_map = _build_parent_map(tree)
+            seen_lines: set[int] = set()
+            for node in ast.walk(tree):
+                if not isinstance(node, ast.Call):
+                    continue
+                if not self._is_client_api_call(node, client_names):
+                    continue
+                if node.lineno in seen_lines:
+                    continue
+                if not _is_inside_try(node, parent_map):
+                    seen_lines.add(node.lineno)
+                    findings.append(self.finding(file=f.relative_path, line=node.lineno))
+        return findings
+
+    @staticmethod
+    def _is_client_api_call(node: ast.Call, client_names: set[str]) -> bool:
+        """Check if node is a method call on a known boto3 client variable."""
+        func = node.func
+        if not isinstance(func, ast.Attribute):
+            return False
+        # Direct: client.put_object(...)
+        if isinstance(func.value, ast.Name) and func.value.id in client_names:
+            return True
+        # Chained: s3.Bucket('x').download_file(...)
+        # Only match the outermost call to avoid double-counting.
+        if isinstance(func.value, ast.Call):
+            inner_func = func.value.func
+            if isinstance(inner_func, ast.Attribute) and isinstance(inner_func.value, ast.Name):
+                if inner_func.value.id in client_names:
+                    return True
+        return False
+
+
+class UnpaginatedList(Rule):
+    code = "AWS-SCALE-001"
+    severity = Severity.WARN
+    category = Category.SCALABILITY
+    requires_library = "boto3"
+    message_template = "Unpaginated AWS API call '{method}' at line {line}"
+    recommendation_template = (
+        "Use client.get_paginator('{method}') instead of calling {method} directly. "
+        "Without pagination, results are truncated at AWS default limits."
+    )
+
+    def check(self, context: PythonContext) -> list[Finding]:
+        findings = []
+        for f in context.files:
+            tree = f.ast_tree
+            if tree is None:
+                continue
+            client_names = _find_boto3_client_names(tree)
+            if not client_names:
+                continue
+            for node in ast.walk(tree):
+                if not isinstance(node, ast.Call):
+                    continue
+                if not isinstance(node.func, ast.Attribute):
+                    continue
+                func = node.func
+                if not isinstance(func.value, ast.Name):
+                    continue
+                if func.value.id not in client_names:
+                    continue
+                method = func.attr
+                if any(method.startswith(p) for p in _PAGINATED_PREFIXES):
+                    findings.append(
+                        self.finding(
+                            file=f.relative_path,
+                            line=node.lineno,
+                            method=method,
+                        )
+                    )
+        return findings
+
+
+BOTO3_RULES = (HardcodedRegion(), BareClientCall(), UnpaginatedList())

--- a/tests/test_boto3_rules.py
+++ b/tests/test_boto3_rules.py
@@ -1,0 +1,188 @@
+# ABOUTME: Tests for boto3 library rules (AWS-ARCH-001, AWS-ERR-001, AWS-SCALE-001).
+# ABOUTME: Covers hardcoded regions, bare client calls, and unpaginated list operations.
+"""Tests for boto3 library-specific rules."""
+
+import tempfile
+from pathlib import Path
+
+from gaudi.packs.python.pack import PythonPack
+
+
+def _check_source(source: str) -> list:
+    """Helper: write source to a temp project with boto3 detected, return findings."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        root = Path(tmpdir)
+        (root / "pyproject.toml").write_text(
+            '[project]\nname = "myapp"\ndependencies = ["boto3"]\n'
+        )
+        (root / "app.py").write_text(source)
+        pack = PythonPack()
+        return pack.check(root)
+
+
+class TestHardcodedRegion:
+    """AWS-ARCH-001: region_name hardcoded instead of config-injected."""
+
+    def test_hardcoded_region_in_client(self):
+        source = "import boto3\n\nclient = boto3.client('s3', region_name='us-east-1')\n"
+        findings = _check_source(source)
+        hits = [f for f in findings if f.code == "AWS-ARCH-001"]
+        assert len(hits) == 1
+        assert hits[0].line == 3
+
+    def test_hardcoded_region_in_resource(self):
+        source = "import boto3\n\ns3 = boto3.resource('s3', region_name='eu-west-1')\n"
+        findings = _check_source(source)
+        hits = [f for f in findings if f.code == "AWS-ARCH-001"]
+        assert len(hits) == 1
+
+    def test_hardcoded_region_in_session(self):
+        source = "import boto3\n\nsession = boto3.Session(region_name='us-west-2')\n"
+        findings = _check_source(source)
+        hits = [f for f in findings if f.code == "AWS-ARCH-001"]
+        assert len(hits) == 1
+
+    def test_no_finding_when_region_from_variable(self):
+        source = (
+            "import boto3\n"
+            "import os\n"
+            "\n"
+            "region = os.environ['AWS_REGION']\n"
+            "client = boto3.client('s3', region_name=region)\n"
+        )
+        findings = _check_source(source)
+        hits = [f for f in findings if f.code == "AWS-ARCH-001"]
+        assert len(hits) == 0
+
+    def test_no_finding_when_no_region_kwarg(self):
+        source = "import boto3\n\nclient = boto3.client('s3')\n"
+        findings = _check_source(source)
+        hits = [f for f in findings if f.code == "AWS-ARCH-001"]
+        assert len(hits) == 0
+
+
+class TestBareClientCall:
+    """AWS-ERR-001: boto3 client/resource call without try/except for ClientError."""
+
+    def test_bare_client_method_call(self):
+        source = (
+            "import boto3\n"
+            "\n"
+            "def upload(bucket, key, data):\n"
+            "    client = boto3.client('s3')\n"
+            "    client.put_object(Bucket=bucket, Key=key, Body=data)\n"
+        )
+        findings = _check_source(source)
+        hits = [f for f in findings if f.code == "AWS-ERR-001"]
+        assert len(hits) == 1
+        assert hits[0].line == 5
+
+    def test_no_finding_when_wrapped_in_try(self):
+        source = (
+            "import boto3\n"
+            "from botocore.exceptions import ClientError\n"
+            "\n"
+            "def upload(bucket, key, data):\n"
+            "    client = boto3.client('s3')\n"
+            "    try:\n"
+            "        client.put_object(Bucket=bucket, Key=key, Body=data)\n"
+            "    except ClientError:\n"
+            "        pass\n"
+        )
+        findings = _check_source(source)
+        hits = [f for f in findings if f.code == "AWS-ERR-001"]
+        assert len(hits) == 0
+
+    def test_no_finding_when_wrapped_with_base_exception(self):
+        source = (
+            "import boto3\n"
+            "\n"
+            "def upload(bucket, key, data):\n"
+            "    client = boto3.client('s3')\n"
+            "    try:\n"
+            "        client.put_object(Bucket=bucket, Key=key, Body=data)\n"
+            "    except Exception:\n"
+            "        pass\n"
+        )
+        findings = _check_source(source)
+        hits = [f for f in findings if f.code == "AWS-ERR-001"]
+        assert len(hits) == 0
+
+    def test_bare_resource_method_call(self):
+        source = (
+            "import boto3\n"
+            "\n"
+            "def download():\n"
+            "    s3 = boto3.resource('s3')\n"
+            "    s3.Bucket('my-bucket').download_file('key', '/tmp/file')\n"
+        )
+        findings = _check_source(source)
+        hits = [f for f in findings if f.code == "AWS-ERR-001"]
+        assert len(hits) == 1
+
+
+class TestUnpaginatedList:
+    """AWS-SCALE-001: list_* operation without Paginator."""
+
+    def test_unpaginated_list_objects(self):
+        source = (
+            "import boto3\n"
+            "\n"
+            "def list_files():\n"
+            "    client = boto3.client('s3')\n"
+            "    return client.list_objects_v2(Bucket='my-bucket')\n"
+        )
+        findings = _check_source(source)
+        hits = [f for f in findings if f.code == "AWS-SCALE-001"]
+        assert len(hits) == 1
+        assert hits[0].line == 5
+
+    def test_unpaginated_list_buckets(self):
+        source = (
+            "import boto3\n"
+            "\n"
+            "def get_buckets():\n"
+            "    client = boto3.client('s3')\n"
+            "    return client.list_buckets()\n"
+        )
+        findings = _check_source(source)
+        hits = [f for f in findings if f.code == "AWS-SCALE-001"]
+        assert len(hits) == 1
+
+    def test_unpaginated_describe_instances(self):
+        source = (
+            "import boto3\n"
+            "\n"
+            "def get_instances():\n"
+            "    ec2 = boto3.client('ec2')\n"
+            "    return ec2.describe_instances()\n"
+        )
+        findings = _check_source(source)
+        hits = [f for f in findings if f.code == "AWS-SCALE-001"]
+        assert len(hits) == 1
+
+    def test_no_finding_for_non_list_operation(self):
+        source = (
+            "import boto3\n"
+            "\n"
+            "def get_object():\n"
+            "    client = boto3.client('s3')\n"
+            "    return client.get_object(Bucket='b', Key='k')\n"
+        )
+        findings = _check_source(source)
+        hits = [f for f in findings if f.code == "AWS-SCALE-001"]
+        assert len(hits) == 0
+
+    def test_no_finding_when_using_paginator(self):
+        source = (
+            "import boto3\n"
+            "\n"
+            "def list_files():\n"
+            "    client = boto3.client('s3')\n"
+            "    paginator = client.get_paginator('list_objects_v2')\n"
+            "    for page in paginator.paginate(Bucket='my-bucket'):\n"
+            "        yield from page['Contents']\n"
+        )
+        findings = _check_source(source)
+        hits = [f for f in findings if f.code == "AWS-SCALE-001"]
+        assert len(hits) == 0

--- a/tests/test_library_activation.py
+++ b/tests/test_library_activation.py
@@ -63,6 +63,7 @@ class TestLibraryFiltering:
                 "PYD-",
                 "TEST-",
                 "DRF-",
+                "AWS-",
             ]
             lib_codes = [
                 f.code for f in findings if any(f.code.startswith(p) for p in lib_prefixes)


### PR DESCRIPTION
## Summary
- Adds 3 AST-based boto3 rules: `AWS-ARCH-001` (hardcoded region), `AWS-ERR-001` (bare client call without error handling), `AWS-SCALE-001` (unpaginated list/describe operations)
- Registers `boto3`/`botocore` in library detection (parser.py)
- Updates rule-registry.md with new rules

Closes #38

## Test plan
- [x] 14 new tests in `test_boto3_rules.py` (positive + negative cases for all 3 rules)
- [x] `test_library_activation.py` updated with `AWS-` prefix filtering — all 6 tests pass
- [x] Full suite: 89 tests pass
- [x] `gaudi check src/` runs clean (no new issues)

🤖 Generated with [Claude Code](https://claude.com/claude-code)