### PR TITLE
Migrate PD (pandas) pack to fixture corpus

### DIFF
--- a/tests/fixtures/python/PD-ARCH-001/expected.json
+++ b/tests/fixtures/python/PD-ARCH-001/expected.json
@@ -1,0 +1,26 @@
+{
+  "rule_id": "PD-ARCH-001",
+  "description": "PandasInplaceAntiPattern -- inplace=True hides mutation",
+  "fixtures": {
+    "fail_inplace_true.py": {
+      "expected_findings": [
+        {
+          "severity": "warn",
+          "line": 7,
+          "message_contains": "inplace"
+        },
+        {
+          "severity": "warn",
+          "line": 8,
+          "message_contains": "inplace"
+        }
+      ]
+    },
+    "pass_assignment.py": {
+      "expected_findings": []
+    },
+    "pass_inplace_false.py": {
+      "expected_findings": []
+    }
+  }
+}

--- a/tests/fixtures/python/PD-ARCH-001/fail_inplace_true.py
+++ b/tests/fixtures/python/PD-ARCH-001/fail_inplace_true.py
@@ -1,0 +1,9 @@
+"""Fixture for PD-ARCH-001: pandas calls with inplace=True."""
+
+import pandas as pd
+
+
+def clean(df):
+    df.dropna(inplace=True)
+    df.rename(columns={"a": "alpha"}, inplace=True)
+    return df

--- a/tests/fixtures/python/PD-ARCH-001/pass_assignment.py
+++ b/tests/fixtures/python/PD-ARCH-001/pass_assignment.py
@@ -1,0 +1,9 @@
+"""Fixture for PD-ARCH-001: same operations done by reassignment."""
+
+import pandas as pd
+
+
+def clean(df):
+    df = df.dropna()
+    df = df.rename(columns={"a": "alpha"})
+    return df

--- a/tests/fixtures/python/PD-ARCH-001/pass_inplace_false.py
+++ b/tests/fixtures/python/PD-ARCH-001/pass_inplace_false.py
@@ -1,0 +1,7 @@
+"""Fixture for PD-ARCH-001: explicit inplace=False is fine (and equivalent to omitting it)."""
+
+import pandas as pd
+
+
+def clean(df):
+    return df.dropna(inplace=False)

--- a/tests/fixtures/python/PD-SCALE-001/expected.json
+++ b/tests/fixtures/python/PD-SCALE-001/expected.json
@@ -1,0 +1,21 @@
+{
+  "rule_id": "PD-SCALE-001",
+  "description": "PandasIterrows -- row-by-row iteration is the wrong tool at production data sizes",
+  "fixtures": {
+    "fail_iterrows.py": {
+      "expected_findings": [
+        {
+          "severity": "warn",
+          "line": 8,
+          "message_contains": "iterrows"
+        }
+      ]
+    },
+    "pass_vectorized.py": {
+      "expected_findings": []
+    },
+    "pass_itertuples.py": {
+      "expected_findings": []
+    }
+  }
+}

--- a/tests/fixtures/python/PD-SCALE-001/fail_iterrows.py
+++ b/tests/fixtures/python/PD-SCALE-001/fail_iterrows.py
@@ -1,0 +1,10 @@
+"""Fixture for PD-SCALE-001: a row-by-row loop using iterrows()."""
+
+import pandas as pd
+
+
+def total(df):
+    out = 0
+    for _, row in df.iterrows():
+        out += row["amount"]
+    return out

--- a/tests/fixtures/python/PD-SCALE-001/pass_itertuples.py
+++ b/tests/fixtures/python/PD-SCALE-001/pass_itertuples.py
@@ -1,0 +1,10 @@
+"""Fixture for PD-SCALE-001: itertuples() is the recommended escape and is not flagged."""
+
+import pandas as pd
+
+
+def total(df):
+    out = 0
+    for row in df.itertuples():
+        out += row.amount
+    return out

--- a/tests/fixtures/python/PD-SCALE-001/pass_vectorized.py
+++ b/tests/fixtures/python/PD-SCALE-001/pass_vectorized.py
@@ -1,0 +1,7 @@
+"""Fixture for PD-SCALE-001: a vectorized sum instead of row iteration."""
+
+import pandas as pd
+
+
+def total(df):
+    return df["amount"].sum()


### PR DESCRIPTION
## Summary
- Adds fixture directories for PD-ARCH-001 (PandasInplaceAntiPattern) and PD-SCALE-001 (PandasIterrows).
- ARCH: two `inplace=True` calls vs reassignment vs explicit `inplace=False` (proves the rule keys on the literal `True`, not the keyword name).
- SCALE: `iterrows()` loop vs vectorized `.sum()` vs `itertuples()` (the recommended escape).

Part of #71 (library packs bullet).

## Test plan
- [x] `pytest tests/test_fixture_corpus.py -k PD-` — 6 passed
- [x] Full `pytest` — 231 passed
- [x] `gaudi-fixture-coverage` — both rules `OK`
- [x] `gaudi check src/` — unchanged dogfood baseline

🤖 Generated with [Claude Code](https://claude.com/claude-code)