### PR TITLE
Migrate SA (sqlalchemy) pack to fixture corpus

### DIFF
--- a/tests/fixtures/python/SA-SCALE-001/expected.json
+++ b/tests/fixtures/python/SA-SCALE-001/expected.json
@@ -1,0 +1,21 @@
+{
+  "rule_id": "SA-SCALE-001",
+  "description": "SQLAlchemyLazyDefault -- relationship() must declare its lazy loading strategy",
+  "fixtures": {
+    "fail_default_lazy.py": {
+      "expected_findings": [
+        {
+          "severity": "warn",
+          "line": 10,
+          "message_contains": "lazy"
+        }
+      ]
+    },
+    "pass_explicit_lazy.py": {
+      "expected_findings": []
+    },
+    "pass_lazy_kwarg_escape.py": {
+      "expected_findings": []
+    }
+  }
+}

--- a/tests/fixtures/python/SA-SCALE-001/fail_default_lazy.py
+++ b/tests/fixtures/python/SA-SCALE-001/fail_default_lazy.py
@@ -1,0 +1,10 @@
+"""Fixture for SA-SCALE-001: relationship() with no explicit lazy strategy."""
+
+from sqlalchemy.orm import declarative_base, relationship
+
+Base = declarative_base()
+
+
+class Order(Base):
+    __tablename__ = "orders"
+    items = relationship("Item")

--- a/tests/fixtures/python/SA-SCALE-001/pass_explicit_lazy.py
+++ b/tests/fixtures/python/SA-SCALE-001/pass_explicit_lazy.py
@@ -1,0 +1,10 @@
+"""Fixture for SA-SCALE-001: relationship() declares its loading strategy."""
+
+from sqlalchemy.orm import declarative_base, relationship
+
+Base = declarative_base()
+
+
+class Order(Base):
+    __tablename__ = "orders"
+    items = relationship("Item", lazy="selectin")

--- a/tests/fixtures/python/SA-SCALE-001/pass_lazy_kwarg_escape.py
+++ b/tests/fixtures/python/SA-SCALE-001/pass_lazy_kwarg_escape.py
@@ -1,0 +1,15 @@
+"""Fixture for SA-SCALE-001: a relationship() call escaped by the lazy kwarg.
+
+This fixture imports sqlalchemy so the rule actually activates, then proves
+that supplying `lazy=` is a sufficient escape regardless of which symbol
+named `relationship` is being called.
+"""
+
+import sqlalchemy  # noqa: F401 -- activates the rule
+
+
+def relationship(target, **kwargs):
+    return (target, kwargs)
+
+
+x = relationship("Item", lazy="selectin")


### PR DESCRIPTION
## Summary
- Adds a fixture directory for SA-SCALE-001 (SQLAlchemyLazyDefault).
- One fail case (`relationship()` with no lazy kwarg), the canonical `lazy='selectin'` escape, and a third pass case that imports `sqlalchemy` and calls a locally-defined `relationship()` symbol with the `lazy` kwarg — proves the rule keys on the kwarg, not on import resolution.
- Caught a near-miss: my first pass fixture had no `sqlalchemy` import, so the rule never activated and the case passed vacuously. Re-shaped to actually exercise the rule.

Part of #71 (library packs bullet). With SA merged, every entry under "Remaining library packs" (anthropic, boto3, fastapi, pandas, requests, sqlalchemy) is now on the corpus.

## Test plan
- [x] `pytest tests/test_fixture_corpus.py -k SA-SCALE` — 3 passed
- [x] Full `pytest` — 234 passed
- [x] `gaudi-fixture-coverage` — SA-SCALE-001 `OK`
- [x] `gaudi check src/` — unchanged dogfood baseline

🤖 Generated with [Claude Code](https://claude.com/claude-code)