### PR TITLE
Migrate DRF pack to fixture corpus

### DIFF
--- a/tests/fixtures/python/DRF-SCALE-001/expected.json
+++ b/tests/fixtures/python/DRF-SCALE-001/expected.json
@@ -1,0 +1,20 @@
+{
+  "rule_id": "DRF-SCALE-001",
+  "description": "DRFNoThrottling -- API views must declare throttle_classes",
+  "fixtures": {
+    "fail_no_throttle_classes.py": {
+      "expected_findings": [
+        {
+          "severity": "info",
+          "message_contains": "throttle_classes"
+        }
+      ]
+    },
+    "pass_explicit_throttle_classes.py": {
+      "expected_findings": []
+    },
+    "pass_non_drf_class.py": {
+      "expected_findings": []
+    }
+  }
+}

--- a/tests/fixtures/python/DRF-SCALE-001/fail_no_throttle_classes.py
+++ b/tests/fixtures/python/DRF-SCALE-001/fail_no_throttle_classes.py
@@ -1,0 +1,9 @@
+"""Fixture for DRF-SCALE-001: API view without throttle_classes."""
+
+from rest_framework.permissions import IsAuthenticated
+from rest_framework.viewsets import ModelViewSet
+
+
+class OrderViewSet(ModelViewSet):
+    queryset = []
+    permission_classes = [IsAuthenticated]

--- a/tests/fixtures/python/DRF-SCALE-001/pass_explicit_throttle_classes.py
+++ b/tests/fixtures/python/DRF-SCALE-001/pass_explicit_throttle_classes.py
@@ -1,0 +1,11 @@
+"""Fixture for DRF-SCALE-001: ViewSet declares its throttle policy."""
+
+from rest_framework.permissions import IsAuthenticated
+from rest_framework.throttling import UserRateThrottle
+from rest_framework.viewsets import ModelViewSet
+
+
+class OrderViewSet(ModelViewSet):
+    queryset = []
+    permission_classes = [IsAuthenticated]
+    throttle_classes = [UserRateThrottle]

--- a/tests/fixtures/python/DRF-SCALE-001/pass_non_drf_class.py
+++ b/tests/fixtures/python/DRF-SCALE-001/pass_non_drf_class.py
@@ -1,0 +1,10 @@
+"""Fixture for DRF-SCALE-001: a plain class in a DRF-aware module is out of scope."""
+
+from rest_framework.viewsets import ModelViewSet
+
+
+class OrderHelper:
+    queryset = []
+
+
+_ = ModelViewSet  # silence unused import

--- a/tests/fixtures/python/DRF-SEC-001/expected.json
+++ b/tests/fixtures/python/DRF-SEC-001/expected.json
@@ -1,0 +1,20 @@
+{
+  "rule_id": "DRF-SEC-001",
+  "description": "DRFNoPermissionClass -- ViewSets must declare permission_classes explicitly",
+  "fixtures": {
+    "fail_no_permission_classes.py": {
+      "expected_findings": [
+        {
+          "severity": "warn",
+          "message_contains": "permission_classes"
+        }
+      ]
+    },
+    "pass_explicit_permission_classes.py": {
+      "expected_findings": []
+    },
+    "pass_non_drf_class.py": {
+      "expected_findings": []
+    }
+  }
+}

--- a/tests/fixtures/python/DRF-SEC-001/fail_no_permission_classes.py
+++ b/tests/fixtures/python/DRF-SEC-001/fail_no_permission_classes.py
@@ -1,0 +1,8 @@
+"""Fixture for DRF-SEC-001: ViewSet without explicit permission_classes."""
+
+from rest_framework.viewsets import ModelViewSet
+
+
+class OrderViewSet(ModelViewSet):
+    queryset = []
+    throttle_classes = []

--- a/tests/fixtures/python/DRF-SEC-001/pass_explicit_permission_classes.py
+++ b/tests/fixtures/python/DRF-SEC-001/pass_explicit_permission_classes.py
@@ -1,0 +1,10 @@
+"""Fixture for DRF-SEC-001: ViewSet declares its permission policy."""
+
+from rest_framework.permissions import IsAuthenticated
+from rest_framework.viewsets import ModelViewSet
+
+
+class OrderViewSet(ModelViewSet):
+    queryset = []
+    permission_classes = [IsAuthenticated]
+    throttle_classes = []

--- a/tests/fixtures/python/DRF-SEC-001/pass_non_drf_class.py
+++ b/tests/fixtures/python/DRF-SEC-001/pass_non_drf_class.py
@@ -1,0 +1,10 @@
+"""Fixture for DRF-SEC-001: a plain class in a DRF-aware module is out of scope."""
+
+from rest_framework.viewsets import ModelViewSet
+
+
+class OrderHelper:
+    queryset = []
+
+
+_ = ModelViewSet  # silence unused import


### PR DESCRIPTION
## Summary
- Adds fixture directories for DRF-SEC-001 (DRFNoPermissionClass) and DRF-SCALE-001 (DRFNoThrottling).
- Each rule gets one fail case (a `ModelViewSet` missing the required attribute), the explicit-declaration pass, and a non-DRF class in a DRF-aware module to prove the rule keys on the ViewSet base.

Part of #71.

## Test plan
- [x] `pytest tests/test_fixture_corpus.py -k DRF` — 6 passed
- [x] Full `pytest` — 201 passed
- [x] `gaudi-fixture-coverage` — both rules `OK`
- [x] `gaudi check src/` — unchanged dogfood baseline

🤖 Generated with [Claude Code](https://claude.com/claude-code)