### PR TITLE
Migrate FAPI pack to fixture corpus

### DIFF
--- a/tests/fixtures/python/FAPI-ARCH-001/expected.json
+++ b/tests/fixtures/python/FAPI-ARCH-001/expected.json
@@ -1,0 +1,21 @@
+{
+  "rule_id": "FAPI-ARCH-001",
+  "description": "FastAPINoResponseModel -- FastAPI endpoints must declare a response_model",
+  "fixtures": {
+    "fail_no_response_model.py": {
+      "expected_findings": [
+        {
+          "severity": "warn",
+          "line": 8,
+          "message_contains": "response_model"
+        }
+      ]
+    },
+    "pass_with_response_model.py": {
+      "expected_findings": []
+    },
+    "pass_plain_function.py": {
+      "expected_findings": []
+    }
+  }
+}

--- a/tests/fixtures/python/FAPI-ARCH-001/fail_no_response_model.py
+++ b/tests/fixtures/python/FAPI-ARCH-001/fail_no_response_model.py
@@ -1,0 +1,10 @@
+"""Fixture for FAPI-ARCH-001: FastAPI endpoint without response_model."""
+
+from fastapi import FastAPI
+
+app = FastAPI()
+
+
+@app.get("/orders/{order_id}")
+def get_order(order_id: int):
+    return {"id": order_id}

--- a/tests/fixtures/python/FAPI-ARCH-001/pass_plain_function.py
+++ b/tests/fixtures/python/FAPI-ARCH-001/pass_plain_function.py
@@ -1,0 +1,12 @@
+"""Fixture for FAPI-ARCH-001: a plain function in a fastapi-aware module is out of scope."""
+
+from fastapi import FastAPI
+
+app = FastAPI()
+
+
+def compute_total(items):
+    return sum(items)
+
+
+_ = app

--- a/tests/fixtures/python/FAPI-ARCH-001/pass_with_response_model.py
+++ b/tests/fixtures/python/FAPI-ARCH-001/pass_with_response_model.py
@@ -1,0 +1,15 @@
+"""Fixture for FAPI-ARCH-001: endpoint declares its response_model."""
+
+from fastapi import FastAPI
+from pydantic import BaseModel
+
+app = FastAPI()
+
+
+class Order(BaseModel):
+    id: int
+
+
+@app.get("/orders/{order_id}", response_model=Order)
+def get_order(order_id: int):
+    return {"id": order_id}


### PR DESCRIPTION
## Summary
- Adds a fixture directory for FAPI-ARCH-001 (FastAPINoResponseModel).
- One fail case (`@app.get` without `response_model`) and two pass cases: the explicit declaration, and a plain function in a fastapi-aware module to prove the rule keys on the route decorator.

Part of #71.

## Test plan
- [x] `pytest tests/test_fixture_corpus.py -k FAPI` — 3 passed
- [x] Full `pytest` — 204 passed
- [x] `gaudi-fixture-coverage` — FAPI-ARCH-001 `OK`
- [x] `gaudi check src/` — unchanged dogfood baseline

🤖 Generated with [Claude Code](https://claude.com/claude-code)