### PR TITLE
Migrate AWS (boto3) pack to fixture corpus

### DIFF
--- a/tests/fixtures/python/AWS-ARCH-001/expected.json
+++ b/tests/fixtures/python/AWS-ARCH-001/expected.json
@@ -1,0 +1,21 @@
+{
+  "rule_id": "AWS-ARCH-001",
+  "description": "HardcodedRegion -- boto3 region_name must not be a literal",
+  "fixtures": {
+    "fail_hardcoded_region.py": {
+      "expected_findings": [
+        {
+          "severity": "warn",
+          "line": 5,
+          "message_contains": "region_name"
+        }
+      ]
+    },
+    "pass_region_from_env.py": {
+      "expected_findings": []
+    },
+    "pass_default_region.py": {
+      "expected_findings": []
+    }
+  }
+}

--- a/tests/fixtures/python/AWS-ARCH-001/fail_hardcoded_region.py
+++ b/tests/fixtures/python/AWS-ARCH-001/fail_hardcoded_region.py
@@ -1,0 +1,5 @@
+"""Fixture for AWS-ARCH-001: boto3 client built with a literal region_name."""
+
+import boto3
+
+client = boto3.client("s3", region_name="us-east-1")

--- a/tests/fixtures/python/AWS-ARCH-001/pass_default_region.py
+++ b/tests/fixtures/python/AWS-ARCH-001/pass_default_region.py
@@ -1,0 +1,5 @@
+"""Fixture for AWS-ARCH-001: no region passed at all -- default chain takes over."""
+
+import boto3
+
+client = boto3.client("s3")

--- a/tests/fixtures/python/AWS-ARCH-001/pass_region_from_env.py
+++ b/tests/fixtures/python/AWS-ARCH-001/pass_region_from_env.py
@@ -1,0 +1,7 @@
+"""Fixture for AWS-ARCH-001: region resolved from configuration, not a literal."""
+
+import os
+
+import boto3
+
+client = boto3.client("s3", region_name=os.environ["AWS_REGION"])

--- a/tests/fixtures/python/AWS-ERR-001/expected.json
+++ b/tests/fixtures/python/AWS-ERR-001/expected.json
@@ -1,0 +1,21 @@
+{
+  "rule_id": "AWS-ERR-001",
+  "description": "BareClientCall -- boto3 API calls must be wrapped in try/except",
+  "fixtures": {
+    "fail_bare_client_call.py": {
+      "expected_findings": [
+        {
+          "severity": "warn",
+          "line": 9,
+          "message_contains": "error handling"
+        }
+      ]
+    },
+    "pass_handled_client_call.py": {
+      "expected_findings": []
+    },
+    "pass_no_boto3_client.py": {
+      "expected_findings": []
+    }
+  }
+}

--- a/tests/fixtures/python/AWS-ERR-001/fail_bare_client_call.py
+++ b/tests/fixtures/python/AWS-ERR-001/fail_bare_client_call.py
@@ -1,0 +1,9 @@
+"""Fixture for AWS-ERR-001: a boto3 API call with no try/except wrapping it."""
+
+import boto3
+
+client = boto3.client("s3")
+
+
+def upload(key, body):
+    client.put_object(Bucket="my-bucket", Key=key, Body=body)

--- a/tests/fixtures/python/AWS-ERR-001/pass_handled_client_call.py
+++ b/tests/fixtures/python/AWS-ERR-001/pass_handled_client_call.py
@@ -1,0 +1,14 @@
+"""Fixture for AWS-ERR-001: API call wrapped in try/except for ClientError."""
+
+import boto3
+from botocore.exceptions import ClientError
+
+client = boto3.client("s3")
+
+
+def upload(key, body):
+    try:
+        client.put_object(Bucket="my-bucket", Key=key, Body=body)
+    except ClientError:
+        return None
+    return key

--- a/tests/fixtures/python/AWS-ERR-001/pass_no_boto3_client.py
+++ b/tests/fixtures/python/AWS-ERR-001/pass_no_boto3_client.py
@@ -1,0 +1,10 @@
+"""Fixture for AWS-ERR-001: no boto3 client assignment in this file."""
+
+import boto3
+
+
+def helper(thing):
+    return thing.put_object()  # `thing` is not a boto3 client
+
+
+_ = boto3

--- a/tests/fixtures/python/AWS-SCALE-001/expected.json
+++ b/tests/fixtures/python/AWS-SCALE-001/expected.json
@@ -1,0 +1,26 @@
+{
+  "rule_id": "AWS-SCALE-001",
+  "description": "UnpaginatedList -- boto3 list/describe/scan calls must use a paginator",
+  "fixtures": {
+    "fail_unpaginated_list.py": {
+      "expected_findings": [
+        {
+          "severity": "warn",
+          "line": 9,
+          "message_contains": "list_buckets"
+        },
+        {
+          "severity": "warn",
+          "line": 13,
+          "message_contains": "list_objects_v2"
+        }
+      ]
+    },
+    "pass_paginator.py": {
+      "expected_findings": []
+    },
+    "pass_non_listing_call.py": {
+      "expected_findings": []
+    }
+  }
+}

--- a/tests/fixtures/python/AWS-SCALE-001/fail_unpaginated_list.py
+++ b/tests/fixtures/python/AWS-SCALE-001/fail_unpaginated_list.py
@@ -1,0 +1,13 @@
+"""Fixture for AWS-SCALE-001: list_/describe_ called directly instead of via paginator."""
+
+import boto3
+
+client = boto3.client("s3")
+
+
+def all_buckets():
+    return client.list_buckets()
+
+
+def all_objects(bucket):
+    return client.list_objects_v2(Bucket=bucket)

--- a/tests/fixtures/python/AWS-SCALE-001/pass_non_listing_call.py
+++ b/tests/fixtures/python/AWS-SCALE-001/pass_non_listing_call.py
@@ -1,0 +1,9 @@
+"""Fixture for AWS-SCALE-001: a non-listing API call (put_object) is out of scope."""
+
+import boto3
+
+client = boto3.client("s3")
+
+
+def upload(key, body):
+    return client.put_object(Bucket="my-bucket", Key=key, Body=body)

--- a/tests/fixtures/python/AWS-SCALE-001/pass_paginator.py
+++ b/tests/fixtures/python/AWS-SCALE-001/pass_paginator.py
@@ -1,0 +1,11 @@
+"""Fixture for AWS-SCALE-001: paginator covers the result set."""
+
+import boto3
+
+client = boto3.client("s3")
+
+
+def all_objects(bucket):
+    paginator = client.get_paginator("list_objects_v2")
+    for page in paginator.paginate(Bucket=bucket):
+        yield from page.get("Contents", [])


### PR DESCRIPTION
## Summary
- Adds fixture directories for AWS-ARCH-001 (HardcodedRegion), AWS-ERR-001 (BareClientCall), and AWS-SCALE-001 (UnpaginatedList).
- Each rule gets one fail case plus two pass cases that exercise both the canonical escape and a negative-keying check (ARCH: env-resolved + no-region-at-all; ERR: try/wrapped + no boto3 client assignment; SCALE: paginator + non-listing call).

Part of #71 (library packs bullet).

## Test plan
- [x] `pytest tests/test_fixture_corpus.py -k AWS` — 9 passed
- [x] Full `pytest` — 216 passed
- [x] `gaudi-fixture-coverage` — all three rules `OK`
- [x] `gaudi check src/` — unchanged dogfood baseline

🤖 Generated with [Claude Code](https://claude.com/claude-code)