### PR TITLE
Migrate DEP pack to fixture corpus

### DIFF
--- a/tests/fixtures/python/DEP-001/expected.json
+++ b/tests/fixtures/python/DEP-001/expected.json
@@ -1,0 +1,17 @@
+{
+  "rule_id": "DEP-001",
+  "description": "CircularImport -- Acyclic Dependencies Principle",
+  "fixtures": {
+    "fail_simple_cycle/": {
+      "expected_findings": [
+        {
+          "severity": "error",
+          "message_contains": "Circular import"
+        }
+      ]
+    },
+    "pass_linear_chain/": {
+      "expected_findings": []
+    }
+  }
+}

--- a/tests/fixtures/python/DEP-001/fail_simple_cycle/a.py
+++ b/tests/fixtures/python/DEP-001/fail_simple_cycle/a.py
@@ -1,0 +1,5 @@
+from b import other  # noqa: F401
+
+
+def value():
+    return 1

--- a/tests/fixtures/python/DEP-001/fail_simple_cycle/b.py
+++ b/tests/fixtures/python/DEP-001/fail_simple_cycle/b.py
@@ -1,0 +1,5 @@
+from a import value  # noqa: F401
+
+
+def other():
+    return 2

--- a/tests/fixtures/python/DEP-001/pass_linear_chain/a.py
+++ b/tests/fixtures/python/DEP-001/pass_linear_chain/a.py
@@ -1,0 +1,5 @@
+from b import value  # noqa: F401
+
+
+def total():
+    return value() + 1

--- a/tests/fixtures/python/DEP-001/pass_linear_chain/b.py
+++ b/tests/fixtures/python/DEP-001/pass_linear_chain/b.py
@@ -1,0 +1,2 @@
+def value():
+    return 1

--- a/tests/fixtures/python/DEP-002/expected.json
+++ b/tests/fixtures/python/DEP-002/expected.json
@@ -1,0 +1,17 @@
+{
+  "rule_id": "DEP-002",
+  "description": "FanOutExplosion -- one module imports too many internal modules",
+  "fixtures": {
+    "fail_high_fan_out/": {
+      "expected_findings": [
+        {
+          "severity": "warn",
+          "message_contains": "imports 10 internal modules"
+        }
+      ]
+    },
+    "pass_below_threshold/": {
+      "expected_findings": []
+    }
+  }
+}

--- a/tests/fixtures/python/DEP-002/fail_high_fan_out/m1.py
+++ b/tests/fixtures/python/DEP-002/fail_high_fan_out/m1.py
@@ -1,0 +1,2 @@
+def value():
+    return 1

--- a/tests/fixtures/python/DEP-002/fail_high_fan_out/m10.py
+++ b/tests/fixtures/python/DEP-002/fail_high_fan_out/m10.py
@@ -1,0 +1,2 @@
+def value():
+    return 10

--- a/tests/fixtures/python/DEP-002/fail_high_fan_out/m2.py
+++ b/tests/fixtures/python/DEP-002/fail_high_fan_out/m2.py
@@ -1,0 +1,2 @@
+def value():
+    return 2

--- a/tests/fixtures/python/DEP-002/fail_high_fan_out/m3.py
+++ b/tests/fixtures/python/DEP-002/fail_high_fan_out/m3.py
@@ -1,0 +1,2 @@
+def value():
+    return 3

--- a/tests/fixtures/python/DEP-002/fail_high_fan_out/m4.py
+++ b/tests/fixtures/python/DEP-002/fail_high_fan_out/m4.py
@@ -1,0 +1,2 @@
+def value():
+    return 4

--- a/tests/fixtures/python/DEP-002/fail_high_fan_out/m5.py
+++ b/tests/fixtures/python/DEP-002/fail_high_fan_out/m5.py
@@ -1,0 +1,2 @@
+def value():
+    return 5

--- a/tests/fixtures/python/DEP-002/fail_high_fan_out/m6.py
+++ b/tests/fixtures/python/DEP-002/fail_high_fan_out/m6.py
@@ -1,0 +1,2 @@
+def value():
+    return 6

--- a/tests/fixtures/python/DEP-002/fail_high_fan_out/m7.py
+++ b/tests/fixtures/python/DEP-002/fail_high_fan_out/m7.py
@@ -1,0 +1,2 @@
+def value():
+    return 7

