### PR TITLE
Wire gaudi.toml exclude patterns into the parser

### DIFF
--- a/gaudi.toml
+++ b/gaudi.toml
@@ -1,0 +1,8 @@
+# Gaudí configuration for the Gaudí project itself.
+# Schema: https://github.com/NathanKrupa/gaudi
+[gaudi]
+# Glob patterns excluded from analysis (in addition to the built-in defaults
+# like venv/ and __pycache__/). The fixture corpus under tests/fixtures/
+# contains deliberately broken sample code that exists to drive the rule
+# tests; running rules against it produces noise, not signal.
+exclude = ["tests/fixtures/**"]

--- a/src/gaudi/packs/python/pack.py
+++ b/src/gaudi/packs/python/pack.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
+from gaudi.config import load_config
 from gaudi.core import Finding
 from gaudi.pack import Pack
 from gaudi.packs.python.context import PythonContext
@@ -22,7 +23,10 @@ class PythonPack(Pack):
         self._rules = list(ALL_RULES)
 
     def parse(self, path: Path) -> PythonContext:
-        return parse_project(path)
+        project_root = path if path.is_dir() else path.parent
+        config = load_config(project_root)
+        extra_excludes = list(config.get("exclude") or [])
+        return parse_project(path, extra_excludes=extra_excludes)
 
     def check(self, path: Path) -> list[Finding]:
         context = self.parse(path)

--- a/src/gaudi/packs/python/parser.py
+++ b/src/gaudi/packs/python/parser.py
@@ -8,6 +8,7 @@ and general Python project layout using AST parsing.
 from __future__ import annotations
 
 import ast
