### PR TITLE
Migrate LLM (anthropic) pack to fixture corpus

### DIFF
--- a/tests/fixtures/python/LLM-ARCH-001/expected.json
+++ b/tests/fixtures/python/LLM-ARCH-001/expected.json
@@ -1,0 +1,21 @@
+{
+  "rule_id": "LLM-ARCH-001",
+  "description": "HardcodedModel -- Anthropic model name must not be a literal in the API call",
+  "fixtures": {
+    "fail_hardcoded_model.py": {
+      "expected_findings": [
+        {
+          "severity": "warn",
+          "line": 9,
+          "message_contains": "Hardcoded model"
+        }
+      ]
+    },
+    "pass_model_from_config.py": {
+      "expected_findings": []
+    },
+    "pass_no_api_call.py": {
+      "expected_findings": []
+    }
+  }
+}

--- a/tests/fixtures/python/LLM-ARCH-001/fail_hardcoded_model.py
+++ b/tests/fixtures/python/LLM-ARCH-001/fail_hardcoded_model.py
@@ -1,0 +1,13 @@
+"""Fixture for LLM-ARCH-001: model name as a string literal in the API call."""
+
+import anthropic
+
+client = anthropic.Anthropic()
+
+
+def ask(prompt):
+    return client.messages.create(
+        model="claude-opus-4-6",
+        max_tokens=1024,
+        messages=[{"role": "user", "content": prompt}],
+    )

--- a/tests/fixtures/python/LLM-ARCH-001/pass_model_from_config.py
+++ b/tests/fixtures/python/LLM-ARCH-001/pass_model_from_config.py
@@ -1,0 +1,16 @@
+"""Fixture for LLM-ARCH-001: model name resolved from a configuration variable."""
+
+import os
+
+import anthropic
+
+MODEL = os.environ["ANTHROPIC_MODEL"]
+client = anthropic.Anthropic()
+
+
+def ask(prompt):
+    return client.messages.create(
+        model=MODEL,
+        max_tokens=1024,
+        messages=[{"role": "user", "content": prompt}],
+    )

--- a/tests/fixtures/python/LLM-ARCH-001/pass_no_api_call.py
+++ b/tests/fixtures/python/LLM-ARCH-001/pass_no_api_call.py
@@ -1,0 +1,7 @@
+"""Fixture for LLM-ARCH-001: a module that imports anthropic but makes no API call."""
+
+import anthropic
+
+
+def build_client():
+    return anthropic.Anthropic()

--- a/tests/fixtures/python/LLM-ERR-001/expected.json
+++ b/tests/fixtures/python/LLM-ERR-001/expected.json
@@ -1,0 +1,21 @@
+{
+  "rule_id": "LLM-ERR-001",
+  "description": "BareAPICall -- Anthropic API calls must be wrapped in try/except",
+  "fixtures": {
+    "fail_bare_api_call.py": {
+      "expected_findings": [
+        {
+          "severity": "warn",
+          "line": 13,
+          "message_contains": "error handling"
+        }
+      ]
+    },
+    "pass_handled_api_call.py": {
+      "expected_findings": []
+    },
+    "pass_no_api_call.py": {
+      "expected_findings": []
+    }
+  }
+}

--- a/tests/fixtures/python/LLM-ERR-001/fail_bare_api_call.py
+++ b/tests/fixtures/python/LLM-ERR-001/fail_bare_api_call.py
@@ -1,0 +1,17 @@
+"""Fixture for LLM-ERR-001: Anthropic API call with no try/except around it."""
+
+import os
+
+import anthropic
+
+MODEL = os.environ["ANTHROPIC_MODEL"]
+client = anthropic.Anthropic()
+
+
+def ask(prompt):
+    # count_tokens(prompt) -- placate LLM-SCALE-001 token-counting heuristic
+    return client.messages.create(
+        model=MODEL,
+        max_tokens=1024,
+        messages=[{"role": "user", "content": prompt}],
+    )

--- a/tests/fixtures/python/LLM-ERR-001/pass_handled_api_call.py
+++ b/tests/fixtures/python/LLM-ERR-001/pass_handled_api_call.py
@@ -1,0 +1,20 @@
+"""Fixture for LLM-ERR-001: API call wrapped in try/except for transient failures."""
+
+import os
+
+import anthropic
+
+MODEL = os.environ["ANTHROPIC_MODEL"]
+client = anthropic.Anthropic()
+
+
+def ask(prompt):
+    # count_tokens(prompt) -- placate LLM-SCALE-001 token-counting heuristic
+    try:
+        return client.messages.create(
+            model=MODEL,
+            max_tokens=1024,
+            messages=[{"role": "user", "content": prompt}],
+        )
+    except anthropic.APIError:
+        return None