--- a/tests/fixtures/python/DEP-002/fail_high_fan_out/m8.py
+++ b/tests/fixtures/python/DEP-002/fail_high_fan_out/m8.py
@@ -1,0 +1,2 @@
+def value():
+    return 8

--- a/tests/fixtures/python/DEP-002/fail_high_fan_out/m9.py
+++ b/tests/fixtures/python/DEP-002/fail_high_fan_out/m9.py
@@ -1,0 +1,2 @@
+def value():
+    return 9

--- a/tests/fixtures/python/DEP-002/fail_high_fan_out/root.py
+++ b/tests/fixtures/python/DEP-002/fail_high_fan_out/root.py
@@ -1,0 +1,14 @@
+from m1 import value as v1
+from m2 import value as v2
+from m3 import value as v3
+from m4 import value as v4
+from m5 import value as v5
+from m6 import value as v6
+from m7 import value as v7
+from m8 import value as v8
+from m9 import value as v9
+from m10 import value as v10
+
+
+def total():
+    return v1() + v2() + v3() + v4() + v5() + v6() + v7() + v8() + v9() + v10()

--- a/tests/fixtures/python/DEP-002/pass_below_threshold/m1.py
+++ b/tests/fixtures/python/DEP-002/pass_below_threshold/m1.py
@@ -1,0 +1,2 @@
+def value():
+    return 1

--- a/tests/fixtures/python/DEP-002/pass_below_threshold/m2.py
+++ b/tests/fixtures/python/DEP-002/pass_below_threshold/m2.py
@@ -1,0 +1,2 @@
+def value():
+    return 2

--- a/tests/fixtures/python/DEP-002/pass_below_threshold/m3.py
+++ b/tests/fixtures/python/DEP-002/pass_below_threshold/m3.py
@@ -1,0 +1,2 @@
+def value():
+    return 3

--- a/tests/fixtures/python/DEP-002/pass_below_threshold/m4.py
+++ b/tests/fixtures/python/DEP-002/pass_below_threshold/m4.py
@@ -1,0 +1,2 @@
+def value():
+    return 4

--- a/tests/fixtures/python/DEP-002/pass_below_threshold/m5.py
+++ b/tests/fixtures/python/DEP-002/pass_below_threshold/m5.py
@@ -1,0 +1,2 @@
+def value():
+    return 5

--- a/tests/fixtures/python/DEP-002/pass_below_threshold/m6.py
+++ b/tests/fixtures/python/DEP-002/pass_below_threshold/m6.py
@@ -1,0 +1,2 @@
+def value():
+    return 6

--- a/tests/fixtures/python/DEP-002/pass_below_threshold/m7.py
+++ b/tests/fixtures/python/DEP-002/pass_below_threshold/m7.py
@@ -1,0 +1,2 @@
+def value():
+    return 7

--- a/tests/fixtures/python/DEP-002/pass_below_threshold/m8.py
+++ b/tests/fixtures/python/DEP-002/pass_below_threshold/m8.py
@@ -1,0 +1,2 @@
+def value():
+    return 8

--- a/tests/fixtures/python/DEP-002/pass_below_threshold/m9.py
+++ b/tests/fixtures/python/DEP-002/pass_below_threshold/m9.py
@@ -1,0 +1,2 @@
+def value():
+    return 9

--- a/tests/fixtures/python/DEP-002/pass_below_threshold/root.py
+++ b/tests/fixtures/python/DEP-002/pass_below_threshold/root.py
@@ -1,0 +1,13 @@
+from m1 import value as v1
+from m2 import value as v2
+from m3 import value as v3
+from m4 import value as v4
+from m5 import value as v5
+from m6 import value as v6
+from m7 import value as v7
+from m8 import value as v8
+from m9 import value as v9
+
+
+def total():
+    return v1() + v2() + v3() + v4() + v5() + v6() + v7() + v8() + v9()