+import re
 from pathlib import Path
 
 from gaudi.packs.python.context import (
@@ -98,12 +99,79 @@ DJANGO_FIELD_TYPES = frozenset(
 DJANGO_IMPORTS = frozenset({"django.db", "django.db.models", "models.Model"})
 SQLALCHEMY_IMPORTS = frozenset({"sqlalchemy", "sqlalchemy.orm"})
 
+# Built-in glob patterns excluded from analysis on every project. Stored in the
+# same gitignore-ish format as user-supplied excludes from gaudi.toml so a single
+# code path applies them. ``migrations`` is here for parity with the previous
+# hardcoded set; removing it is tracked as a follow-up.
+DEFAULT_EXCLUDE_GLOBS: tuple[str, ...] = (
+    "**/venv/**",
+    "**/.venv/**",
+    "**/env/**",
+    "**/.env/**",
+    "**/node_modules/**",
+    "**/__pycache__/**",
+    "**/.git/**",
+    "**/migrations/**",
+)
 
-def parse_project(path: Path) -> PythonContext:
+
+def _compile_glob(pattern: str) -> re.Pattern[str]:
+    """Translate a gitignore-ish glob into an anchored regex.
+
+    Supported syntax:
+      ``**`` -- match any number of path segments (including zero)
+      ``*``  -- match any characters except ``/``
+      ``?``  -- match a single character except ``/``
+
+    Patterns are matched against POSIX-style relative paths.
+    """
+    out: list[str] = ["^"]
+    i = 0
+    while i < len(pattern):
+        c = pattern[i]
+        if c == "*" and i + 1 < len(pattern) and pattern[i + 1] == "*":
+            i += 2
+            if i < len(pattern) and pattern[i] == "/":
+                # ``**/`` matches zero or more leading directories.
+                out.append("(?:.*/)?")
+                i += 1
+            else:
+                # Trailing ``**`` matches anything (including ``/``).
+                out.append(".*")
+        elif c == "*":
+            out.append("[^/]*")
+            i += 1
+        elif c == "?":
+            out.append("[^/]")
+            i += 1
+        elif c in r".+()|^${}\\":
+            out.append("\\" + c)
+            i += 1
+        else:
+            out.append(c)
+            i += 1
+    out.append("$")
+    return re.compile("".join(out))
+
+
+def _compile_exclude_patterns(patterns: list[str] | tuple[str, ...]) -> list[re.Pattern[str]]:
+    return [_compile_glob(p) for p in patterns]
+
+
+def _is_excluded(relpath: str, compiled: list[re.Pattern[str]]) -> bool:
+    """Return True if the POSIX-normalized relative path matches any pattern."""
+    posix = relpath.replace("\\", "/")
+    return any(rx.match(posix) for rx in compiled)
+
+
+def parse_project(path: Path, extra_excludes: list[str] | None = None) -> PythonContext:
     """
     Parse a Python project and extract structural information.
 
-    Handles both single files and directories.
+    Handles both single files and directories. ``extra_excludes`` are user-supplied
+    glob patterns from ``gaudi.toml``; they are layered on top of
+    :data:`DEFAULT_EXCLUDE_GLOBS` and matched against each candidate file's
+    project-relative POSIX path.
     """
     root = path if path.is_dir() else path.parent
     context = PythonContext(root=root)
@@ -111,19 +179,10 @@ def parse_project(path: Path) -> PythonContext:
     if path.is_file():
         py_files = [path]
     else:
-        py_files = sorted(path.rglob("*.py"))
-        # Filter out common non-project directories
-        exclude_dirs = {
-            "venv",
-            ".venv",
-            "env",
-            ".env",
-            "node_modules",
-            "__pycache__",
-            ".git",
-            "migrations",
-        }
-        py_files = [f for f in py_files if not any(part in exclude_dirs for part in f.parts)]
+        all_patterns = list(DEFAULT_EXCLUDE_GLOBS) + list(extra_excludes or [])
+        compiled = _compile_exclude_patterns(all_patterns)
+        candidates = sorted(path.rglob("*.py"))
+        py_files = [f for f in candidates if not _is_excluded(str(f.relative_to(path)), compiled)]
 
     # Detect project-level files
     if path.is_dir():

--- a/src/gaudi/packs/python/rules/alembic.py
+++ b/src/gaudi/packs/python/rules/alembic.py
@@ -10,19 +10,6 @@ from gaudi.packs.python.context import PythonContext
 _LIBRARY = "alembic"
 
 
-def _is_test_or_fixture(relpath: str) -> bool:
-    """Skip files under tests/, fixtures/, or named like test files.
-
-    Duplicated from complexity.py until we extract a shared helpers module.
-    Without this, running ``gaudi check`` against the Gaudi repo itself
-    matches our own ALM fixture corpus and reports findings on the test data.
-    """
-    parts = relpath.replace("\\", "/").split("/")
-    return any(p in {"tests", "test", "fixtures", "conftest.py"} for p in parts) or any(
-        p.startswith("test_") for p in parts
-    )
-
-
 def _is_alembic_migration(tree: ast.Module) -> bool:
     """Check if an AST looks like an alembic migration (has module-level `revision` assignment)."""
     for node in ast.iter_child_nodes(tree):
@@ -74,8 +61,6 @@ class MigrationNoDowngrade(Rule):
     def check(self, context: PythonContext) -> list[Finding]:
         findings = []
         for f in context.files:
-            if _is_test_or_fixture(f.relative_path):
-                continue
             tree = f.ast_tree
             if tree is None:
                 continue
@@ -105,8 +90,6 @@ class MultipleHeads(Rule):
         # Map down_revision -> list of migration files that depend on it
         children: dict[str, list[str]] = {}
         for f in context.files:
-            if _is_test_or_fixture(f.relative_path):
-                continue
             tree = f.ast_tree
             if tree is None:
                 continue

--- a/src/gaudi/packs/python/rules/complexity.py
+++ b/src/gaudi/packs/python/rules/complexity.py
@@ -8,13 +8,6 @@ from gaudi.core import Category, Finding, Rule, Severity
 from gaudi.packs.python.context import PythonContext
 
 
-def _is_test_or_fixture(relpath: str) -> bool:
-    parts = relpath.replace("\\", "/").split("/")
-    return any(p in {"tests", "test", "fixtures", "conftest.py"} for p in parts) or any(
-        p.startswith("test_") for p in parts
-    )
-
-
 def _public_module_members(tree: ast.Module) -> list[ast.AST]:
     """Top-level public functions and classes (or those in __all__ if present)."""
     explicit: set[str] | None = None
@@ -86,8 +79,6 @@ class ShallowModule(Rule):
     def check(self, context: PythonContext) -> list[Finding]:
         findings: list[Finding] = []
         for fi in context.files:
-            if _is_test_or_fixture(fi.relative_path):
-                continue
             if fi.path.name == "__init__.py":
                 continue
             tree = fi.ast_tree
@@ -181,8 +172,6 @@ class PassThroughVariable(Rule):
     def check(self, context: PythonContext) -> list[Finding]:
         findings: list[Finding] = []
         for fi in context.files:
-            if _is_test_or_fixture(fi.relative_path):
-                continue
             tree = fi.ast_tree
             if tree is None:
                 continue
@@ -245,8 +234,6 @@ class InformationLeakage(Rule):
     def check(self, context: PythonContext) -> list[Finding]:
         findings: list[Finding] = []
         for fi in context.files:
-            if _is_test_or_fixture(fi.relative_path):
-                continue
             tree = fi.ast_tree
             if tree is None:
                 continue
@@ -353,8 +340,6 @@ class ConjoinedMethods(Rule):
     def check(self, context: PythonContext) -> list[Finding]:
         findings: list[Finding] = []
         for fi in context.files:
-            if _is_test_or_fixture(fi.relative_path):
-                continue
             tree = fi.ast_tree
             if tree is None:
                 continue

--- a/tests/test_parser_excludes.py
+++ b/tests/test_parser_excludes.py
@@ -1,0 +1,147 @@
+# ABOUTME: Tests for the glob-based file-exclusion plumbing in parse_project / PythonPack.
+# ABOUTME: Covers _compile_glob translation, default excludes, and gaudi.toml-driven excludes.
+from __future__ import annotations
+
+from pathlib import Path
+
+from gaudi.packs.python.pack import PythonPack
+from gaudi.packs.python.parser import (
+    DEFAULT_EXCLUDE_GLOBS,
+    _compile_glob,
+    _is_excluded,
+    parse_project,
+)
+
+
+class TestCompileGlob:
+    def test_double_star_slash_matches_zero_segments(self) -> None:
+        rx = _compile_glob("**/venv/**")
+        assert rx.match("venv/lib/foo.py"), "**/venv/** should match a top-level venv dir"
+
+    def test_double_star_slash_matches_nested(self) -> None:
+        rx = _compile_glob("**/venv/**")
+        assert rx.match("app/venv/lib/foo.py"), "**/venv/** should match a nested venv dir"
+
+    def test_double_star_respects_segment_boundaries(self) -> None:
+        """``**/venv/**`` must NOT match a directory named ``myvenv`` -- the segment must align."""
+        rx = _compile_glob("**/venv/**")
+        assert not rx.match("myvenv/foo.py"), (
+            "**/venv/** should not match dirs that merely contain 'venv'"
+        )
+
+    def test_trailing_double_star_matches_subtree(self) -> None:
+        rx = _compile_glob("tests/fixtures/**")
+        assert rx.match("tests/fixtures/python/CPLX-001/fail_x.py")
+        assert rx.match("tests/fixtures/sample.py")
+
+    def test_single_star_does_not_cross_slash(self) -> None:
+        rx = _compile_glob("src/*.py")
+        assert rx.match("src/foo.py")
+        assert not rx.match("src/sub/foo.py"), "* should not cross directory boundaries"
+
+    def test_question_mark_single_char(self) -> None:
+        rx = _compile_glob("file?.py")
+        assert rx.match("file1.py")
+        assert not rx.match("file12.py")
+
+    def test_dot_in_pattern_is_literal(self) -> None:
+        rx = _compile_glob("**/.git/**")
+        assert rx.match(".git/HEAD")
+        assert rx.match("sub/.git/objects/abc")
+        assert not rx.match("git/HEAD"), ". in the pattern should be literal, not regex-any"
+
+
+class TestIsExcluded:
+    def test_normalizes_windows_separators(self) -> None:
+        compiled = [_compile_glob("**/venv/**")]
+        assert _is_excluded("app\\venv\\lib\\foo.py", compiled), (
+            "Windows backslashes should be normalized before matching"
+        )
+
+    def test_no_patterns_excludes_nothing(self) -> None:
+        assert not _is_excluded("anything/at/all.py", [])
+
+
+class TestParseProjectDefaults:
+    """Built-in DEFAULT_EXCLUDE_GLOBS skip the obvious infrastructure dirs."""
+
+    def test_venv_files_excluded(self, tmp_path: Path) -> None:
+        (tmp_path / "src").mkdir()
+        (tmp_path / "src" / "real.py").write_text("x = 1\n")
+        (tmp_path / "venv" / "lib").mkdir(parents=True)
+        (tmp_path / "venv" / "lib" / "site.py").write_text("y = 2\n")
+
+        ctx = parse_project(tmp_path)
+
+        rels = {f.relative_path.replace("\\", "/") for f in ctx.files}
+        assert "src/real.py" in rels
+        assert all("venv" not in r.split("/") for r in rels), (
+            f"venv files leaked into context: {rels}"
+        )
+
+    def test_pycache_excluded(self, tmp_path: Path) -> None:
+        (tmp_path / "src").mkdir()
+        (tmp_path / "src" / "real.py").write_text("x = 1\n")
+        (tmp_path / "src" / "__pycache__").mkdir()
+        (tmp_path / "src" / "__pycache__" / "real.cpython-312.pyc.py").write_text("# fake")
+
+        ctx = parse_project(tmp_path)
+
+        rels = {f.relative_path.replace("\\", "/") for f in ctx.files}
+        assert "src/real.py" in rels
+        assert all("__pycache__" not in r for r in rels)
+
+    def test_default_globs_are_a_tuple(self) -> None:
+        """Defaults must be immutable -- a list could be mutated by callers and break isolation."""
+        assert isinstance(DEFAULT_EXCLUDE_GLOBS, tuple)
+
+
+class TestParseProjectExtraExcludes:
+    def test_extra_excludes_layered_on_top_of_defaults(self, tmp_path: Path) -> None:
+        (tmp_path / "src" / "real.py").parent.mkdir(parents=True)
+        (tmp_path / "src" / "real.py").write_text("x = 1\n")
+        (tmp_path / "vendor").mkdir()
+        (tmp_path / "vendor" / "third_party.py").write_text("y = 2\n")
+        # venv is a default exclude -- it should still be filtered out
+        (tmp_path / "venv").mkdir()
+        (tmp_path / "venv" / "site.py").write_text("z = 3\n")
+
+        ctx = parse_project(tmp_path, extra_excludes=["vendor/**"])
+
+        rels = {f.relative_path.replace("\\", "/") for f in ctx.files}
+        assert rels == {"src/real.py"}
+
+    def test_none_extra_excludes_uses_only_defaults(self, tmp_path: Path) -> None:
+        (tmp_path / "app.py").write_text("x = 1\n")
+        ctx = parse_project(tmp_path, extra_excludes=None)
+        rels = {f.relative_path.replace("\\", "/") for f in ctx.files}
+        assert "app.py" in rels
+
+
+class TestPythonPackReadsGaudiToml:
+    """End-to-end: PythonPack.parse must read gaudi.toml from the project root."""
+
+    def test_excludes_from_gaudi_toml_are_applied(self, tmp_path: Path) -> None:
+        (tmp_path / "pyproject.toml").write_text("[project]\nname = 't'\n")
+        (tmp_path / "gaudi.toml").write_text("[gaudi]\nexclude = ['third_party/**']\n")
+        (tmp_path / "src").mkdir()
+        (tmp_path / "src" / "app.py").write_text("x = 1\n")
+        (tmp_path / "third_party").mkdir()
+        (tmp_path / "third_party" / "lib.py").write_text("y = 2\n")
+
+        pack = PythonPack()
+        ctx = pack.parse(tmp_path)
+
+        rels = {f.relative_path.replace("\\", "/") for f in ctx.files}
+        assert "src/app.py" in rels
+        assert "third_party/lib.py" not in rels
+
+    def test_no_gaudi_toml_falls_back_to_defaults_only(self, tmp_path: Path) -> None:
+        (tmp_path / "pyproject.toml").write_text("[project]\nname = 't'\n")
+        (tmp_path / "app.py").write_text("x = 1\n")
+
+        pack = PythonPack()
+        ctx = pack.parse(tmp_path)
+
+        rels = {f.relative_path.replace("\\", "/") for f in ctx.files}
+        assert "app.py" in rels


### PR DESCRIPTION
## Summary
- Wires `[gaudi].exclude = [...]` glob patterns from `gaudi.toml` through `PythonPack.parse` into `parse_project`, where they are layered on top of the built-in `DEFAULT_EXCLUDE_GLOBS` and applied via a single matching path.
- Converts the previously hardcoded `exclude_dirs` set into glob patterns of the same format as user excludes -- one mental model, one code path.
- Adds `gaudi.toml` at the project root excluding `tests/fixtures/**`.
- Removes the per-rule `_is_test_or_fixture` workaround from `complexity.py` and `alembic.py`.
- Closes the gap that `CLAUDE.md` (local) documented as "loads but exclusions not wired into engine."

## Why
PR #76 surfaced a recurring problem: rules fire on the project's own fixture data when `gaudi check` runs against the Gaudi repo. CPLX and ALM both worked around this with a per-rule `_is_test_or_fixture` skip helper -- a workaround for a missing config layer. With every cross-file rule in the issue #71 backlog about to need the same treatment, the right move was to fix the root cause once instead of paying the per-rule tax 22 more times.

## Design decisions and the principles that drove them

**Uniform representation -- one format, one code path.**
*Principle: dual formats are a debt source.* The previous hardcoded set of dir names and a hypothetical user glob list would have been two mental models for "how is this path being skipped?". Built-in defaults are now stored as glob patterns in the same gitignore-ish format users will write in `gaudi.toml`, and both flow through one matcher.

**Fix the root cause, not the symptom.**
*Principle: when N rules duplicate a workaround, the workaround belongs at the layer above.* Per-rule `_is_test_or_fixture` was treating the symptom that the parser couldn't be told what to skip. Wiring the config layer gives every rule (and every future rule) correct behavior for free, and the helpers delete cleanly.

**No new dependency for glob translation.**
*Principle: YAGNI on dependencies.* `_compile_glob` is ~25 lines that translate `**`, `*`, `?`, and literal segments to a regex. Critically, `**/venv/**` is segment-aware -- it matches `app/venv/x.py` but **not** `myvenv/x.py` (test case included). `pathspec` would have been overkill for this surface area.

**Architecture layering preserved.**
*Principle: INNER does not import MIDDLE.* `parse_project` (inner / parser) accepts an `extra_excludes` parameter; `PythonPack.parse` (middle / pack) loads `gaudi.toml` via `load_config` and threads the value in. The parser stays config-agnostic.

**Parameter named `extra_excludes`, not `exclude`.**
*Principle: names must make true claims.* `exclude` would imply "the complete exclude list", which is false because the parser also applies built-in defaults. `extra_excludes` accurately conveys the merge semantics.

## Side observation (not in scope)
`migrations` is still in `DEFAULT_EXCLUDE_GLOBS` for behavior parity with the previous hardcoded set. It is the only default that is project-policy rather than universal infrastructure -- a project might legitimately want to lint its migrations. Removing it deserves its own PR with a migration note for any users who silently relied on the default. **Tracked as a follow-up issue.**

## Test plan
- [x] `pytest tests/test_parser_excludes.py` -- 16 new unit tests covering `_compile_glob` translation (zero/nested/segment-boundary `**`, single `*` not crossing slashes, `?`, dot escaping), `_is_excluded` Windows path normalization, default exclusion behavior, layered extra excludes, and end-to-end `PythonPack.parse` reading `gaudi.toml`
- [x] Full `pytest` suite: 161 passed (was 145; +16 new)
- [x] `gaudi-fixture-coverage`: still 6/102 OK -- no rule regressed
- [x] `gaudi check` (dogfood): drops from **27 errors / 226 warnings / 155 infos across 95 files** to **0 errors / 154 warnings / 8 infos across 39 files**. The 27 errors and most of the warnings were rules firing on `tests/fixtures/*.py` legacy fixture data. Real findings in `src/` are unchanged.
- [x] `ruff format --check` and `ruff check` clean

Refs #71

🤖 Generated with [Claude Code](https://claude.com/claude-code)