### PR TITLE
Migrate IDX pack to fixture corpus

### DIFF
--- a/tests/fixtures/python/IDX-001/expected.json
+++ b/tests/fixtures/python/IDX-001/expected.json
@@ -1,0 +1,31 @@
+{
+  "rule_id": "IDX-001",
+  "description": "MissingStringIndex -- lookup-shaped CharFields need db_index",
+  "fixtures": {
+    "fail_lookup_charfields_unindexed.py": {
+      "expected_findings": [
+        {
+          "severity": "warn",
+          "line": 7,
+          "message_contains": "email"
+        },
+        {
+          "severity": "warn",
+          "line": 8,
+          "message_contains": "slug"
+        },
+        {
+          "severity": "warn",
+          "line": 9,
+          "message_contains": "api_key"
+        }
+      ]
+    },
+    "pass_indexed_or_unique.py": {
+      "expected_findings": []
+    },
+    "pass_non_lookup_charfields.py": {
+      "expected_findings": []
+    }
+  }
+}

--- a/tests/fixtures/python/IDX-001/fail_lookup_charfields_unindexed.py
+++ b/tests/fixtures/python/IDX-001/fail_lookup_charfields_unindexed.py
@@ -1,0 +1,9 @@
+"""Fixture for IDX-001: lookup-named CharFields without db_index."""
+
+from django.db import models
+
+
+class Customer(models.Model):
+    email = models.CharField(max_length=200)
+    slug = models.SlugField(max_length=200)
+    api_key = models.CharField(max_length=64)

--- a/tests/fixtures/python/IDX-001/pass_indexed_or_unique.py
+++ b/tests/fixtures/python/IDX-001/pass_indexed_or_unique.py
@@ -1,0 +1,9 @@
+"""Fixture for IDX-001: lookup fields with db_index or unique are fine."""
+
+from django.db import models
+
+
+class Customer(models.Model):
+    email = models.CharField(max_length=200, unique=True)
+    slug = models.SlugField(max_length=200, db_index=True)
+    api_key = models.CharField(max_length=64, db_index=True)

--- a/tests/fixtures/python/IDX-001/pass_non_lookup_charfields.py
+++ b/tests/fixtures/python/IDX-001/pass_non_lookup_charfields.py
@@ -1,0 +1,9 @@
+"""Fixture for IDX-001: CharFields whose names are not lookup-shaped don't need indexes."""
+
+from django.db import models
+
+
+class Note(models.Model):
+    title = models.CharField(max_length=200)
+    body = models.CharField(max_length=2000)
+    author_display = models.CharField(max_length=200)

--- a/tests/fixtures/python/IDX-002/expected.json
+++ b/tests/fixtures/python/IDX-002/expected.json
@@ -1,0 +1,31 @@
+{
+  "rule_id": "IDX-002",
+  "description": "NoIndexOnFilterableField -- DateTime/Date fields commonly filtered need an index",
+  "fixtures": {
+    "fail_datetime_unindexed.py": {
+      "expected_findings": [
+        {
+          "severity": "info",
+          "line": 7,
+          "message_contains": "starts_at"
+        },
+        {
+          "severity": "info",
+          "line": 8,
+          "message_contains": "ends_at"
+        },
+        {
+          "severity": "info",
+          "line": 9,
+          "message_contains": "published_on"
+        }
+      ]
+    },
+    "pass_indexed_datetimes.py": {
+      "expected_findings": []
+    },
+    "pass_auto_timestamps.py": {
+      "expected_findings": []
+    }
+  }
+}

--- a/tests/fixtures/python/IDX-002/fail_datetime_unindexed.py
+++ b/tests/fixtures/python/IDX-002/fail_datetime_unindexed.py
@@ -1,0 +1,9 @@
+"""Fixture for IDX-002: DateTimeFields without db_index that aren't auto-timestamps."""
+
+from django.db import models
+
+
+class Event(models.Model):
+    starts_at = models.DateTimeField()
+    ends_at = models.DateTimeField()
+    published_on = models.DateField()

--- a/tests/fixtures/python/IDX-002/pass_auto_timestamps.py
+++ b/tests/fixtures/python/IDX-002/pass_auto_timestamps.py
@@ -1,0 +1,9 @@
+"""Fixture for IDX-002: auto-timestamp columns are exempt."""
+
+from django.db import models
+
+
+class Event(models.Model):
+    created_at = models.DateTimeField(auto_now_add=True)
+    updated_at = models.DateTimeField(auto_now=True)
+    modified_at = models.DateTimeField(auto_now=True)

--- a/tests/fixtures/python/IDX-002/pass_indexed_datetimes.py
+++ b/tests/fixtures/python/IDX-002/pass_indexed_datetimes.py
@@ -1,0 +1,9 @@
+"""Fixture for IDX-002: DateTime/Date fields with db_index are fine."""
+
+from django.db import models
+
+
+class Event(models.Model):
+    starts_at = models.DateTimeField(db_index=True)
+    ends_at = models.DateTimeField(db_index=True)
+    published_on = models.DateField(db_index=True)

--- a/tests/test_python_pack.py
+++ b/tests/test_python_pack.py
@@ -85,13 +85,6 @@ class TestRules:
         assert len(arch_002) >= 1
         assert any("Donor" in f.message for f in arch_002)
 
-    def test_idx_001_missing_string_index(self, findings):
-        """Should flag email and code fields without indexes."""
-        idx_001 = [f for f in findings if f.code == "IDX-001"]
-        assert len(idx_001) >= 1
-        flagged_columns = {f.context.get("column") for f in idx_001}
-        assert "email" in flagged_columns
-
     def test_schema_001_missing_timestamps(self, findings):
         """Should flag models without timestamp fields."""
         schema_001 = [f for f in findings if f.code == "SCHEMA-001"]


### PR DESCRIPTION
## Summary
- Adds per-rule fixture directories for IDX-001 (MissingStringIndex) and IDX-002 (NoIndexOnFilterableField).
- Each rule gets one fail fixture and two pass fixtures (escape via index/unique, plus a domain-specific exemption).
- Removes the legacy ad-hoc IDX-001 assertion from `test_python_pack.py` now that the corpus owns coverage.

Part of #71.

## Test plan
- [x] `pytest tests/test_fixture_corpus.py -k "IDX-001 or IDX-002"` — 6 passed
- [x] Full `pytest` — 183 passed
- [x] `gaudi-fixture-coverage` — IDX-001 and IDX-002 both `OK`
- [x] `gaudi check src/` — unchanged dogfood baseline

🤖 Generated with [Claude Code](https://claude.com/claude-code)