### PR TITLE
Migrate PYD pack to fixture corpus

### DIFF
--- a/tests/fixtures/python/PYD-ARCH-001/expected.json
+++ b/tests/fixtures/python/PYD-ARCH-001/expected.json
@@ -1,0 +1,26 @@
+{
+  "rule_id": "PYD-ARCH-001",
+  "description": "PydanticMutableDefault -- bare mutable literal as a Pydantic model default",
+  "fixtures": {
+    "fail_mutable_defaults.py": {
+      "expected_findings": [
+        {
+          "severity": "error",
+          "line": 7,
+          "message_contains": "Mutable default"
+        },
+        {
+          "severity": "error",
+          "line": 8,
+          "message_contains": "Mutable default"
+        }
+      ]
+    },
+    "pass_default_factory.py": {
+      "expected_findings": []
+    },
+    "pass_non_pydantic_class.py": {
+      "expected_findings": []
+    }
+  }
+}

--- a/tests/fixtures/python/PYD-ARCH-001/fail_mutable_defaults.py
+++ b/tests/fixtures/python/PYD-ARCH-001/fail_mutable_defaults.py
@@ -1,0 +1,8 @@
+"""Fixture for PYD-ARCH-001: bare list/dict literals as Pydantic defaults."""
+
+from pydantic import BaseModel
+
+
+class Order(BaseModel):
+    items: list = []
+    metadata: dict = {}

--- a/tests/fixtures/python/PYD-ARCH-001/pass_default_factory.py
+++ b/tests/fixtures/python/PYD-ARCH-001/pass_default_factory.py
@@ -1,0 +1,8 @@
+"""Fixture for PYD-ARCH-001: Field(default_factory=...) is the safe form."""
+
+from pydantic import BaseModel, Field
+
+
+class Order(BaseModel):
+    items: list = Field(default_factory=list)
+    metadata: dict = Field(default_factory=dict)

--- a/tests/fixtures/python/PYD-ARCH-001/pass_non_pydantic_class.py
+++ b/tests/fixtures/python/PYD-ARCH-001/pass_non_pydantic_class.py
@@ -1,0 +1,11 @@
+"""Fixture for PYD-ARCH-001: a plain class (not a Pydantic model) is out of scope."""
+
+from pydantic import BaseModel  # imported but unused on this class
+
+
+class Bag:
+    items: list = []
+    metadata: dict = {}
+
+
+_ = BaseModel  # silence unused import


### PR DESCRIPTION
## Summary
- Adds a fixture directory for PYD-ARCH-001 (PydanticMutableDefault).
- One fail case (`fail_mutable_defaults.py` — list and dict literal defaults on a `BaseModel`) and two pass cases: `Field(default_factory=...)`, and a plain class with the same field shape to prove the rule keys on the Pydantic base.

Part of #71.

## Test plan
- [x] `pytest tests/test_fixture_corpus.py -k PYD-ARCH-001` — 3 passed
- [x] Full `pytest` — 189 passed
- [x] `gaudi-fixture-coverage` — PYD-ARCH-001 `OK`
- [x] `gaudi check src/` — unchanged dogfood baseline

🤖 Generated with [Claude Code](https://claude.com/claude-code)