### PR TITLE
Migrate HTTP (requests) pack to fixture corpus

### DIFF
--- a/tests/fixtures/python/HTTP-SCALE-001/expected.json
+++ b/tests/fixtures/python/HTTP-SCALE-001/expected.json
@@ -1,0 +1,26 @@
+{
+  "rule_id": "HTTP-SCALE-001",
+  "description": "RequestsNoTimeout -- requests calls must declare a timeout",
+  "fixtures": {
+    "fail_no_timeout.py": {
+      "expected_findings": [
+        {
+          "severity": "error",
+          "line": 7,
+          "message_contains": "timeout"
+        },
+        {
+          "severity": "error",
+          "line": 11,
+          "message_contains": "timeout"
+        }
+      ]
+    },
+    "pass_with_timeout.py": {
+      "expected_findings": []
+    },
+    "pass_unrelated_get.py": {
+      "expected_findings": []
+    }
+  }
+}

--- a/tests/fixtures/python/HTTP-SCALE-001/fail_no_timeout.py
+++ b/tests/fixtures/python/HTTP-SCALE-001/fail_no_timeout.py
@@ -1,0 +1,11 @@
+"""Fixture for HTTP-SCALE-001: requests calls without a timeout."""
+
+import requests
+
+
+def fetch(url):
+    return requests.get(url)
+
+
+def submit(url, payload):
+    return requests.post(url, json=payload)

--- a/tests/fixtures/python/HTTP-SCALE-001/pass_unrelated_get.py
+++ b/tests/fixtures/python/HTTP-SCALE-001/pass_unrelated_get.py
@@ -1,0 +1,10 @@
+"""Fixture for HTTP-SCALE-001: a `.get()` call on a non-requests object is out of scope."""
+
+import requests
+
+
+def lookup(mapping, key):
+    return mapping.get(key)
+
+
+_ = requests

--- a/tests/fixtures/python/HTTP-SCALE-001/pass_with_timeout.py
+++ b/tests/fixtures/python/HTTP-SCALE-001/pass_with_timeout.py
@@ -1,0 +1,11 @@
+"""Fixture for HTTP-SCALE-001: every requests call declares a timeout."""
+
+import requests
+
+
+def fetch(url):
+    return requests.get(url, timeout=5)
+
+
+def submit(url, payload):
+    return requests.post(url, json=payload, timeout=10)


### PR DESCRIPTION
## Summary
- Adds a fixture directory for HTTP-SCALE-001 (RequestsNoTimeout).
- One fail case (two `requests.get/post` calls without `timeout`) and two pass cases: explicit `timeout=` kwargs, and an unrelated `mapping.get()` to prove the rule keys on the `requests` module, not the method name.

Part of #71 (library packs bullet).

## Test plan
- [x] `pytest tests/test_fixture_corpus.py -k HTTP-SCALE` — 3 passed
- [x] Full `pytest` — 207 passed
- [x] `gaudi-fixture-coverage` — HTTP-SCALE-001 `OK`
- [x] `gaudi check src/` — unchanged dogfood baseline

🤖 Generated with [Claude Code](https://claude.com/claude-code)