--- a/tests/fixtures/python/DEP-003/expected.json
+++ b/tests/fixtures/python/DEP-003/expected.json
@@ -1,0 +1,17 @@
+{
+  "rule_id": "DEP-003",
+  "description": "FanInConcentration -- one module is depended on by most of the project",
+  "fixtures": {
+    "fail_hub/": {
+      "expected_findings": [
+        {
+          "severity": "info",
+          "message_contains": "imported by 4/5"
+        }
+      ]
+    },
+    "pass_no_hub/": {
+      "expected_findings": []
+    }
+  }
+}

--- a/tests/fixtures/python/DEP-003/fail_hub/a.py
+++ b/tests/fixtures/python/DEP-003/fail_hub/a.py
@@ -1,0 +1,5 @@
+from hub import shared
+
+
+def use():
+    return shared()

--- a/tests/fixtures/python/DEP-003/fail_hub/b.py
+++ b/tests/fixtures/python/DEP-003/fail_hub/b.py
@@ -1,0 +1,5 @@
+from hub import shared
+
+
+def use():
+    return shared()

--- a/tests/fixtures/python/DEP-003/fail_hub/c.py
+++ b/tests/fixtures/python/DEP-003/fail_hub/c.py
@@ -1,0 +1,5 @@
+from hub import shared
+
+
+def use():
+    return shared()

--- a/tests/fixtures/python/DEP-003/fail_hub/d.py
+++ b/tests/fixtures/python/DEP-003/fail_hub/d.py
@@ -1,0 +1,5 @@
+from hub import shared
+
+
+def use():
+    return shared()

--- a/tests/fixtures/python/DEP-003/fail_hub/hub.py
+++ b/tests/fixtures/python/DEP-003/fail_hub/hub.py
@@ -1,0 +1,2 @@
+def shared():
+    return 1

--- a/tests/fixtures/python/DEP-003/pass_no_hub/a.py
+++ b/tests/fixtures/python/DEP-003/pass_no_hub/a.py
@@ -1,0 +1,5 @@
+from hub import shared
+
+
+def use():
+    return shared()

--- a/tests/fixtures/python/DEP-003/pass_no_hub/b.py
+++ b/tests/fixtures/python/DEP-003/pass_no_hub/b.py
@@ -1,0 +1,5 @@
+from hub import shared
+
+
+def use():
+    return shared()

--- a/tests/fixtures/python/DEP-003/pass_no_hub/c.py
+++ b/tests/fixtures/python/DEP-003/pass_no_hub/c.py
@@ -1,0 +1,5 @@
+from hub import shared
+
+
+def use():
+    return shared()

--- a/tests/fixtures/python/DEP-003/pass_no_hub/d.py
+++ b/tests/fixtures/python/DEP-003/pass_no_hub/d.py
@@ -1,0 +1,2 @@
+def standalone():
+    return 99

--- a/tests/fixtures/python/DEP-003/pass_no_hub/hub.py
+++ b/tests/fixtures/python/DEP-003/pass_no_hub/hub.py
@@ -1,0 +1,2 @@
+def shared():
+    return 1

--- a/tests/fixtures/python/DEP-004/expected.json
+++ b/tests/fixtures/python/DEP-004/expected.json
@@ -1,0 +1,17 @@
+{
+  "rule_id": "DEP-004",
+  "description": "UnstableDependency -- module is depended on but unstable (Stable Dependencies Principle)",
+  "fixtures": {
+    "fail_unstable_hub/": {
+      "expected_findings": [
+        {
+          "severity": "warn",
+          "message_contains": "unstable"
+        }
+      ]
+    },
+    "pass_stable_hub/": {
+      "expected_findings": []
+    }
+  }
+}

--- a/tests/fixtures/python/DEP-004/fail_unstable_hub/a.py
+++ b/tests/fixtures/python/DEP-004/fail_unstable_hub/a.py
@@ -1,0 +1,2 @@
+def value():
+    return 1

--- a/tests/fixtures/python/DEP-004/fail_unstable_hub/b.py
+++ b/tests/fixtures/python/DEP-004/fail_unstable_hub/b.py
@@ -1,0 +1,2 @@
+def value():
+    return 2

--- a/tests/fixtures/python/DEP-004/fail_unstable_hub/c.py
+++ b/tests/fixtures/python/DEP-004/fail_unstable_hub/c.py
@@ -1,0 +1,2 @@
+def value():
+    return 3

