### PR TITLE
Migrate CELERY pack to fixture corpus

### DIFF
--- a/tests/fixtures/python/CELERY-ARCH-001/expected.json
+++ b/tests/fixtures/python/CELERY-ARCH-001/expected.json
@@ -1,0 +1,21 @@
+{
+  "rule_id": "CELERY-ARCH-001",
+  "description": "CeleryNoRetry -- Celery tasks must declare a retry policy",
+  "fixtures": {
+    "fail_task_without_retry.py": {
+      "expected_findings": [
+        {
+          "severity": "warn",
+          "line": 7,
+          "message_contains": "retry"
+        }
+      ]
+    },
+    "pass_task_with_retry.py": {
+      "expected_findings": []
+    },
+    "pass_plain_function.py": {
+      "expected_findings": []
+    }
+  }
+}

--- a/tests/fixtures/python/CELERY-ARCH-001/fail_task_without_retry.py
+++ b/tests/fixtures/python/CELERY-ARCH-001/fail_task_without_retry.py
@@ -1,0 +1,8 @@
+"""Fixture for CELERY-ARCH-001: a Celery task without retry configuration."""
+
+from celery import shared_task
+
+
+@shared_task
+def send_invoice(order_id):
+    return order_id

--- a/tests/fixtures/python/CELERY-ARCH-001/pass_plain_function.py
+++ b/tests/fixtures/python/CELERY-ARCH-001/pass_plain_function.py
@@ -1,0 +1,10 @@
+"""Fixture for CELERY-ARCH-001: a plain function in a celery-aware module is out of scope."""
+
+from celery import shared_task
+
+
+def send_invoice(order_id):
+    return order_id
+
+
+_ = shared_task  # silence unused import

--- a/tests/fixtures/python/CELERY-ARCH-001/pass_task_with_retry.py
+++ b/tests/fixtures/python/CELERY-ARCH-001/pass_task_with_retry.py
@@ -1,0 +1,8 @@
+"""Fixture for CELERY-ARCH-001: task declares its retry policy."""
+
+from celery import shared_task
+
+
+@shared_task(autoretry_for=(Exception,), max_retries=3, retry_backoff=True)
+def send_invoice(order_id):
+    return order_id

--- a/tests/fixtures/python/CELERY-SCALE-001/expected.json
+++ b/tests/fixtures/python/CELERY-SCALE-001/expected.json
@@ -1,0 +1,21 @@
+{
+  "rule_id": "CELERY-SCALE-001",
+  "description": "CeleryNoTimeLimit -- Celery tasks must be bounded by a time limit",
+  "fixtures": {
+    "fail_task_without_time_limit.py": {
+      "expected_findings": [
+        {
+          "severity": "warn",
+          "line": 7,
+          "message_contains": "time limit"
+        }
+      ]
+    },
+    "pass_task_with_time_limit.py": {
+      "expected_findings": []
+    },
+    "pass_plain_function.py": {
+      "expected_findings": []
+    }
+  }
+}

--- a/tests/fixtures/python/CELERY-SCALE-001/fail_task_without_time_limit.py
+++ b/tests/fixtures/python/CELERY-SCALE-001/fail_task_without_time_limit.py
@@ -1,0 +1,8 @@
+"""Fixture for CELERY-SCALE-001: a Celery task without time_limit/soft_time_limit."""
+
+from celery import shared_task
+
+
+@shared_task(autoretry_for=(Exception,), max_retries=3)
+def send_invoice(order_id):
+    return order_id

--- a/tests/fixtures/python/CELERY-SCALE-001/pass_plain_function.py
+++ b/tests/fixtures/python/CELERY-SCALE-001/pass_plain_function.py
@@ -1,0 +1,10 @@
+"""Fixture for CELERY-SCALE-001: a plain function in a celery-aware module is out of scope."""
+
+from celery import shared_task
+
+
+def send_invoice(order_id):
+    return order_id
+
+
+_ = shared_task  # silence unused import

--- a/tests/fixtures/python/CELERY-SCALE-001/pass_task_with_time_limit.py
+++ b/tests/fixtures/python/CELERY-SCALE-001/pass_task_with_time_limit.py
@@ -1,0 +1,8 @@
+"""Fixture for CELERY-SCALE-001: task is bounded by a time limit."""
+
+from celery import shared_task
+
+
+@shared_task(time_limit=60, soft_time_limit=50)
+def send_invoice(order_id):
+    return order_id


### PR DESCRIPTION
## Summary
- Adds fixture directories for CELERY-ARCH-001 (CeleryNoRetry) and CELERY-SCALE-001 (CeleryNoTimeLimit).
- Each rule gets one fail case (a bare `@shared_task`) and two pass cases: the kwarg escape (`autoretry_for` / `time_limit`) plus a plain function in a celery-aware module to prove the rule keys on the `@task` decorator, not just the import.

Part of #71.

## Test plan
- [x] `pytest tests/test_fixture_corpus.py -k CELERY` — 6 passed
- [x] Full `pytest` — 195 passed
- [x] `gaudi-fixture-coverage` — both rules `OK`
- [x] `gaudi check src/` — unchanged dogfood baseline

🤖 Generated with [Claude Code](https://claude.com/claude-code)