### PR TITLE
Migrate FLASK pack to fixture corpus

### DIFF
--- a/tests/fixtures/python/FLASK-STRUCT-001/expected.json
+++ b/tests/fixtures/python/FLASK-STRUCT-001/expected.json
@@ -1,0 +1,21 @@
+{
+  "rule_id": "FLASK-STRUCT-001",
+  "description": "FlaskNoAppFactory -- Flask() at module level instead of inside an application factory",
+  "fixtures": {
+    "fail_module_level_app.py": {
+      "expected_findings": [
+        {
+          "severity": "warn",
+          "line": 5,
+          "message_contains": "application factory"
+        }
+      ]
+    },
+    "pass_application_factory.py": {
+      "expected_findings": []
+    },
+    "pass_no_flask_import.py": {
+      "expected_findings": []
+    }
+  }
+}

--- a/tests/fixtures/python/FLASK-STRUCT-001/fail_module_level_app.py
+++ b/tests/fixtures/python/FLASK-STRUCT-001/fail_module_level_app.py
@@ -1,0 +1,10 @@
+"""Fixture for FLASK-STRUCT-001: Flask app constructed at module level."""
+
+from flask import Flask
+
+app = Flask(__name__)
+
+
+@app.route("/")
+def index():
+    return "hello"

--- a/tests/fixtures/python/FLASK-STRUCT-001/pass_application_factory.py
+++ b/tests/fixtures/python/FLASK-STRUCT-001/pass_application_factory.py
@@ -1,0 +1,13 @@
+"""Fixture for FLASK-STRUCT-001: Flask app built inside a factory function."""
+
+from flask import Flask
+
+
+def create_app() -> Flask:
+    app = Flask(__name__)
+
+    @app.route("/")
+    def index():
+        return "hello"
+
+    return app

--- a/tests/fixtures/python/FLASK-STRUCT-001/pass_no_flask_import.py
+++ b/tests/fixtures/python/FLASK-STRUCT-001/pass_no_flask_import.py
@@ -1,0 +1,9 @@
+"""Fixture for FLASK-STRUCT-001: a module-level `app = Foo()` in a non-Flask file is irrelevant."""
+
+
+class App:
+    def run(self) -> None:
+        pass
+
+
+app = App()


### PR DESCRIPTION
## Summary
- Adds a fixture directory for FLASK-STRUCT-001 (FlaskNoAppFactory).
- One fail case (`fail_module_level_app.py`) and two pass cases: the application factory pattern, plus a non-Flask file with a module-level `app =` binding to prove the rule keys on the import.

Part of #71.

## Test plan
- [x] `pytest tests/test_fixture_corpus.py -k FLASK-STRUCT-001` — 3 passed
- [x] Full `pytest` — 186 passed
- [x] `gaudi-fixture-coverage` — FLASK-STRUCT-001 `OK`
- [x] `gaudi check src/` — unchanged dogfood baseline

🤖 Generated with [Claude Code](https://claude.com/claude-code)