--- a/tests/fixtures/python/LLM-ERR-001/pass_no_api_call.py
+++ b/tests/fixtures/python/LLM-ERR-001/pass_no_api_call.py
@@ -1,0 +1,7 @@
+"""Fixture for LLM-ERR-001: a module that imports anthropic but makes no API call."""
+
+import anthropic
+
+
+def build_client():
+    return anthropic.Anthropic()

--- a/tests/fixtures/python/LLM-SCALE-001/expected.json
+++ b/tests/fixtures/python/LLM-SCALE-001/expected.json
@@ -1,0 +1,20 @@
+{
+  "rule_id": "LLM-SCALE-001",
+  "description": "NoTokenCounting -- Anthropic API calls must be paired with a token-budget check",
+  "fixtures": {
+    "fail_no_token_counting.py": {
+      "expected_findings": [
+        {
+          "severity": "warn",
+          "message_contains": "token counting"
+        }
+      ]
+    },
+    "pass_with_count_tokens.py": {
+      "expected_findings": []
+    },
+    "pass_no_api_call.py": {
+      "expected_findings": []
+    }
+  }
+}

--- a/tests/fixtures/python/LLM-SCALE-001/fail_no_token_counting.py
+++ b/tests/fixtures/python/LLM-SCALE-001/fail_no_token_counting.py
@@ -1,0 +1,19 @@
+"""Fixture for LLM-SCALE-001: API call without any token-counting safeguard."""
+
+import os
+
+import anthropic
+
+MODEL = os.environ["ANTHROPIC_MODEL"]
+client = anthropic.Anthropic()
+
+
+def ask(prompt):
+    try:
+        return client.messages.create(
+            model=MODEL,
+            max_tokens=1024,
+            messages=[{"role": "user", "content": prompt}],
+        )
+    except anthropic.APIError:
+        return None

--- a/tests/fixtures/python/LLM-SCALE-001/pass_no_api_call.py
+++ b/tests/fixtures/python/LLM-SCALE-001/pass_no_api_call.py
@@ -1,0 +1,7 @@
+"""Fixture for LLM-SCALE-001: a module that imports anthropic but makes no API call."""
+
+import anthropic
+
+
+def build_client():
+    return anthropic.Anthropic()

--- a/tests/fixtures/python/LLM-SCALE-001/pass_with_count_tokens.py
+++ b/tests/fixtures/python/LLM-SCALE-001/pass_with_count_tokens.py
@@ -1,0 +1,26 @@
+"""Fixture for LLM-SCALE-001: API call alongside a count_tokens budget check."""
+
+import os
+
+import anthropic
+
+MODEL = os.environ["ANTHROPIC_MODEL"]
+client = anthropic.Anthropic()
+TOKEN_BUDGET = 100_000
+
+
+def ask(prompt):
+    n = client.messages.count_tokens(
+        model=MODEL,
+        messages=[{"role": "user", "content": prompt}],
+    ).input_tokens
+    if n > TOKEN_BUDGET:
+        raise ValueError("prompt exceeds token budget")
+    try:
+        return client.messages.create(
+            model=MODEL,
+            max_tokens=1024,
+            messages=[{"role": "user", "content": prompt}],
+        )
+    except anthropic.APIError:
+        return None


### PR DESCRIPTION
## Summary
- Adds fixture directories for LLM-ARCH-001 (HardcodedModel), LLM-ERR-001 (BareAPICall), and LLM-SCALE-001 (NoTokenCounting).
- Each rule gets one fail case and two pass cases. Pass cases for ERR include a `count_tokens` comment so the per-file LLM-SCALE-001 token-counting heuristic doesn't accidentally fire on a fixture under test for ERR — each fixture isolates its own rule.

Part of #71 (library packs bullet).

## Test plan
- [x] `pytest tests/test_fixture_corpus.py -k LLM` — 9 passed
- [x] Full `pytest` — 225 passed
- [x] `gaudi-fixture-coverage` — all three rules `OK`
- [x] `gaudi check src/` — unchanged dogfood baseline

🤖 Generated with [Claude Code](https://claude.com/claude-code)