### PR TITLE
Add dependency graph rules (DEP-001 through DEP-004)

### DIFF
--- a/docs/rule-registry.md
+++ b/docs/rule-registry.md
@@ -13,6 +13,7 @@ a mining queue for planned rules.
 |------------|---------------------------------------------------------------|------------------------|---------|
 | **FOWLER** | *Refactoring: Improving the Design of Existing Code*          | Martin Fowler          | 2nd     |
 | **NYGARD** | *Release It! Design and Deploy Production-Ready Software*     | Michael T. Nygard      | 2nd     |
+| **MARTIN** | *Clean Architecture: A Craftsman's Guide to Software Structure and Design* | Robert C. Martin | 1st  |
 | **ARCH90** | Architecture 90 (internal curriculum)                         | Nathan Krupa           | --      |
 | **PY314**  | CPython 3.14 changelog / PEPs                                 | Python core devs       | --      |
 | **FWDOCS** | Framework official documentation (Django, FastAPI, Flask, etc.)| Various                | --      |
@@ -149,6 +150,18 @@ detectable failure states -- exactly the grammar Gaudi needs.
 | STAB-007  | UnboundedThreadPool   | Unbalanced Capacities (anti-pattern)         | Ch. 4     |
 
 *STAB-002 (NoCircuitBreaker) removed -- detection too weak (project-level heuristic). Moved to mining queue.*
+
+### Dependency Graph Rules (DEP) -- Source: MARTIN
+
+Rules mined from *Clean Architecture*. Module-level coupling metrics that
+no other Python linter detects, because they require project-wide graph analysis.
+
+| Code     | Class Name           | Martin Principle                            | Detection                          |
+|----------|----------------------|----------------------------------------------|------------------------------------|
+| DEP-001  | CircularImport       | Acyclic Dependencies Principle (ADP)         | DFS cycle detection on import graph|
+| DEP-002  | FanOutExplosion      | Component coupling: efferent coupling (Ce)   | Internal imports per module >= 10  |
+| DEP-003  | FanInConcentration   | Fragile hub detection                        | Imported by >= 80% of project      |
+| DEP-004  | UnstableDependency   | Stable Dependencies Principle (SDP)          | I = Ce / (Ca + Ce) >= 0.5 with high Ca |
 
 ---
 

--- a/src/gaudi/packs/python/rules/__init__.py
+++ b/src/gaudi/packs/python/rules/__init__.py
@@ -27,6 +27,7 @@ from gaudi.packs.python.rules.stability import STABILITY_RULES
 from gaudi.packs.python.rules.services import SERVICE_RULES
 from gaudi.packs.python.rules.anthropic_rules import ANTHROPIC_RULES
 from gaudi.packs.python.rules.alembic import ALEMBIC_RULES