--- a/tests/fixtures/python/DEP-004/fail_unstable_hub/m.py
+++ b/tests/fixtures/python/DEP-004/fail_unstable_hub/m.py
@@ -1,0 +1,7 @@
+from a import value as va
+from b import value as vb
+from c import value as vc
+
+
+def total():
+    return va() + vb() + vc()

--- a/tests/fixtures/python/DEP-004/fail_unstable_hub/x.py
+++ b/tests/fixtures/python/DEP-004/fail_unstable_hub/x.py
@@ -1,0 +1,5 @@
+from m import total
+
+
+def use():
+    return total()

--- a/tests/fixtures/python/DEP-004/fail_unstable_hub/y.py
+++ b/tests/fixtures/python/DEP-004/fail_unstable_hub/y.py
@@ -1,0 +1,5 @@
+from m import total
+
+
+def use():
+    return total()

--- a/tests/fixtures/python/DEP-004/fail_unstable_hub/z.py
+++ b/tests/fixtures/python/DEP-004/fail_unstable_hub/z.py
@@ -1,0 +1,5 @@
+from m import total
+
+
+def use():
+    return total()

--- a/tests/fixtures/python/DEP-004/pass_stable_hub/a.py
+++ b/tests/fixtures/python/DEP-004/pass_stable_hub/a.py
@@ -1,0 +1,2 @@
+def value():
+    return 1

--- a/tests/fixtures/python/DEP-004/pass_stable_hub/filler.py
+++ b/tests/fixtures/python/DEP-004/pass_stable_hub/filler.py
@@ -1,0 +1,2 @@
+def filler():
+    return 0

--- a/tests/fixtures/python/DEP-004/pass_stable_hub/m.py
+++ b/tests/fixtures/python/DEP-004/pass_stable_hub/m.py
@@ -1,0 +1,5 @@
+from a import value as va
+
+
+def total():
+    return va()

--- a/tests/fixtures/python/DEP-004/pass_stable_hub/x.py
+++ b/tests/fixtures/python/DEP-004/pass_stable_hub/x.py
@@ -1,0 +1,5 @@
+from m import total
+
+
+def use():
+    return total()

--- a/tests/fixtures/python/DEP-004/pass_stable_hub/y.py
+++ b/tests/fixtures/python/DEP-004/pass_stable_hub/y.py
@@ -1,0 +1,5 @@
+from m import total
+
+
+def use():
+    return total()

--- a/tests/fixtures/python/DEP-004/pass_stable_hub/z.py
+++ b/tests/fixtures/python/DEP-004/pass_stable_hub/z.py
@@ -1,0 +1,5 @@
+from m import total
+
+
+def use():
+    return total()


### PR DESCRIPTION
## Summary
- Adds directory-shaped fixtures for DEP-001 (CircularImport), DEP-002 (FanOutExplosion), DEP-003 (FanInConcentration), and DEP-004 (UnstableDependency).
- Each rule gets one fail directory + one pass directory exercised against a real multi-file project tree:
  - **DEP-001**: 2-module cycle (a↔b) vs linear chain.
  - **DEP-002**: `root.py` importing 10 internal modules vs 9 (the exact threshold boundary).
  - **DEP-003**: 5-file project where 4/5 files import a hub vs 3/5.
  - **DEP-004**: 7-file project where `m` has fan_in=3 and fan_out=3 (instability=0.5) vs a 6-file project where `m` has fan_out=1.

## Why this scope (and what is *not* in it)

Legacy `tests/test_dependency_rules.py` is **kept** for now. It covers boundary cases the corpus doesn't yet exercise: stdlib filtering, 3-node cycles, package-style `from pkg import mod_b` imports, and the min-files threshold for DEP-003/DEP-004. Adding boundary fixtures (`fail_boundary_*` / `pass_boundary_*`) would balloon this PR; it's a scoped follow-up.

Part of #71.

## Test plan
- [x] `pytest tests/test_fixture_corpus.py -k DEP-00` — 8 passed
- [x] Full `pytest` — 242 passed
- [x] `gaudi-fixture-coverage` — DEP-001..004 all `OK`
- [x] `gaudi check src/` — unchanged dogfood baseline

🤖 Generated with [Claude Code](https://claude.com/claude-code)