### PR TITLE
Migrate TEST (pytest) pack to fixture corpus

### DIFF
--- a/tests/fixtures/python/TEST-SCALE-001/expected.json
+++ b/tests/fixtures/python/TEST-SCALE-001/expected.json
@@ -1,0 +1,26 @@
+{
+  "rule_id": "TEST-SCALE-001",
+  "description": "PytestFixtureScope -- expensive conftest fixtures need an explicit scope",
+  "fixtures": {
+    "fail_conftest_no_scope.py": {
+      "expected_findings": [
+        {
+          "severity": "info",
+          "line": 7,
+          "message_contains": "without scope"
+        },
+        {
+          "severity": "info",
+          "line": 12,
+          "message_contains": "without scope"
+        }
+      ]
+    },
+    "pass_conftest_with_scope.py": {
+      "expected_findings": []
+    },
+    "pass_conftest_cheap_fixtures.py": {
+      "expected_findings": []
+    }
+  }
+}

--- a/tests/fixtures/python/TEST-SCALE-001/fail_conftest_no_scope.py
+++ b/tests/fixtures/python/TEST-SCALE-001/fail_conftest_no_scope.py
@@ -1,0 +1,13 @@
+"""Fixture for TEST-SCALE-001: expensive fixtures in conftest with no scope= kwarg."""
+
+import pytest
+
+
+@pytest.fixture
+def database():
+    return {"connected": True}
+
+
+@pytest.fixture()
+def client():
+    return object()

--- a/tests/fixtures/python/TEST-SCALE-001/pass_conftest_cheap_fixtures.py
+++ b/tests/fixtures/python/TEST-SCALE-001/pass_conftest_cheap_fixtures.py
@@ -1,0 +1,13 @@
+"""Fixture for TEST-SCALE-001: cheap fixtures (no expensive-resource name) are out of scope."""
+
+import pytest
+
+
+@pytest.fixture
+def sample_data():
+    return [1, 2, 3]
+
+
+@pytest.fixture()
+def config():
+    return {"debug": True}

--- a/tests/fixtures/python/TEST-SCALE-001/pass_conftest_with_scope.py
+++ b/tests/fixtures/python/TEST-SCALE-001/pass_conftest_with_scope.py
@@ -1,0 +1,13 @@
+"""Fixture for TEST-SCALE-001: expensive fixtures declare a wider scope."""
+
+import pytest
+
+
+@pytest.fixture(scope="session")
+def database():
+    return {"connected": True}
+
+
+@pytest.fixture(scope="module")
+def client():
+    return object()

--- a/tests/fixtures/python/TEST-STRUCT-001/expected.json
+++ b/tests/fixtures/python/TEST-STRUCT-001/expected.json
@@ -1,0 +1,31 @@
+{
+  "rule_id": "TEST-STRUCT-001",
+  "description": "PytestAssertMessage -- complex assertions need a failure message",
+  "fixtures": {
+    "fail_test_complex_assertions.py": {
+      "expected_findings": [
+        {
+          "severity": "info",
+          "line": 8,
+          "message_contains": "Complex assertion"
+        },
+        {
+          "severity": "info",
+          "line": 13,
+          "message_contains": "Complex assertion"
+        },
+        {
+          "severity": "info",
+          "line": 18,
+          "message_contains": "Complex assertion"
+        }
+      ]
+    },
+    "pass_test_with_messages.py": {
+      "expected_findings": []
+    },
+    "pass_test_simple_assertions.py": {
+      "expected_findings": []
+    }
+  }
+}

--- a/tests/fixtures/python/TEST-STRUCT-001/fail_test_complex_assertions.py
+++ b/tests/fixtures/python/TEST-STRUCT-001/fail_test_complex_assertions.py
@@ -1,0 +1,21 @@
+"""Fixture for TEST-STRUCT-001: complex assertions with no failure message."""
+
+import pytest
+
+
+def test_chain_compare():
+    x = 5
+    assert 0 < x < 10
+
+
+def test_bool_op():
+    a, b = 1, 2
+    assert a > 0 and b > 0
+
+
+def test_negation():
+    items = [1, 2, 3]
+    assert not (len(items) == 0)
+
+
+_ = pytest

--- a/tests/fixtures/python/TEST-STRUCT-001/pass_test_simple_assertions.py
+++ b/tests/fixtures/python/TEST-STRUCT-001/pass_test_simple_assertions.py
@@ -1,0 +1,18 @@
+"""Fixture for TEST-STRUCT-001: simple (non-complex) assertions don't require a message."""
+
+import pytest
+
+
+def test_equality():
+    assert 1 + 1 == 2
+
+
+def test_membership():
+    assert "a" in "abc"
+
+
+def test_truthy():
+    assert [1]
+
+
+_ = pytest

--- a/tests/fixtures/python/TEST-STRUCT-001/pass_test_with_messages.py
+++ b/tests/fixtures/python/TEST-STRUCT-001/pass_test_with_messages.py
@@ -1,0 +1,21 @@
+"""Fixture for TEST-STRUCT-001: complex assertions all carry a failure message."""
+
+import pytest
+
+
+def test_chain_compare():
+    x = 5
+    assert 0 < x < 10, "x must be in (0, 10)"
+
+
+def test_bool_op():
+    a, b = 1, 2
+    assert a > 0 and b > 0, "both inputs must be positive"
+
+
+def test_negation():
+    items = [1, 2, 3]
+    assert not (len(items) == 0), "items must not be empty"
+
+
+_ = pytest


### PR DESCRIPTION
## Summary
- Adds fixture directories for TEST-STRUCT-001 (PytestAssertMessage) and TEST-SCALE-001 (PytestFixtureScope).
- TEST-STRUCT-001: three complex assertions (chain compare / bool op / negation) without messages vs the same three with messages vs simple assertions that don't need them. Filenames begin with `test_` so the rule's path filter activates.
- TEST-SCALE-001: two expensive fixtures (`database`, `client`) without scope vs the same two with `scope=` vs cheap fixtures whose names don't match the expensive set. Filenames keep the `conftest` substring after fixture-prefix stripping.

Part of #71.

## Test plan
- [x] `pytest tests/test_fixture_corpus.py -k TEST-S` — 6 passed
- [x] Full `pytest` — 252 passed
- [x] `gaudi-fixture-coverage` — both rules `OK`
- [x] `gaudi check src/` — unchanged dogfood baseline

🤖 Generated with [Claude Code](https://claude.com/claude-code)