### PR TITLE
Cite principles and source on every Rule subclass (closes #81)

### DIFF
--- a/src/gaudi/packs/python/rules/alembic.py
+++ b/src/gaudi/packs/python/rules/alembic.py
@@ -48,6 +48,12 @@ def _get_string_assign(tree: ast.Module, var_name: str) -> str | None:
 
 
 class MigrationNoDowngrade(Rule):
+    """Detect Alembic migrations missing a downgrade path.
+
+    Principles: #14 (Reversibility is a design property), #4 (Failure must be named).
+    Source: FWDOCS Alembic — every migration needs a downgrade for safe rollback.
+    """
+
     code = "ALM-ARCH-001"
     severity = Severity.WARN
     category = Category.ARCHITECTURE
@@ -73,6 +79,12 @@ class MigrationNoDowngrade(Rule):
 
 
 class MultipleHeads(Rule):
+    """Detect divergent (multiple) Alembic migration heads.
+
+    Principles: #14 (Reversibility is a design property), #1 (The structure tells the story).
+    Source: FWDOCS Alembic — branched heads block safe deploys until merged.
+    """
+
     code = "ALM-OPS-001"
     severity = Severity.ERROR
     category = Category.OPERATIONS

--- a/src/gaudi/packs/python/rules/anthropic_rules.py
+++ b/src/gaudi/packs/python/rules/anthropic_rules.py
@@ -58,6 +58,12 @@ def _build_parent_map(tree: ast.Module) -> dict[ast.AST, ast.AST]:
 
 
 class HardcodedModel(Rule):
+    """Detect hardcoded Anthropic model names instead of config injection.
+
+    Principles: #5 (State must be visible), #2 (One concept, one home).
+    Source: FWDOCS Anthropic SDK — model selection is configuration, not code.
+    """
+
     code = "LLM-ARCH-001"
     severity = Severity.WARN
     category = Category.ARCHITECTURE
@@ -89,6 +95,12 @@ class HardcodedModel(Rule):
 
 
 class BareAPICall(Rule):
+    """Detect Anthropic API calls without error handling for transient failures.
+
+    Principles: #4 (Failure must be named).
+    Source: FWDOCS Anthropic SDK + NYGARD Ch. 5 — every external call states its failures.
+    """
+
     code = "LLM-ERR-001"
     severity = Severity.WARN
     category = Category.ERROR_HANDLING
@@ -119,6 +131,12 @@ class BareAPICall(Rule):
 
 
 class NoTokenCounting(Rule):
+    """Detect Anthropic API calls without token counting safeguards.
+
+    Principles: #4 (Failure must be named).
+    Source: FWDOCS Anthropic SDK — token budgets are explicit failure modes.
+    """
+
     code = "LLM-SCALE-001"
     severity = Severity.WARN
     category = Category.SCALABILITY

--- a/src/gaudi/packs/python/rules/architecture.py
+++ b/src/gaudi/packs/python/rules/architecture.py
@@ -23,6 +23,9 @@ class NoTenantIsolation(Rule):
     If a project has 3+ models with relationships between them but no
     model has a tenant/organization/account foreign key, the project
     likely needs a tenant isolation strategy.
+
+    Principles: #1 (The structure tells the story), #4 (Failure must be named).
+    Source: FWDOCS Django multi-tenancy patterns — tenant isolation is structural.
     """
 
     code = "ARCH-001"
@@ -63,6 +66,9 @@ class NoTenantIsolation(Rule):
 class GodModel(Rule):
     """
     ARCH-002: Model with too many fields suggests it should be split.
+
+    Principles: #7 (Layers must earn their existence), #2 (One concept, one home).
+    Source: FOWLER Ch. 3 — Large Class, applied to ORM models.
     """
 
     code = "ARCH-002"
@@ -95,6 +101,9 @@ class GodModel(Rule):
 class NullableForeignKeySprawl(Rule):
     """
     ARCH-003: Multiple nullable ForeignKeys suggest missing join table or polymorphism.
+
+    Principles: #1 (The structure tells the story).
+    Source: FWDOCS Django relationship patterns — nullable FK sprawl signals a missing entity.
     """
 
     code = "ARCH-003"
@@ -137,6 +146,9 @@ class MissingStringIndex(Rule):
 
     CharField fields with common lookup names (email, slug, username, code, etc.)
     should have db_index=True.
+
+    Principles: #4 (Failure must be named).
+    Source: FWDOCS Django query optimization — missing indexes fail under load.
     """
 
     code = "IDX-001"
@@ -183,6 +195,9 @@ class MissingStringIndex(Rule):
 class NoIndexOnFilterableField(Rule):
     """
     IDX-002: DateTimeField without an index — common filter/sort target.
+
+    Principles: #4 (Failure must be named).
+    Source: FWDOCS Django query optimization — missing indexes fail under load.
     """
 
     code = "IDX-002"
@@ -224,6 +239,9 @@ class NoIndexOnFilterableField(Rule):
 class MissingTimestamps(Rule):
     """
     SCHEMA-001: Model without created_at/updated_at timestamps.
+
+    Principles: #13 (The system must explain itself).
+    Source: FWDOCS Django audit trail conventions — timestamps explain the row's history.
     """
 
     code = "SCHEMA-001"
@@ -273,6 +291,9 @@ class MissingTimestamps(Rule):
 class ColumnSprawl(Rule):
     """
     SCHEMA-002: Too many nullable columns suggest the table is trying to do too much.
+
+    Principles: #7 (Layers must earn their existence), #2 (One concept, one home).
+    Source: FOWLER Ch. 3 — Large Class, applied to schema width.
     """
 
     code = "SCHEMA-002"
@@ -315,6 +336,9 @@ class ColumnSprawl(Rule):
 class NoStringLengthLimit(Rule):
     """
     SCHEMA-003: TextField used where CharField with max_length might be appropriate.
+
+    Principles: #4 (Failure must be named).
+    Source: FWDOCS Django field best practices — unbounded text is an unbounded failure mode.
     """
 
     code = "SCHEMA-003"
@@ -354,6 +378,9 @@ class NoStringLengthLimit(Rule):
 class NoMetaPermissions(Rule):
     """
     SEC-001: Django model without explicit permissions in Meta.
+
+    Principles: #4 (Failure must be named).
+    Source: FWDOCS Django auth framework — implicit permissions are silent failure under hostile input.
     """
 
     code = "SEC-001"
@@ -390,6 +417,9 @@ class NoMetaPermissions(Rule):
 class SingleFileModels(Rule):
     """
     STRUCT-001: All models in a single file that's getting too long.
+
+    Principles: #1 (The structure tells the story), #7 (Layers must earn their existence).
+    Source: ARCH90 Day 1 — one concern per module.
     """
 
     code = "STRUCT-001"

--- a/src/gaudi/packs/python/rules/bloaters.py
+++ b/src/gaudi/packs/python/rules/bloaters.py
@@ -16,7 +16,11 @@ from gaudi.packs.python.context import PythonContext
 
 
 class LongFunction(Rule):
-    """SMELL-003: Functions that exceed 25 lines."""
+    """SMELL-003: Functions that exceed 25 lines.
+
+    Principles: #7 (Layers must earn their existence), #11 (The reader is the user).
+    Source: FOWLER Ch. 3 — Long Function.
+    """
 
     code = "SMELL-003"
     severity = Severity.WARN
@@ -56,7 +60,11 @@ class LongFunction(Rule):
 
 
 class LongParameterList(Rule):
-    """SMELL-004: Functions with too many parameters."""
+    """SMELL-004: Functions with too many parameters.
+
+    Principles: #11 (The reader is the user), #3 (Names are contracts).
+    Source: FOWLER Ch. 3 — Long Parameter List.
+    """
 
     code = "SMELL-004"
     severity = Severity.WARN
@@ -106,7 +114,11 @@ class LongParameterList(Rule):
 
 
 class LargeClass(Rule):
-    """SMELL-020: Classes with too many methods or attributes."""
+    """SMELL-020: Classes with too many methods or attributes.
+
+    Principles: #7 (Layers must earn their existence), #2 (One concept, one home).
+    Source: FOWLER Ch. 3 — Large Class.
+    """
 
     code = "SMELL-020"
     severity = Severity.WARN
@@ -165,7 +177,11 @@ class LargeClass(Rule):
 
 
 class DataClumps(Rule):
-    """SMELL-010: Same parameter groups in multiple functions."""
+    """SMELL-010: Same parameter groups in multiple functions.
+
+    Principles: #2 (One concept, one home).
+    Source: FOWLER Ch. 3 — Data Clumps.
+    """
 
     code = "SMELL-010"
     severity = Severity.INFO
@@ -275,7 +291,11 @@ def _collect_attr_string_compares(
 
 
 class PrimitiveObsession(Rule):
-    """SMELL-011: Attribute compared to many string literals."""
+    """SMELL-011: Attribute compared to many string literals.
+
+    Principles: #3 (Names are contracts).
+    Source: FOWLER Ch. 3 — Primitive Obsession.
+    """
 
     code = "SMELL-011"
     severity = Severity.WARN

--- a/src/gaudi/packs/python/rules/boto3.py
+++ b/src/gaudi/packs/python/rules/boto3.py
@@ -63,6 +63,12 @@ def _build_parent_map(tree: ast.Module) -> dict[ast.AST, ast.AST]:
 
 
 class HardcodedRegion(Rule):
+    """Detect hardcoded AWS region_name passed to boto3 clients.
+
+    Principles: #5 (State must be visible).
+    Source: FWDOCS boto3 + AWS Well-Architected — region is configuration.
+    """
+
     code = "AWS-ARCH-001"
     severity = Severity.WARN
     category = Category.ARCHITECTURE
@@ -91,6 +97,12 @@ class HardcodedRegion(Rule):
 
 
 class BareClientCall(Rule):
+    """Detect boto3 API calls without ClientError handling.
+
+    Principles: #4 (Failure must be named).
+    Source: FWDOCS boto3 error handling — every external call states its failures.
+    """
+
     code = "AWS-ERR-001"
     severity = Severity.WARN
     category = Category.ERROR_HANDLING
@@ -144,6 +156,12 @@ class BareClientCall(Rule):
 
 
 class UnpaginatedList(Rule):
+    """Detect AWS list/describe/scan calls without pagination.
+
+    Principles: #4 (Failure must be named).
+    Source: FWDOCS boto3 pagination — every result set has a bound.
+    """
+
     code = "AWS-SCALE-001"
     severity = Severity.WARN
     category = Category.SCALABILITY

--- a/src/gaudi/packs/python/rules/celery.py
+++ b/src/gaudi/packs/python/rules/celery.py
@@ -36,6 +36,12 @@ def _decorator_has_kwarg(node: ast.FunctionDef | ast.AsyncFunctionDef, *kwarg_na
 
 
 class CeleryNoRetry(Rule):
+    """Detect Celery tasks without retry configuration.
+
+    Principles: #4 (Failure must be named).
+    Source: FWDOCS Celery + NYGARD Ch. 5 — retries are how an external call states its failure mode.
+    """
+
     code = "CELERY-ARCH-001"
     severity = Severity.WARN
     category = Category.ARCHITECTURE
@@ -67,6 +73,12 @@ class CeleryNoRetry(Rule):
 
 
 class CeleryNoTimeLimit(Rule):
+    """Detect Celery tasks without time_limit/soft_time_limit.
+
+    Principles: #4 (Failure must be named).
+    Source: FWDOCS Celery + NYGARD Ch. 5 — every loop and call has a bound.
+    """
+
     code = "CELERY-SCALE-001"
     severity = Severity.WARN
     category = Category.SCALABILITY

--- a/src/gaudi/packs/python/rules/change_preventers.py
+++ b/src/gaudi/packs/python/rules/change_preventers.py
@@ -30,7 +30,11 @@ def _method_attr_set(
 
 
 class DivergentChange(Rule):
-    """SMELL-007: Class methods touch disjoint attribute sets."""
+    """SMELL-007: Class methods touch disjoint attribute sets.
+
+    Principles: #2 (One concept, one home), #7 (Layers must earn their existence).
+    Source: FOWLER Ch. 3 — Divergent Change.
+    """
 
     code = "SMELL-007"
     severity = Severity.WARN
@@ -109,7 +113,11 @@ class DivergentChange(Rule):
 
 
 class ShotgunSurgery(Rule):
-    """SMELL-008: Module-level name used in 4+ functions."""
+    """SMELL-008: Module-level name used in 4+ functions.
+
+    Principles: #2 (One concept, one home).
+    Source: FOWLER Ch. 3 — Shotgun Surgery.
+    """
 
     code = "SMELL-008"
     severity = Severity.WARN
@@ -184,7 +192,11 @@ class _Normalizer(ast.NodeTransformer):
 
 
 class DuplicatedCode(Rule):
-    """SMELL-002: Functions with identical normalized structure."""
+    """SMELL-002: Functions with identical normalized structure.
+
+    Principles: #2 (One concept, one home).
+    Source: FOWLER Ch. 3 — Duplicated Code.
+    """
 
     code = "SMELL-002"
     severity = Severity.WARN

--- a/src/gaudi/packs/python/rules/complexity.py
+++ b/src/gaudi/packs/python/rules/complexity.py
@@ -62,6 +62,12 @@ _MAX_AVG_DEPTH = 3.0
 
 
 class ShallowModule(Rule):
+    """Detect modules with many shallow public names (small interface, small body).
+
+    Principles: #7 (Layers must earn their existence).
+    Source: OUSTERHOUT Ch. 4 — Modules Should Be Deep.
+    """
+
     code = "CPLX-001"
     severity = Severity.INFO
     category = Category.COMPLEXITY
@@ -156,6 +162,12 @@ def _function_params(func: ast.FunctionDef | ast.AsyncFunctionDef) -> list[str]:
 
 
 class PassThroughVariable(Rule):
+    """Detect parameters threaded through many functions without use.
+
+    Principles: #7 (Layers must earn their existence).
+    Source: OUSTERHOUT Ch. 7 — Different Layer, Different Abstraction.
+    """
+
     code = "CPLX-002"
     severity = Severity.WARN
     category = Category.COMPLEXITY
@@ -221,6 +233,12 @@ def _annotation_leaks_private(ann: ast.expr | None) -> str | None:
 
 
 class InformationLeakage(Rule):
+    """Detect public function signatures that expose private types.
+
+    Principles: #10 (Boundaries are real or fictional).
+    Source: OUSTERHOUT Ch. 5 — Information Hiding.
+    """
+
     code = "CPLX-003"
     severity = Severity.WARN
     category = Category.COMPLEXITY
@@ -324,6 +342,12 @@ def _attrs_in_test(test: ast.expr) -> set[str]:
 
 
 class ConjoinedMethods(Rule):
+    """Detect classes whose methods have temporal-coupling state.
+
+    Principles: #7 (Layers must earn their existence), #5 (State must be visible).
+    Source: OUSTERHOUT Ch. 6 — General-Purpose Modules are Deeper.
+    """
+
     code = "CPLX-004"
     severity = Severity.INFO
     category = Category.COMPLEXITY

--- a/src/gaudi/packs/python/rules/config_rules.py
+++ b/src/gaudi/packs/python/rules/config_rules.py
@@ -13,6 +13,12 @@ from gaudi.packs.python.context import PythonContext
 
 
 class EnvLeakage(Rule):
+    """Detect class methods reading os.getenv() directly (env leakage).
+
+    Principles: #5 (State must be visible).
+    Source: ARCH90 Day 4 — config injection over direct environment reads.
+    """
+
     code = "ARCH-020"
     severity = Severity.WARN
     category = Category.ARCHITECTURE
@@ -86,6 +92,12 @@ class EnvLeakage(Rule):
 
 
 class ScatteredConfig(Rule):
+    """Detect environment reads scattered across many files.
+
+    Principles: #2 (One concept, one home).
+    Source: ARCH90 Day 4 — centralize configuration.
+    """
+
     code = "ARCH-022"
     severity = Severity.WARN
     category = Category.ARCHITECTURE

--- a/src/gaudi/packs/python/rules/couplers.py
+++ b/src/gaudi/packs/python/rules/couplers.py
@@ -15,7 +15,11 @@ from gaudi.packs.python.rules.dispensables import _BOILERPLATE_DUNDERS
 
 
 class FeatureEnvy(Rule):
-    """SMELL-009: Method accesses another object more than its own."""
+    """SMELL-009: Method accesses another object more than its own.
+
+    Principles: #10 (Boundaries are real or fictional).
+    Source: FOWLER Ch. 3 — Feature Envy.
+    """
 
     code = "SMELL-009"
     severity = Severity.WARN
@@ -69,7 +73,11 @@ class FeatureEnvy(Rule):
 
 
 class MessageChains(Rule):
-    """SMELL-017: Long attribute access chains."""
+    """SMELL-017: Long attribute access chains.
+
+    Principles: #10 (Boundaries are real or fictional).
+    Source: FOWLER Ch. 3 — Message Chains.
+    """
 
     code = "SMELL-017"
     severity = Severity.INFO
@@ -148,7 +156,11 @@ def _is_pure_delegation(method: ast.FunctionDef) -> bool:
 
 
 class MiddleMan(Rule):
-    """SMELL-018: Class that mostly delegates to another."""
+    """SMELL-018: Class that mostly delegates to another.
+
+    Principles: #7 (Layers must earn their existence).
+    Source: FOWLER Ch. 3 — Middle Man.
+    """
 
     code = "SMELL-018"
     severity = Severity.WARN
@@ -197,7 +209,11 @@ class MiddleMan(Rule):
 
 
 class InsiderTrading(Rule):
-    """SMELL-019: Method writes to another object's attributes."""
+    """SMELL-019: Method writes to another object's attributes.
+
+    Principles: #10 (Boundaries are real or fictional).
+    Source: FOWLER Ch. 3 — Insider Trading.
+    """
 
     code = "SMELL-019"
     severity = Severity.WARN

--- a/src/gaudi/packs/python/rules/dependency.py
+++ b/src/gaudi/packs/python/rules/dependency.py
@@ -182,6 +182,12 @@ def _compute_fan_out(graph: dict[str, set[str]]) -> dict[str, int]:
 
 
 class CircularImport(Rule):
+    """Detect circular imports between modules.
+
+    Principles: #9 (Dependencies flow toward stability), #1 (The structure tells the story).
+    Source: MARTIN Clean Architecture — Acyclic Dependencies Principle.
+    """
+
     code = "DEP-001"
     severity = Severity.ERROR
     category = Category.ARCHITECTURE
@@ -216,6 +222,12 @@ class CircularImport(Rule):
 
 
 class FanOutExplosion(Rule):
+    """Detect modules with high efferent coupling (fan-out explosion).
+
+    Principles: #9 (Dependencies flow toward stability), #7 (Layers must earn their existence).
+    Source: MARTIN Clean Architecture — efferent coupling (Ce).
+    """
+
     code = "DEP-002"
     severity = Severity.WARN
     category = Category.ARCHITECTURE
@@ -251,6 +263,12 @@ class FanOutExplosion(Rule):
 
 
 class FanInConcentration(Rule):
+    """Detect modules imported by most of the project (fragile hub).
+
+    Principles: #9 (Dependencies flow toward stability).
+    Source: MARTIN Clean Architecture — fragile hub detection.
+    """
+
     code = "DEP-003"
     severity = Severity.INFO
     category = Category.ARCHITECTURE
@@ -299,6 +317,12 @@ class FanInConcentration(Rule):
 
 
 class UnstableDependency(Rule):
+    """Detect modules that violate the Stable Dependencies Principle.
+
+    Principles: #9 (Dependencies flow toward stability).
+    Source: MARTIN Clean Architecture — Stable Dependencies Principle (SDP).
+    """
+
     code = "DEP-004"
     severity = Severity.WARN
     category = Category.ARCHITECTURE

--- a/src/gaudi/packs/python/rules/dispensables.py
+++ b/src/gaudi/packs/python/rules/dispensables.py
@@ -19,7 +19,11 @@ _BOILERPLATE_DUNDERS = frozenset({"__init__", "__repr__", "__str__", "__eq__", "
 
 
 class LazyElement(Rule):
-    """SMELL-014: Classes with a single trivial method."""
+    """SMELL-014: Classes with a single trivial method.
+
+    Principles: #6 (The best line is the one not written).
+    Source: FOWLER Ch. 3 — Lazy Element.
+    """
 
     code = "SMELL-014"
     severity = Severity.INFO
@@ -61,7 +65,11 @@ class LazyElement(Rule):
 
 
 class SpeculativeGenerality(Rule):
-    """SMELL-015: Premature abstractions or unused parameters."""
+    """SMELL-015: Premature abstractions or unused parameters.
+
+    Principles: #6 (The best line is the one not written).
+    Source: FOWLER Ch. 3 — Speculative Generality.
+    """
 
     code = "SMELL-015"
     severity = Severity.WARN
@@ -185,7 +193,11 @@ class SpeculativeGenerality(Rule):
 
 
 class Comments(Rule):
-    """SMELL-024: Functions with excessive comment density."""
+    """SMELL-024: Functions with excessive comment density.
+
+    Principles: #3 (Names are contracts), #11 (The reader is the user).
+    Source: FOWLER Ch. 3 — Comments.
+    """
 
     code = "SMELL-024"
     severity = Severity.INFO
@@ -252,7 +264,11 @@ _DATA_DUNDERS = _BOILERPLATE_DUNDERS | {"__lt__", "__le__", "__gt__", "__ge__"}
 
 
 class DataClassSmell(Rule):
-    """SMELL-022: Classes that are pure data holders."""
+    """SMELL-022: Classes that are pure data holders.
+
+    Principles: #6 (The best line is the one not written).
+    Source: FOWLER Ch. 3 — Data Class.
+    """
 
     code = "SMELL-022"
     severity = Severity.INFO

--- a/src/gaudi/packs/python/rules/django.py
+++ b/src/gaudi/packs/python/rules/django.py
@@ -9,6 +9,12 @@ from gaudi.packs.python.context import PythonContext
 
 
 class DjangoSecretKeyExposed(Rule):
+    """Detect Django SECRET_KEY hardcoded in settings.
+
+    Principles: #5 (State must be visible), #4 (Failure must be named).
+    Source: FWDOCS Django deployment checklist — secrets are configuration, not code.
+    """
+
     code = "DJ-SEC-001"
     severity = Severity.ERROR
     category = Category.SECURITY
@@ -40,6 +46,12 @@ class DjangoSecretKeyExposed(Rule):
 
 
 class DjangoDebugTrue(Rule):
+    """Detect DEBUG=True in Django settings.
+
+    Principles: #5 (State must be visible), #4 (Failure must be named).
+    Source: FWDOCS Django deployment checklist — DEBUG=True is a hostile-input failure mode.
+    """
+
     code = "DJ-SEC-002"
     severity = Severity.ERROR
     category = Category.SECURITY

--- a/src/gaudi/packs/python/rules/drf.py
+++ b/src/gaudi/packs/python/rules/drf.py
@@ -30,6 +30,12 @@ def _has_class_attr(cls: ast.ClassDef, attr_name: str) -> bool:
 
 
 class DRFNoPermissionClass(Rule):
+    """Detect DRF ViewSets without explicit permission_classes.
+
+    Principles: #4 (Failure must be named).
+    Source: FWDOCS DRF permissions — implicit auth fails silently against hostile input.
+    """
+
     code = "DRF-SEC-001"
     severity = Severity.WARN
     category = Category.SECURITY
@@ -56,6 +62,12 @@ class DRFNoPermissionClass(Rule):
 
 
 class DRFNoThrottling(Rule):
+    """Detect DRF API views without throttle_classes.
+
+    Principles: #4 (Failure must be named).
+    Source: FWDOCS DRF throttling — unthrottled endpoints are an unbounded failure mode.
+    """
+
     code = "DRF-SCALE-001"
     severity = Severity.INFO
     category = Category.SCALABILITY

--- a/src/gaudi/packs/python/rules/errors.py
+++ b/src/gaudi/packs/python/rules/errors.py
@@ -13,6 +13,12 @@ from gaudi.packs.python.context import PythonContext
 
 
 class BareExcept(Rule):
+    """Detect bare except blocks and broad Exception handlers.
+
+    Principles: #4 (Failure must be named).
+    Source: ARCH90 Day 5 — catch the exception you actually expect.
+    """
+
     code = "ERR-001"
     severity = Severity.WARN
     category = Category.ERROR_HANDLING
@@ -58,6 +64,12 @@ class BareExcept(Rule):
 
 
 class ErrorSwallowing(Rule):
+    """Detect errors that are logged but not re-raised (error swallowing).
+
+    Principles: #4 (Failure must be named), #13 (The system must explain itself).
+    Source: ARCH90 Day 5 — silent failure is hidden from monitoring.
+    """
+
     code = "ERR-003"
     severity = Severity.WARN
     category = Category.ERROR_HANDLING

--- a/src/gaudi/packs/python/rules/fastapi.py
+++ b/src/gaudi/packs/python/rules/fastapi.py
@@ -11,6 +11,12 @@ _ROUTE_METHODS = frozenset({"get", "post", "put", "patch", "delete"})
 
 
 class FastAPINoResponseModel(Rule):
+    """Detect FastAPI endpoints missing response_model.
+
+    Principles: #3 (Names are contracts), #10 (Boundaries are real or fictional).
+    Source: FWDOCS FastAPI response models — the response shape is a contract.
+    """
+
     code = "FAPI-ARCH-001"
     severity = Severity.WARN
     category = Category.ARCHITECTURE

--- a/src/gaudi/packs/python/rules/flask.py
+++ b/src/gaudi/packs/python/rules/flask.py
@@ -9,6 +9,12 @@ from gaudi.packs.python.context import PythonContext
 
 
 class FlaskNoAppFactory(Rule):
+    """Detect Flask apps created at module level (no app factory).
+
+    Principles: #5 (State must be visible), #1 (The structure tells the story).
+    Source: FWDOCS Flask application factory pattern.
+    """
+
     code = "FLASK-STRUCT-001"
     severity = Severity.WARN
     category = Category.STRUCTURE

--- a/src/gaudi/packs/python/rules/layers.py
+++ b/src/gaudi/packs/python/rules/layers.py
@@ -15,6 +15,12 @@ _OUTER_KEYWORDS = ("scripts.", "cli.", "commands.", "views.")
 
 
 class ImportDirectionViolation(Rule):
+    """Detect inner-layer files importing from outer layers (import direction violation).
+
+    Principles: #1 (The structure tells the story), #9 (Dependencies flow toward stability).
+    Source: ARCH90 Day 3 — arrows point inward only.
+    """
+
     code = "ARCH-010"
     severity = Severity.ERROR
     category = Category.ARCHITECTURE
@@ -67,6 +73,12 @@ _DATA_LAYER_KEYWORDS = ("connector", "store", "repository", "db")
 
 
 class ConnectorLogicLeak(Rule):
+    """Detect data-layer files containing business logic (connector logic leak).
+
+    Principles: #10 (Boundaries are real or fictional).
+    Source: ARCH90 Day 3 — connectors translate, services decide.
+    """
+
     code = "ARCH-011"
     severity = Severity.WARN
     category = Category.ARCHITECTURE
@@ -107,6 +119,12 @@ class ConnectorLogicLeak(Rule):
 
 
 class FatScript(Rule):
+    """Detect entry-point functions with too much business logic (fat scripts).
+
+    Principles: #1 (The structure tells the story), #7 (Layers must earn their existence).
+    Source: ARCH90 Day 3 — thin entry points, fat services.
+    """
+
     code = "ARCH-013"
     severity = Severity.WARN
     category = Category.ARCHITECTURE

--- a/src/gaudi/packs/python/rules/logging_rules.py
+++ b/src/gaudi/packs/python/rules/logging_rules.py
@@ -22,6 +22,12 @@ _LOG_METHODS = frozenset(
 
 
 class UnstructuredLogging(Rule):
+    """Detect f-strings in logger calls (use lazy %-formatting).
+
+    Principles: #13 (The system must explain itself).
+    Source: ARCH90 Day 5 — structured logging is how the system explains itself.
+    """
+
     code = "LOG-001"
     severity = Severity.INFO
     category = Category.LOGGING

--- a/src/gaudi/packs/python/rules/oo_abusers.py
+++ b/src/gaudi/packs/python/rules/oo_abusers.py
@@ -70,7 +70,11 @@ def _extract_compare(
 
 
 class RepeatedSwitches(Rule):
-    """SMELL-012: Same switch pattern in multiple functions."""
+    """SMELL-012: Same switch pattern in multiple functions.
+
+    Principles: #2 (One concept, one home).
+    Source: FOWLER Ch. 3 — Repeated Switches.
+    """
 
     code = "SMELL-012"
     severity = Severity.WARN
@@ -123,7 +127,11 @@ class RepeatedSwitches(Rule):
 
 
 class TemporaryField(Rule):
-    """SMELL-016: Class with attributes set in only one method."""
+    """SMELL-016: Class with attributes set in only one method.
+
+    Principles: #5 (State must be visible).
+    Source: FOWLER Ch. 3 — Temporary Field.
+    """
 
     code = "SMELL-016"
     severity = Severity.WARN
@@ -218,7 +226,11 @@ def _is_refused_body(body: list[ast.stmt]) -> bool:
 
 
 class RefusedBequest(Rule):
-    """SMELL-023: Subclasses that refuse inherited behavior."""
+    """SMELL-023: Subclasses that refuse inherited behavior.
+
+    Principles: #10 (Boundaries are real or fictional).
+    Source: FOWLER Ch. 3 — Refused Bequest.
+    """
 
     code = "SMELL-023"
     severity = Severity.WARN
@@ -269,7 +281,11 @@ class RefusedBequest(Rule):
 
 
 class AlternativeInterfaces(Rule):
-    """SMELL-021: Similar classes with different method names."""
+    """SMELL-021: Similar classes with different method names.
+
+    Principles: #3 (Names are contracts).
+    Source: FOWLER Ch. 3 — Alternative Classes with Different Interfaces.
+    """
 
     code = "SMELL-021"
     severity = Severity.INFO

--- a/src/gaudi/packs/python/rules/ops.py
+++ b/src/gaudi/packs/python/rules/ops.py
@@ -12,6 +12,12 @@ from gaudi.packs.python.context import PythonContext
 
 
 class MissingPrecommit(Rule):
+    """Detect projects without a pre-commit configuration.
+
+    Principles: #12 (Tests are the specification).
+    Source: ARCH90 Day 6 — pre-commit hooks gate the build before CI does.
+    """
+
     code = "OPS-002"
     severity = Severity.INFO
     category = Category.OPERATIONS
@@ -33,6 +39,12 @@ class MissingPrecommit(Rule):
 
 
 class MissingPRTemplate(Rule):
+    """Detect projects without a pull request template.
+
+    Principles: #8 (Smallest reasonable change).
+    Source: ARCH90 — PRs are the project's task board.
+    """
+
     code = "OPS-003"
     severity = Severity.INFO
     category = Category.OPERATIONS
@@ -60,6 +72,12 @@ class MissingPRTemplate(Rule):
 
 
 class MissingCodeowners(Rule):
+    """Detect projects without a CODEOWNERS file.
+
+    Principles: #11 (The reader is the user).
+    Source: ARCH90 — CODEOWNERS routes review to the right reader.
+    """
+
     code = "OPS-004"
     severity = Severity.INFO
     category = Category.OPERATIONS
@@ -85,6 +103,12 @@ class MissingCodeowners(Rule):
 
 
 class MissingContribGuide(Rule):
+    """Detect projects without a CONTRIBUTING.md guide.
+
+    Principles: #11 (The reader is the user).
+    Source: ARCH90 — the contributor is a future reader who has none of the maintainer's context.
+    """
+
     code = "OPS-005"
     severity = Severity.INFO
     category = Category.OPERATIONS

--- a/src/gaudi/packs/python/rules/packaging.py
+++ b/src/gaudi/packs/python/rules/packaging.py
@@ -13,6 +13,12 @@ from gaudi.packs.python.context import PythonContext
 
 
 class PathHacks(Rule):
+    """Detect sys.path manipulation (path hacks).
+
+    Principles: #1 (The structure tells the story), #9 (Dependencies flow toward stability).
+    Source: ARCH90 Day 1 — proper packaging over sys.path hacks.
+    """
+
     code = "STRUCT-010"
     severity = Severity.ERROR
     category = Category.STRUCTURE
@@ -57,6 +63,12 @@ class PathHacks(Rule):
 
 
 class MissingPyproject(Rule):
+    """Detect projects without a pyproject.toml.
+
+    Principles: #1 (The structure tells the story), #14 (Reversibility is a design property).
+    Source: ARCH90 Day 1 — modern packaging requires pyproject.toml.
+    """
+
     code = "STRUCT-011"
     severity = Severity.WARN
     category = Category.STRUCTURE
@@ -78,6 +90,12 @@ class MissingPyproject(Rule):
 
 
 class NoEntryPoint(Rule):
+    """Detect CLI scripts without console_scripts entry points.
+
+    Principles: #1 (The structure tells the story).
+    Source: ARCH90 Day 1 — CLI scripts need entry points.
+    """
+
     code = "STRUCT-012"
     severity = Severity.WARN
     category = Category.STRUCTURE
@@ -141,6 +159,12 @@ _LOCK_FILES = (
 
 
 class NoLockFile(Rule):
+    """Detect projects without a dependency lock file.
+
+    Principles: #14 (Reversibility is a design property).
+    Source: ARCH90 Day 1 — pin dependencies for reproducibility.
+    """
+
     code = "STRUCT-013"
     severity = Severity.INFO
     category = Category.STRUCTURE

--- a/src/gaudi/packs/python/rules/pandas.py
+++ b/src/gaudi/packs/python/rules/pandas.py
@@ -9,6 +9,12 @@ from gaudi.packs.python.context import PythonContext
 
 
 class PandasInplaceAntiPattern(Rule):
+    """Detect pandas inplace=True usage.
+
+    Principles: #5 (State must be visible).
+    Source: FWDOCS Pandas deprecation guidance — inplace mutates hidden state.
+    """
+
     code = "PD-ARCH-001"
     severity = Severity.WARN
     category = Category.ARCHITECTURE
@@ -41,6 +47,12 @@ class PandasInplaceAntiPattern(Rule):
 
 
 class PandasIterrows(Rule):
+    """Detect pandas iterrows() usage.
+
+    Principles: #4 (Failure must be named).
+    Source: FWDOCS Pandas vectorization — row iteration fails under production data sizes.
+    """
+
     code = "PD-SCALE-001"
     severity = Severity.WARN
     category = Category.SCALABILITY

--- a/src/gaudi/packs/python/rules/py314.py
+++ b/src/gaudi/packs/python/rules/py314.py
@@ -143,6 +143,9 @@ class RemovedIn314Import(Rule):
 
     Detects `from module import name` or `import module.name` patterns
     that reference APIs removed in Python 3.14.
+
+    Principles: #14 (Reversibility is a design property).
+    Source: PY314 What's New — Removals.
     """
 
     code = "PY314-001"
@@ -184,6 +187,9 @@ class DeprecatedIn314Import(Rule):
     PY314-002: Import of API deprecated in Python 3.14.
 
     These APIs still work but will be removed in a future Python version.
+
+    Principles: #14 (Reversibility is a design property).
+    Source: PY314 What's New — Deprecations.
     """
 
     code = "PY314-002"
@@ -251,6 +257,9 @@ class DeferredAnnotationAccess(Rule):
     In Python 3.14, annotations are no longer evaluated eagerly (PEP 649/749).
     Code that directly accesses `__annotations__` may get unexpected results.
     Use annotationlib.get_annotations() instead.
+
+    Principles: #14 (Reversibility is a design property).
+    Source: PEP 649 — Deferred Evaluation of Annotations.
     """
 
     code = "PY314-003"
@@ -295,6 +304,9 @@ class FinallyControlFlow(Rule):
     PEP 765 (Python 3.14) adds SyntaxWarning for control flow statements
     (return, break, continue) inside finally blocks, as these silently
     swallow exceptions. Will become SyntaxError in a future version.
+
+    Principles: #4 (Failure must be named).
+    Source: PY314 SyntaxWarning — control flow in finally is a hidden failure.
     """
 
     code = "PY314-004"
@@ -361,6 +373,9 @@ class NotImplementedBoolContext(Rule):
 
     In Python 3.14, using NotImplemented in a boolean context raises
     TypeError (previously DeprecationWarning since 3.9).
+
+    Principles: #4 (Failure must be named).
+    Source: PY314 — NotImplemented bool context now raises.
     """
 
     code = "PY314-005"
@@ -411,6 +426,9 @@ class TarfileNoFilter(Rule):
     In Python 3.14, the default tarfile extraction filter changed to 'data'.
     Code that extracts tar archives without specifying a filter should
     explicitly set filter='data' or filter='fully_trusted'.
+
+    Principles: #4 (Failure must be named).
+    Source: PY314 tarfile security — hostile archives require explicit filtering.
     """
 
     code = "PY314-006"

--- a/src/gaudi/packs/python/rules/pydantic.py
+++ b/src/gaudi/packs/python/rules/pydantic.py
@@ -20,6 +20,12 @@ def _is_pydantic_class(cls: ast.ClassDef) -> bool:
 
 
 class PydanticMutableDefault(Rule):
+    """Detect mutable default values in Pydantic models.
+
+    Principles: #5 (State must be visible).
+    Source: FWDOCS Pydantic validators — mutable defaults are shared hidden state.
+    """
+
     code = "PYD-ARCH-001"
     severity = Severity.ERROR
     category = Category.ARCHITECTURE

--- a/src/gaudi/packs/python/rules/pytest_rules.py
+++ b/src/gaudi/packs/python/rules/pytest_rules.py
@@ -13,6 +13,12 @@ _EXPENSIVE_FIXTURE_NAMES = frozenset(
 
 
 class PytestAssertMessage(Rule):
+    """Detect complex assertions without failure messages.
+
+    Principles: #12 (Tests are the specification), #13 (The system must explain itself).
+    Source: FWDOCS pytest assertion introspection — failure messages are the test's diagnostic surface.
+    """
+
     code = "TEST-STRUCT-001"
     severity = Severity.INFO
     category = Category.STRUCTURE
@@ -50,6 +56,12 @@ class PytestAssertMessage(Rule):
 
 
 class PytestFixtureScope(Rule):
+    """Detect expensive pytest fixtures without explicit scope.
+
+    Principles: #12 (Tests are the specification).
+    Source: FWDOCS pytest fixture optimization — expensive fixtures need wider scope.
+    """
+
     code = "TEST-SCALE-001"
     severity = Severity.INFO
     category = Category.SCALABILITY

--- a/src/gaudi/packs/python/rules/requests_rules.py
+++ b/src/gaudi/packs/python/rules/requests_rules.py
@@ -11,6 +11,12 @@ _HTTP_METHODS = frozenset({"get", "post", "put", "patch", "delete", "head", "opt
 
 
 class RequestsNoTimeout(Rule):
+    """Detect HTTP requests without a timeout parameter.
+
+    Principles: #4 (Failure must be named).
+    Source: NYGARD Ch. 5 — Timeouts: every external call has a deadline.
+    """
+
     code = "HTTP-SCALE-001"
     severity = Severity.ERROR
     category = Category.SCALABILITY

--- a/src/gaudi/packs/python/rules/security.py
+++ b/src/gaudi/packs/python/rules/security.py
@@ -54,7 +54,11 @@ def _is_unsafe_sql_arg(arg: ast.expr) -> bool:
 
 
 class RawSQLInjection(Rule):
-    """SEC-002: SQL execution with interpolated strings."""
+    """SEC-002: SQL execution with interpolated strings.
+
+    Principles: #4 (Failure must be named).
+    Source: OWASP A03 — Injection: hostile input must be parameterized.
+    """
 
     code = "SEC-002"
     severity = Severity.ERROR
@@ -139,7 +143,11 @@ def _looks_like_placeholder_value(value: str) -> bool:
 
 
 class HardcodedCredential(Rule):
-    """SEC-003: Credential-named variable assigned to a string literal."""
+    """SEC-003: Credential-named variable assigned to a string literal.
+
+    Principles: #5 (State must be visible), #4 (Failure must be named).
+    Source: OWASP A07 — secrets are configuration, not code.
+    """
 
     code = "SEC-003"
     severity = Severity.ERROR
@@ -198,7 +206,11 @@ class HardcodedCredential(Rule):
 
 
 class EvalExecUsage(Rule):
-    """SEC-004: Use of built-in eval() or exec()."""
+    """SEC-004: Use of built-in eval() or exec().
+
+    Principles: #4 (Failure must be named).
+    Source: OWASP A03 — arbitrary code execution from hostile input.
+    """
 
     code = "SEC-004"
     severity = Severity.ERROR
@@ -251,7 +263,11 @@ def _yaml_load_has_safe_loader(call: ast.Call) -> bool:
 
 
 class UnsafeDeserialization(Rule):
-    """SEC-005: Insecure deserialization via pickle or yaml.load."""
+    """SEC-005: Insecure deserialization via pickle or yaml.load.
+
+    Principles: #4 (Failure must be named).
+    Source: OWASP A08 — Software and Data Integrity Failures.
+    """
 
     code = "SEC-005"
     severity = Severity.ERROR

--- a/src/gaudi/packs/python/rules/services.py
+++ b/src/gaudi/packs/python/rules/services.py
@@ -28,6 +28,12 @@ _HARDCODED_URL_RE = re.compile(
 
 
 class HardcodedServiceURL(Rule):
+    """Detect hardcoded service URLs (localhost, 127.0.0.1, etc.).
+
+    Principles: #5 (State must be visible).
+    Source: NEWMAN Ch. 5 — service discovery: endpoints are configuration.
+    """
+
     code = "SVC-001"
     severity = Severity.WARN
     category = Category.ARCHITECTURE
@@ -71,6 +77,12 @@ _HTTP_MODULES = frozenset({"requests", "httpx", "aiohttp", "client", "session"})
 
 
 class ChattyIntegration(Rule):
+    """Detect functions making many HTTP calls (chatty integration).
+
+    Principles: #10 (Boundaries are real or fictional).
+    Source: NEWMAN Ch. 4 — chatty service boundary.
+    """
+
     code = "SVC-002"
     severity = Severity.INFO
     category = Category.ARCHITECTURE
@@ -134,6 +146,12 @@ _ROUTE_DECORATOR_RE = re.compile(r"@\w+\.(get|post|put|patch|delete|route|api_ro
 
 
 class NoAPIVersioning(Rule):
+    """Detect API endpoints without a version prefix.
+
+    Principles: #14 (Reversibility is a design property).
+    Source: NEWMAN Ch. 7 — API versioning enables safe evolution.
+    """
+
     code = "SVC-003"
     severity = Severity.INFO
     category = Category.ARCHITECTURE

--- a/src/gaudi/packs/python/rules/smells.py
+++ b/src/gaudi/packs/python/rules/smells.py
@@ -93,7 +93,11 @@ def _mysterious_in_init(cls: ast.ClassDef) -> list[str]:
 
 
 class MysteriousName(Rule):
-    """SMELL-001: Functions or classes that use too many mysterious names."""
+    """SMELL-001: Functions or classes that use too many mysterious names.
+
+    Principles: #3 (Names are contracts), #11 (The reader is the user).
+    Source: FOWLER Ch. 3 — Mysterious Name.
+    """
 
     code = "SMELL-001"
     severity = Severity.INFO
@@ -179,7 +183,11 @@ def _is_mutable_call(node: ast.expr) -> bool:
 
 
 class GlobalData(Rule):
-    """SMELL-005: Mutable module-level variables."""
+    """SMELL-005: Mutable module-level variables.
+
+    Principles: #5 (State must be visible).
+    Source: FOWLER Ch. 3 — Global Data.
+    """
 
     code = "SMELL-005"
     severity = Severity.ERROR
@@ -256,7 +264,11 @@ def _is_append_on(call: ast.Call, var_name: str) -> bool:
 
 
 class Loops(Rule):
-    """SMELL-013: Accumulation loops replaceable by comprehensions."""
+    """SMELL-013: Accumulation loops replaceable by comprehensions.
+
+    Principles: #11 (The reader is the user).
+    Source: FOWLER Ch. 3 — Loops.
+    """
 
     code = "SMELL-013"
     severity = Severity.INFO
@@ -419,7 +431,11 @@ def _function_mutates(
 
 
 class MutableData(Rule):
-    """SMELL-006: Shared mutable state mutated by multiple functions."""
+    """SMELL-006: Shared mutable state mutated by multiple functions.
+
+    Principles: #5 (State must be visible).
+    Source: FOWLER Ch. 3 — Mutable Data.
+    """
 
     code = "SMELL-006"
     severity = Severity.ERROR

--- a/src/gaudi/packs/python/rules/sqlalchemy.py
+++ b/src/gaudi/packs/python/rules/sqlalchemy.py
@@ -9,6 +9,12 @@ from gaudi.packs.python.context import PythonContext
 
 
 class SQLAlchemyLazyDefault(Rule):
+    """Detect SQLAlchemy relationships without explicit lazy loading strategy.
+
+    Principles: #4 (Failure must be named).
+    Source: FWDOCS SQLAlchemy — default lazy loading causes N+1 failures under load.
+    """
+
     code = "SA-SCALE-001"
     severity = Severity.WARN
     category = Category.SCALABILITY

--- a/src/gaudi/packs/python/rules/stability.py
+++ b/src/gaudi/packs/python/rules/stability.py
@@ -24,6 +24,12 @@ _ORM_ALL_ATTRS = frozenset({"all", "filter", "exclude", "select_related", "prefe
 
 
 class UnboundedResultSet(Rule):
+    """Detect ORM queries returning unbounded result sets.
+
+    Principles: #4 (Failure must be named).
+    Source: NYGARD Ch. 4 — Unbounded Result Sets anti-pattern.
+    """
+
     code = "STAB-001"
     severity = Severity.WARN
     category = Category.STABILITY
@@ -77,6 +83,12 @@ class UnboundedResultSet(Rule):
 
 
 class RetryWithoutBackoff(Rule):
+    """Detect retry logic without exponential backoff.
+
+    Principles: #4 (Failure must be named).
+    Source: NYGARD Ch. 5 — Retry must include backoff to avoid thundering herds.
+    """
+
     code = "STAB-003"
     severity = Severity.WARN
     category = Category.STABILITY
@@ -143,6 +155,12 @@ class RetryWithoutBackoff(Rule):
 
 
 class UnboundedCache(Rule):
+    """Detect unbounded caches (lru_cache without maxsize, or @cache).
+
+    Principles: #4 (Failure must be named).
+    Source: NYGARD Ch. 5 — Steady State: unbounded resource growth.
+    """
+
     code = "STAB-004"
     severity = Severity.WARN
     category = Category.STABILITY
@@ -208,6 +226,12 @@ _BLOCKING_MODULES = frozenset({"time", "requests"})
 
 
 class BlockingInAsync(Rule):
+    """Detect blocking calls inside async functions.
+
+    Principles: #5 (State must be visible), #4 (Failure must be named).
+    Source: NYGARD Ch. 4 — Blocked Threads anti-pattern.
+    """
+
     code = "STAB-005"
     severity = Severity.ERROR
     category = Category.STABILITY
@@ -264,6 +288,12 @@ _RESOURCE_CALLS = frozenset({"open", "Session", "connect", "Connection"})
 
 
 class UnmanagedResource(Rule):
+    """Detect resources opened without context-manager management.
+
+    Principles: #4 (Failure must be named).
+    Source: NYGARD Ch. 5 — Steady State: every resource has an owner.
+    """
+
     code = "STAB-006"
     severity = Severity.WARN
     category = Category.STABILITY
@@ -341,6 +371,12 @@ class UnmanagedResource(Rule):
 
 
 class UnboundedThreadPool(Rule):
+    """Detect ThreadPoolExecutor instantiated without max_workers.
+
+    Principles: #4 (Failure must be named).
+    Source: NYGARD Ch. 4 — Unbalanced Capacities anti-pattern.
+    """
+
     code = "STAB-007"
     severity = Severity.WARN
     category = Category.STABILITY

--- a/src/gaudi/packs/python/rules/types.py
+++ b/src/gaudi/packs/python/rules/types.py
@@ -13,6 +13,12 @@ from gaudi.packs.python.context import PythonContext
 
 
 class MissingReturnTypes(Rule):
+    """Detect public functions without return type annotations.
+
+    Principles: #11 (The reader is the user), #3 (Names are contracts).
+    Source: ARCH90 Day 2 — type annotations on public APIs.
+    """
+
     code = "STRUCT-020"
     severity = Severity.INFO
     category = Category.STRUCTURE
@@ -72,6 +78,12 @@ _EXEMPT_STRINGS = frozenset(
 
 
 class MagicStrings(Rule):
+    """Detect repeated string literals that should be named constants.
+
+    Principles: #2 (One concept, one home), #3 (Names are contracts).
+    Source: ARCH90 Day 2 — extract repeated literals to constants.
+    """
+
     code = "STRUCT-021"
     severity = Severity.WARN
     category = Category.STRUCTURE

--- a/tests/test_rule_principle_citations.py
+++ b/tests/test_rule_principle_citations.py
@@ -1,0 +1,63 @@
+"""Forcing function: every Rule subclass must cite its principles and source.
+
+This test fails if any rule's class docstring lacks a well-formed `Principles:`
+line and a `Source:` line. The Principles line must cite at least one and at
+most three numbered principles from docs/principles.md (numbered 1-14).
+
+Adding a new rule without citations is therefore impossible: the test will
+break the build, and `docs/principles.md` becomes load-bearing on every
+individual rule.
+"""
+
+from __future__ import annotations
+
+import re
+
+from gaudi.packs.python.rules import ALL_RULES
+
+VALID_PRINCIPLE_NUMBERS = frozenset(range(1, 15))  # 1..14
+
+PRINCIPLES_LINE_RE = re.compile(
+    r"Principles:\s*((?:#\d+\s*\([^)]+\)(?:,\s*)?){1,3})\.",
+    re.MULTILINE,
+)
+SOURCE_LINE_RE = re.compile(r"Source:\s*\S.*", re.MULTILINE)
+PRINCIPLE_REF_RE = re.compile(r"#(\d+)")
+
+
+def test_at_least_one_rule_discovered() -> None:
+    """Sanity: ALL_RULES is non-empty so the assertions below aren't trivially green."""
+    assert len(ALL_RULES) > 0, "ALL_RULES discovered no rules"
+
+
+def test_every_rule_cites_principles() -> None:
+    failures: list[str] = []
+    for rule in ALL_RULES:
+        cls = type(rule)
+        doc = cls.__doc__ or ""
+        match = PRINCIPLES_LINE_RE.search(doc)
+        if not match:
+            failures.append(
+                f"{cls.__name__} ({rule.code}): missing or malformed `Principles:` line"
+            )
+            continue
+        nums = [int(n) for n in PRINCIPLE_REF_RE.findall(match.group(1))]
+        if not nums:
+            failures.append(f"{cls.__name__} ({rule.code}): no principle numbers found in citation")
+            continue
+        if len(nums) > 3:
+            failures.append(f"{cls.__name__} ({rule.code}): cites {len(nums)} principles (max 3)")
+        invalid = [n for n in nums if n not in VALID_PRINCIPLE_NUMBERS]
+        if invalid:
+            failures.append(f"{cls.__name__} ({rule.code}): invalid principle numbers {invalid}")
+    assert not failures, "Rules missing principle citations:\n  " + "\n  ".join(failures)
+
+
+def test_every_rule_cites_source() -> None:
+    failures: list[str] = []
+    for rule in ALL_RULES:
+        cls = type(rule)
+        doc = cls.__doc__ or ""
+        if not SOURCE_LINE_RE.search(doc):
+            failures.append(f"{cls.__name__} ({rule.code}): missing `Source:` line")
+    assert not failures, "Rules missing source citations:\n  " + "\n  ".join(failures)


### PR DESCRIPTION
## Summary

- Adds `Principles:` and `Source:` lines to every concrete Rule subclass docstring (102 classes across 33 files).
- Adds a forcing-function test ([tests/test_rule_principle_citations.py](tests/test_rule_principle_citations.py)) that walks `ALL_RULES` and asserts every rule has well-formed citations. Future rules cannot land without them.
- Closes #81.

## Why

Doctrine v0.1 (#80) established fourteen first principles in three pillars. The principles document already lists which rules each principle justifies (the "In Gaudi" bullet under each numbered principle), but the inverse mapping — which principle(s) each rule appeals to — lived only in the maintainer's head. This PR makes the inverse index explicit on the rule itself.

The point: when a maintainer is tuning a threshold, weighing subsumption, or considering removal, the docstring should reveal which principle(s) the rule serves. The Rule Acceptance Test (`docs/principles.md`) is easier to apply when the rule already says what it appeals to. AI agents consuming Gaudi findings can reason about *why* the finding matters, not just *what* to change.

## Format

Every concrete `Rule` subclass now has a class docstring of the form:

```python
class UnboundedResultSet(Rule):
    """Detect ORM queries returning unbounded result sets.

    Principles: #4 (Failure must be named).
    Source: NYGARD Ch. 4 — Unbounded Result Sets anti-pattern.
    """
    code = "STAB-001"
    ...
```

The `Principles:` line cites 1-3 numbered principles from `docs/principles.md`. The `Source:` line preserves the citation that was previously in the rule registry footnote or an ABOUTME comment.

## Method

The citations were extracted by inversion (the same hanging-chain method that derived the principles themselves). For each rule:

1. Read the existing source comments, ABOUTME headers, message templates, recommendation strings, and check() logic.
2. Identify which principle(s) the rule appeals to. The principles were already encoded in the rules — this PR lifts the encoding into a canonical, greppable place.
3. Cap at three principles per rule. Any rule that legitimately needs four+ would be a smell that the rule is too broad and should be split (none surfaced; the cap held).

## Forcing Function

The test in `tests/test_rule_principle_citations.py` is the load-bearing piece:

```python
def test_every_rule_cites_principles():
    for rule in ALL_RULES:
        cls = type(rule)
        doc = cls.__doc__ or ""
        match = PRINCIPLES_LINE_RE.search(doc)
        # ...assert well-formed, valid principle numbers, max 3
```

It validates:
- Every Rule subclass has a `Principles:` line.
- The cited principles are in the valid range 1..14.
- No rule cites more than 3 principles.
- Every Rule subclass has a `Source:` line.

The test fails the build on any rule lacking citations. The PR template checkbox added in #80 ("cite the principle(s) it satisfies") is now mechanically verifiable in CI, not just by reviewer attention.

## Coverage by Principle

The citation pass surfaces which principles are doing the most load-bearing work in the current catalog:

| Principle | Rules citing it (approx.) |
|---|---|
| #4 Failure must be named | ~30 (Nygard STAB family, errors, unbounded result sets, hostile-input SEC, framework timeouts) |
| #5 State must be visible | ~15 (config injection, Pydantic mutable defaults, global data, mutable data, hidden state) |
| #2 One concept, one home | ~10 (duplicated code, scattered config, magic strings, divergent change) |
| #7 Layers must earn existence | ~10 (CPLX shallow modules, large class, fat scripts, middle man) |
| #1 Structure tells the story | ~8 (import direction, fat scripts, single-file models, structural defects) |
| #3 Names are contracts | ~7 (mysterious names, primitive obsession, FastAPI response models, missing types) |
| #10 Boundaries are real or fictional | ~6 (feature envy, message chains, insider trading, connector logic leak) |
| #9 Deps flow toward stability | ~5 (DEP family, import direction, path hacks) |
| #11 Reader is the user | ~5 (long parameter list, comments, missing types, mysterious names) |
| #14 Reversibility | ~5 (Alembic family, PY314 deprecations, lock file, API versioning) |
| #13 System must explain itself | ~4 (logging, error swallowing, audit timestamps, pytest assertion messages) |
| #12 Tests are the specification | ~3 (pytest rules, pre-commit) |
| #8 Smallest reasonable change | 1 (PR template) |
| #6 Best line is the one not written | ~3 (lazy element, speculative generality, data class smell) |

The shape is interesting: **Failure must be named** is the most load-bearing principle in the current catalog, which fits the project's emphasis on detection-grammar rules from Nygard. **Smallest reasonable change** has only one rule citing it — that principle does most of its work in the PR template, not in the catalog.

## Test plan

- [x] `pytest -q` — 164 passed (3 new tests + 161 existing). The new test moved from red to green over the citation pass, which is the point.
- [x] `ruff check src tests` — clean.
- [x] `ruff format --check src tests` — clean (the citation pass touched 25 files, which `ruff format` then tidied).
- [x] `gaudi check .` — 0 errors, 155 warnings, 8 infos across 40 files. Net delta from main: +1 file (the test) and +1 warning (STRUCT-021 false positive on the test's error-message formatting, consistent with the existing dogfood baseline of similar findings).
- [x] Spot-checked one insertion case (`stability.py` STAB-001) and one append-to-existing case (`bloaters.py` SMELL-003) — both render as intended.

## Out of scope (separate PRs)

- **Severity audit against the new "name the day" grammar.** This PR is documentation; severity reassignment touches behavior and deserves its own review.
- **Splitting any rule that needed four+ principles to justify itself.** None surfaced.
- **Refactoring the test file's STRUCT-021 false positive.** Same shape as the 154 existing dogfood findings; belongs in a broader dogfood cleanup pass.

## Doctrine version

Stays at v0.1. This PR is operationalization, not a doctrinal change.