+from gaudi.packs.python.rules.dependency import DEPENDENCY_RULES
 
 ALL_RULES = (
     *ARCHITECTURE_RULES,
@@ -54,4 +55,5 @@ ALL_RULES = (
     *SERVICE_RULES,
     *ANTHROPIC_RULES,
     *ALEMBIC_RULES,
+    *DEPENDENCY_RULES,
 )

--- a/src/gaudi/packs/python/rules/dependency.py
+++ b/src/gaudi/packs/python/rules/dependency.py
@@ -1,0 +1,351 @@
+# ABOUTME: Dependency graph rules for module-level coupling analysis.
+# ABOUTME: Detects circular imports, fan-out/fan-in problems, and unstable dependencies.
+from __future__ import annotations
+
+import ast
+
+from gaudi.core import Category, Finding, Rule, Severity
+from gaudi.packs.python.context import FileInfo, PythonContext
+
+# Minimum project size for graph metrics to be meaningful
+_MIN_FILES_FOR_METRICS = 5
+
+# DEP-002 threshold: max internal imports before warning
+_FAN_OUT_THRESHOLD = 10
+
+# DEP-003 threshold: fraction of project files that import a module
+_FAN_IN_THRESHOLD = 0.8
+
+# DEP-004 threshold: instability above which a depended-on module is flagged
+# 0.5 means fan-out >= fan-in: as much outgoing as incoming coupling.
+_INSTABILITY_THRESHOLD = 0.5
+
+# DEP-004 threshold: minimum fan-in to be considered "depended on"
+_MIN_FAN_IN_FOR_UNSTABLE = 3
+
+
+def _register_module(rp: str, index: dict[str, str]) -> None:
+    """Register a single file's possible import names in the module index."""
+    if rp.endswith("__init__.py"):
+        pkg = rp.rsplit("/__init__.py", 1)[0].replace("/", ".")
+        if pkg:
+            index[pkg] = rp
+    elif rp.endswith(".py"):
+        dotted = rp[:-3].replace("/", ".")
+        index[dotted] = rp
+        bare = rp.rsplit("/", 1)[-1][:-3]
+        if bare not in index:
+            index[bare] = rp
+
+
+def _build_module_index(files: list[FileInfo]) -> dict[str, str]:
+    """Map possible import names to relative file paths.
+
+    For 'pkg/utils.py' registers both 'pkg.utils' and 'utils'.
+    For 'pkg/__init__.py' registers 'pkg'.
+    """
+    index: dict[str, str] = {}
+    for fi in files:
+        rp = fi.relative_path.replace("\\", "/")
+        _register_module(rp, index)
+    return index
+
+
+def _resolve_import(imp: str, module_index: dict[str, str]) -> str | None:
+    """Resolve an import string to a project-internal relative path.
+
+    Tries exact match first, then prefix matches for sub-imports.
+    Returns None for external/stdlib imports.
+    """
+    if imp in module_index:
+        return module_index[imp]
+    # Try prefix: 'pkg.mod.Class' might match 'pkg.mod'
+    parts = imp.split(".")
+    for i in range(len(parts) - 1, 0, -1):
+        prefix = ".".join(parts[:i])
+        if prefix in module_index:
+            return module_index[prefix]
+    return None
+
+
+def _extract_full_imports(fi: FileInfo) -> list[str]:
+    """Extract all import targets from a file's AST.
+
+    For 'import foo.bar' -> ['foo.bar']
+    For 'from foo import bar' -> ['foo.bar', 'foo']
+    For 'from foo.bar import baz' -> ['foo.bar.baz', 'foo.bar']
+
+    Returns both the full dotted path and the base module so resolution
+    can match either the submodule or the package.
+    """
+    tree = fi.ast_tree
+    if tree is None:
+        return []
+    targets: list[str] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                targets.append(alias.name)
+        elif isinstance(node, ast.ImportFrom) and node.module:
+            targets.append(node.module)
+            for alias in node.names:
+                targets.append(f"{node.module}.{alias.name}")
+    return targets
+
+
+def _build_internal_graph(
+    files: list[FileInfo], module_index: dict[str, str]
+) -> dict[str, set[str]]:
+    """Build directed graph: file_path -> set of internal file_paths it imports."""
+    graph: dict[str, set[str]] = {}
+    for fi in files:
+        rp = fi.relative_path.replace("\\", "/")
+        deps: set[str] = set()
+        for imp in _extract_full_imports(fi):
+            target = _resolve_import(imp, module_index)
+            if target and target != rp:  # No self-edges
+                deps.add(target)
+        graph[rp] = deps
+    return graph
+
+
+def _normalize_cycle(cycle: list[str]) -> list[str]:
+    """Rotate a cycle to start at its lexicographically smallest node."""
+    # cycle ends with a repeat of its start; strip it for rotation logic
+    body = cycle[:-1]
+    min_idx = body.index(min(body))
+    rotated = body[min_idx:] + body[:min_idx]
+    return rotated + [rotated[0]]
+
+
+class _CycleSearch:
+    """DFS state for finding elementary cycles in a directed graph."""
+
+    def __init__(self, graph: dict[str, set[str]]) -> None:
+        self.graph = graph
+        self.cycles: list[list[str]] = []
+        self.seen: set[tuple[str, ...]] = set()
+        self.visited: set[str] = set()
+        self.path: list[str] = []
+        self.path_set: set[str] = set()
+
+    def dfs(self, node: str) -> None:
+        if node in self.path_set:
+            self._record_cycle(node)
+            return
+        if node in self.visited:
+            return
+        self.visited.add(node)
+        self.path.append(node)
+        self.path_set.add(node)
+        for neighbor in sorted(self.graph.get(node, set())):
+            self.dfs(neighbor)
+        self.path.pop()
+        self.path_set.discard(node)
+
+    def _record_cycle(self, node: str) -> None:
+        cycle_start = self.path.index(node)
+        normalized = _normalize_cycle(self.path[cycle_start:] + [node])
+        key = tuple(normalized)
+        if key not in self.seen:
+            self.seen.add(key)
+            self.cycles.append(normalized)
+
+
+def _find_cycles(graph: dict[str, set[str]]) -> list[list[str]]:
+    """Find all elementary cycles in the graph using DFS."""
+    search = _CycleSearch(graph)
+    for start in sorted(graph):
+        search.visited.clear()
+        search.dfs(start)
+    return search.cycles
+
+
+def _compute_fan_in(graph: dict[str, set[str]]) -> dict[str, int]:
+    """Count how many modules import each module."""
+    fan_in: dict[str, int] = {}
+    for deps in graph.values():
+        for dep in deps:
+            fan_in[dep] = fan_in.get(dep, 0) + 1
+    return fan_in
+
+
+def _compute_fan_out(graph: dict[str, set[str]]) -> dict[str, int]:
+    """Count how many internal modules each module imports."""
+    return {node: len(deps) for node, deps in graph.items()}
+
+
+# ---------------------------------------------------------------
+# DEP-001  CircularImport
+# Martin, Clean Architecture: Acyclic Dependencies Principle
+# ---------------------------------------------------------------
+
+
+class CircularImport(Rule):
+    code = "DEP-001"
+    severity = Severity.ERROR
+    category = Category.ARCHITECTURE
+    message_template = "Circular import cycle: {cycle}"
+    recommendation_template = (
+        "Break the cycle by extracting shared code into a separate module,"
+        " using dependency inversion, or deferring imports."
+        " Circular imports cause ImportError at runtime in Python."
+    )
+
+    def check(self, context: PythonContext) -> list[Finding]:
+        module_index = _build_module_index(context.files)
+        graph = _build_internal_graph(context.files, module_index)
+        cycles = _find_cycles(graph)
+
+        findings: list[Finding] = []
+        for cycle in cycles:
+            cycle_str = " -> ".join(cycle)
+            findings.append(
+                self.finding(
+                    file=cycle[0],
+                    cycle=cycle_str,
+                )
+            )
+        return findings
+
+
+# ---------------------------------------------------------------
+# DEP-002  FanOutExplosion
+# Martin, Clean Architecture: component coupling metrics
+# ---------------------------------------------------------------
+
+
+class FanOutExplosion(Rule):
+    code = "DEP-002"
+    severity = Severity.WARN
+    category = Category.ARCHITECTURE
+    message_template = "Module '{file}' imports {count} internal modules (threshold: {threshold})"
+    recommendation_template = (
+        "Split this module into smaller, focused modules."
+        " High fan-out means a module has too many responsibilities"
+        " and is fragile to changes in any dependency."
+    )
+
+    def check(self, context: PythonContext) -> list[Finding]:
+        module_index = _build_module_index(context.files)
+        graph = _build_internal_graph(context.files, module_index)
+        fan_out = _compute_fan_out(graph)
+
+        findings: list[Finding] = []
+        for node, count in sorted(fan_out.items()):
+            if count >= _FAN_OUT_THRESHOLD:
+                findings.append(
+                    self.finding(
+                        file=node,
+                        count=count,
+                        threshold=_FAN_OUT_THRESHOLD,
+                    )
+                )
+        return findings
+
+
+# ---------------------------------------------------------------
+# DEP-003  FanInConcentration
+# Martin, Clean Architecture: fragile hub detection
+# ---------------------------------------------------------------
+
+
+class FanInConcentration(Rule):
+    code = "DEP-003"
+    severity = Severity.INFO
+    category = Category.ARCHITECTURE
+    message_template = (
+        "Module '{file}' is imported by {count}/{total} project modules"
+        " ({pct}% — threshold: {threshold}%)"
+    )
+    recommendation_template = (
+        "Consider whether this module is doing too much."
+        " A module imported everywhere becomes a fragile hub —"
+        " any change risks breaking the entire project."
+    )
+
+    def check(self, context: PythonContext) -> list[Finding]:
+        files = context.files
+        total = len(files)
+        if total < _MIN_FILES_FOR_METRICS:
+            return []
+
+        module_index = _build_module_index(files)
+        graph = _build_internal_graph(files, module_index)
+        fan_in = _compute_fan_in(graph)
+
+        findings: list[Finding] = []
+        for node, count in sorted(fan_in.items()):
+            ratio = count / total
+            if ratio >= _FAN_IN_THRESHOLD:
+                findings.append(
+                    self.finding(
+                        file=node,
+                        count=count,
+                        total=total,
+                        pct=int(ratio * 100),
+                        threshold=int(_FAN_IN_THRESHOLD * 100),
+                    )
+                )
+        return findings
+
+
+# ---------------------------------------------------------------
+# DEP-004  UnstableDependency
+# Martin, Clean Architecture: Stable Dependencies Principle
+# Instability I = fan_out / (fan_in + fan_out)
+# Flag: high instability AND high fan-in (depended on but volatile)
+# ---------------------------------------------------------------
+
+
+class UnstableDependency(Rule):
+    code = "DEP-004"
+    severity = Severity.WARN
+    category = Category.ARCHITECTURE
+    message_template = (
+        "Module '{file}' is unstable (I={instability:.2f}) but depended on by {fan_in} modules"
+    )
+    recommendation_template = (
+        "Stabilize this module by reducing its outgoing dependencies,"
+        " or depend on an abstraction instead."
+        " Per the Stable Dependencies Principle, modules that others depend on"
+        " should be stable (low instability)."
+    )
+
+    def check(self, context: PythonContext) -> list[Finding]:
+        if len(context.files) < _MIN_FILES_FOR_METRICS:
+            return []
+
+        module_index = _build_module_index(context.files)
+        graph = _build_internal_graph(context.files, module_index)
+        fan_in = _compute_fan_in(graph)
+        fan_out = _compute_fan_out(graph)
+
+        findings: list[Finding] = []
+        for node in sorted(graph):
+            fi = fan_in.get(node, 0)
+            fo = fan_out.get(node, 0)
+            if fi + fo == 0:
+                continue
+            instability = fo / (fi + fo)
+            if instability >= _INSTABILITY_THRESHOLD and fi >= _MIN_FAN_IN_FOR_UNSTABLE:
+                findings.append(
+                    self.finding(
+                        file=node,
+                        instability=instability,
+                        fan_in=fi,
+                    )
+                )
+        return findings
+
+
+# ---------------------------------------------------------------
+# Exported rule list
+# ---------------------------------------------------------------
+
+DEPENDENCY_RULES = (
+    CircularImport(),
+    FanOutExplosion(),
+    FanInConcentration(),
+    UnstableDependency(),
+)

--- a/tests/test_dependency_rules.py
+++ b/tests/test_dependency_rules.py
@@ -1,0 +1,230 @@
+# ABOUTME: Tests for dependency graph rules (DEP-001 through DEP-004).
+# ABOUTME: Covers circular imports, fan-out, fan-in, and unstable dependencies.
+"""Tests for dependency graph rules."""
+
+import tempfile
+from pathlib import Path
+
+from gaudi.packs.python.pack import PythonPack
+
+
+def _check_project(files: dict[str, str]) -> list:
+    """Create a temp project with given files and run all rules."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        root = Path(tmpdir)
+        (root / "pyproject.toml").write_text('[project]\nname = "myapp"\n')
+        for name, source in files.items():
+            filepath = root / name
+            filepath.parent.mkdir(parents=True, exist_ok=True)
+            filepath.write_text(source)
+        pack = PythonPack()
+        return pack.check(root)
+
+
+def _hits(findings: list, code: str) -> list:
+    return [f for f in findings if f.code == code]
+
+
+# ---------------------------------------------------------------
+# DEP-001  CircularImport
+# ---------------------------------------------------------------
+
+
+class TestCircularImport:
+    def test_direct_cycle_detected(self):
+        """A imports B, B imports A — should fire."""
+        findings = _check_project(
+            {
+                "a.py": "import b\nx = 1\n",
+                "b.py": "import a\ny = 2\n",
+            }
+        )
+        hits = _hits(findings, "DEP-001")
+        assert len(hits) >= 1
+
+    def test_three_node_cycle_detected(self):
+        """A→B→C→A cycle — should fire."""
+        findings = _check_project(
+            {
+                "a.py": "import b\n",
+                "b.py": "import c\n",
+                "c.py": "import a\n",
+            }
+        )
+        hits = _hits(findings, "DEP-001")
+        assert len(hits) >= 1
+
+    def test_no_cycle(self):
+        """Linear chain A→B→C — should not fire."""
+        findings = _check_project(
+            {
+                "a.py": "import b\n",
+                "b.py": "import c\n",
+                "c.py": "x = 1\n",
+            }
+        )
+        hits = _hits(findings, "DEP-001")
+        assert len(hits) == 0
+
+    def test_stdlib_imports_ignored(self):
+        """Imports of stdlib modules shouldn't create false cycles."""
+        findings = _check_project(
+            {
+                "a.py": "import os\nimport sys\n",
+                "b.py": "import os\nimport json\n",
+            }
+        )
+        hits = _hits(findings, "DEP-001")
+        assert len(hits) == 0
+
+    def test_package_imports_cycle(self):
+        """from pkg.mod import x style cycle — should fire."""
+        findings = _check_project(
+            {
+                "pkg/__init__.py": "",
+                "pkg/mod_a.py": "from pkg import mod_b\n",
+                "pkg/mod_b.py": "from pkg import mod_a\n",
+            }
+        )
+        hits = _hits(findings, "DEP-001")
+        assert len(hits) >= 1
+
+
+# ---------------------------------------------------------------
+# DEP-002  FanOutExplosion
+# ---------------------------------------------------------------
+
+
+class TestFanOutExplosion:
+    def test_high_fan_out_fires(self):
+        """Module importing 10+ internal modules should trigger."""
+        internal_modules = {f"mod_{i}.py": f"x = {i}\n" for i in range(12)}
+        imports = "\n".join(f"import mod_{i}" for i in range(12))
+        internal_modules["hub.py"] = imports + "\n"
+        findings = _check_project(internal_modules)
+        hits = _hits(findings, "DEP-002")
+        assert len(hits) >= 1
+
+    def test_low_fan_out_clean(self):
+        """Module importing only a few internal modules — should not fire."""
+        findings = _check_project(
+            {
+                "main.py": "import utils\nimport config\n",
+                "utils.py": "x = 1\n",
+                "config.py": "y = 2\n",
+            }
+        )
+        hits = _hits(findings, "DEP-002")
+        assert len(hits) == 0
+
+    def test_stdlib_not_counted(self):
+        """stdlib imports shouldn't count toward fan-out."""
+        source = "\n".join(
+            f"import {m}"
+            for m in [
+                "os",
+                "sys",
+                "json",
+                "pathlib",
+                "typing",
+                "dataclasses",
+                "collections",
+                "functools",
+                "itertools",
+                "re",
+                "hashlib",
+                "math",
+            ]
+        )
+        findings = _check_project({"app.py": source + "\n"})
+        hits = _hits(findings, "DEP-002")
+        assert len(hits) == 0
+
+
+# ---------------------------------------------------------------
+# DEP-003  FanInConcentration
+# ---------------------------------------------------------------
+
+
+class TestFanInConcentration:
+    def test_hub_module_fires(self):
+        """Module imported by 80%+ of project files — should fire."""
+        files = {"shared.py": "CONST = 42\n"}
+        # 10 files all importing shared
+        for i in range(10):
+            files[f"mod_{i}.py"] = "import shared\nx = 1\n"
+        findings = _check_project(files)
+        hits = _hits(findings, "DEP-003")
+        assert len(hits) >= 1
+
+    def test_normal_import_pattern_clean(self):
+        """Module imported by a few files — should not fire."""
+        findings = _check_project(
+            {
+                "utils.py": "x = 1\n",
+                "a.py": "import utils\n",
+                "b.py": "import utils\n",
+                "c.py": "x = 1\n",
+                "d.py": "x = 1\n",
+                "e.py": "x = 1\n",
+            }
+        )
+        hits = _hits(findings, "DEP-003")
+        assert len(hits) == 0
+
+    def test_small_project_not_triggered(self):
+        """Projects with < 5 files shouldn't trigger (not meaningful)."""
+        findings = _check_project(
+            {
+                "utils.py": "x = 1\n",
+                "a.py": "import utils\n",
+                "b.py": "import utils\n",
+            }
+        )
+        hits = _hits(findings, "DEP-003")
+        assert len(hits) == 0
+
+
+# ---------------------------------------------------------------
+# DEP-004  UnstableDependency
+# ---------------------------------------------------------------
+
+
+class TestUnstableDependency:
+    def test_unstable_hub_fires(self):
+        """High-instability module with high fan-in — should fire."""
+        # "hub" imports many things (high fan-out → high instability)
+        # AND many modules depend on it (high fan-in)
+        files = {}
+        # Create leaf modules
+        for i in range(8):
+            files[f"leaf_{i}.py"] = "x = 1\n"
+        # hub imports many leaves (high fan-out)
+        hub_imports = "\n".join(f"import leaf_{i}" for i in range(8))
+        files["hub.py"] = hub_imports + "\n"
+        # Many modules depend on hub (high fan-in)
+        for i in range(8):
+            files[f"consumer_{i}.py"] = "import hub\nx = 1\n"
+        findings = _check_project(files)
+        hits = _hits(findings, "DEP-004")
+        assert len(hits) >= 1
+
+    def test_stable_hub_clean(self):
+        """Module with high fan-in but low fan-out (stable) — should not fire."""
+        files = {"constants.py": "X = 1\nY = 2\n"}
+        for i in range(8):
+            files[f"mod_{i}.py"] = "import constants\nx = 1\n"
+        findings = _check_project(files)
+        hits = _hits(findings, "DEP-004")
+        assert len(hits) == 0
+
+    def test_small_project_not_triggered(self):
+        """Projects with < 5 files shouldn't trigger."""
+        findings = _check_project(
+            {
+                "a.py": "import b\n",
+                "b.py": "import a\n",
+            }
+        )
+        hits = _hits(findings, "DEP-004")
+        assert len(hits) == 0


### PR DESCRIPTION
## Summary

Implements 4 new dependency graph rules from Martin's *Clean Architecture*. These detect project-wide module coupling issues that no other Python linter catches, because they require building an internal import graph and analyzing it as a whole.

- **DEP-001 CircularImport** (ERROR) — DFS cycle detection on the import graph. Catches direct (A↔B), transitive (A→B→C→A), and package-level cycles.
- **DEP-002 FanOutExplosion** (WARN) — Modules importing 10+ other internal modules. Signals overgrown modules with too many responsibilities.
- **DEP-003 FanInConcentration** (INFO) — Modules imported by 80%+ of project files. Identifies fragile hubs where any change risks breaking the project.
- **DEP-004 UnstableDependency** (WARN) — Implements Martin's Stable Dependencies Principle: instability I = Ce / (Ca + Ce). Flags modules with high instability that are also widely depended on.

## Implementation Notes

- The existing parser only stores `node.module` for `from X import Y`, losing the imported name. The dependency rules do their own AST walk via `_extract_full_imports` to record both `pkg.mod_b` and `pkg` as targets, enabling cross-package cycle detection.
- Module index maps both dotted (`pkg.utils`) and bare (`utils`) names to file paths, so resolution handles both `import pkg.utils` and `import utils` styles.
- Metric rules (DEP-003, DEP-004) require >= 5 project files before firing, since coupling ratios on tiny projects aren't meaningful.

Resolves #48

## Test plan

- [x] 14 new tests covering positive and negative cases for all 4 rules
- [x] Direct cycle (A↔B), 3-node cycle (A→B→C→A), and `from pkg import` package-level cycles
- [x] Negative cases: stdlib imports ignored, linear chains, small projects
- [x] Full test suite passes (130 tests)
- [x] `ruff format --check` clean
- [x] Dogfood: `gaudi check src/gaudi` produces zero DEP findings on Gaudi itself