### PR TITLE
Migrate DJ-SEC pack to fixture corpus

### DIFF
--- a/tests/fixtures/python/DJ-SEC-001/expected.json
+++ b/tests/fixtures/python/DJ-SEC-001/expected.json
@@ -1,0 +1,21 @@
+{
+  "rule_id": "DJ-SEC-001",
+  "description": "DjangoSecretKeyExposed -- SECRET_KEY must not be a string literal in settings",
+  "fixtures": {
+    "fail_settings_hardcoded_secret.py": {
+      "expected_findings": [
+        {
+          "severity": "error",
+          "line": 5,
+          "message_contains": "SECRET_KEY"
+        }
+      ]
+    },
+    "pass_settings_secret_from_env.py": {
+      "expected_findings": []
+    },
+    "pass_models.py": {
+      "expected_findings": []
+    }
+  }
+}

--- a/tests/fixtures/python/DJ-SEC-001/fail_settings_hardcoded_secret.py
+++ b/tests/fixtures/python/DJ-SEC-001/fail_settings_hardcoded_secret.py
@@ -1,0 +1,6 @@
+"""Fixture for DJ-SEC-001: SECRET_KEY assigned to a string literal in settings."""
+
+import django  # noqa: F401  -- activates the django library gate
+
+SECRET_KEY = "django-insecure-very-bad-do-not-use"
+DEBUG = False

--- a/tests/fixtures/python/DJ-SEC-001/pass_models.py
+++ b/tests/fixtures/python/DJ-SEC-001/pass_models.py
@@ -1,0 +1,9 @@
+"""Fixture for DJ-SEC-001: a literal SECRET_KEY in a non-settings module is out of scope.
+
+The rule keys on the file path containing 'settings'. This file isn't a settings
+module, so even a literal assignment must not fire.
+"""
+
+import django  # noqa: F401
+
+SECRET_KEY = "literal-but-not-a-settings-file"

--- a/tests/fixtures/python/DJ-SEC-001/pass_settings_secret_from_env.py
+++ b/tests/fixtures/python/DJ-SEC-001/pass_settings_secret_from_env.py
@@ -1,0 +1,8 @@
+"""Fixture for DJ-SEC-001: SECRET_KEY pulled from environment, not a literal."""
+
+import os
+
+import django  # noqa: F401  -- activates the django library gate
+
+SECRET_KEY = os.environ["DJANGO_SECRET_KEY"]
+DEBUG = False

--- a/tests/fixtures/python/DJ-SEC-002/expected.json
+++ b/tests/fixtures/python/DJ-SEC-002/expected.json
@@ -1,0 +1,21 @@
+{
+  "rule_id": "DJ-SEC-002",
+  "description": "DjangoDebugTrue -- DEBUG must not be the literal True in settings",
+  "fixtures": {
+    "fail_settings_debug_true.py": {
+      "expected_findings": [
+        {
+          "severity": "error",
+          "line": 8,
+          "message_contains": "DEBUG"
+        }
+      ]
+    },
+    "pass_settings_debug_false.py": {
+      "expected_findings": []
+    },
+    "pass_settings_debug_from_env.py": {
+      "expected_findings": []
+    }
+  }
+}

--- a/tests/fixtures/python/DJ-SEC-002/fail_settings_debug_true.py
+++ b/tests/fixtures/python/DJ-SEC-002/fail_settings_debug_true.py
@@ -1,0 +1,8 @@
+"""Fixture for DJ-SEC-002: DEBUG = True in a settings module."""
+
+import os
+
+import django  # noqa: F401  -- activates the django library gate
+
+SECRET_KEY = os.environ["DJANGO_SECRET_KEY"]
+DEBUG = True

--- a/tests/fixtures/python/DJ-SEC-002/pass_settings_debug_false.py
+++ b/tests/fixtures/python/DJ-SEC-002/pass_settings_debug_false.py
@@ -1,0 +1,8 @@
+"""Fixture for DJ-SEC-002: DEBUG = False is the production-safe setting."""
+
+import os
+
+import django  # noqa: F401  -- activates the django library gate
+
+SECRET_KEY = os.environ["DJANGO_SECRET_KEY"]
+DEBUG = False

--- a/tests/fixtures/python/DJ-SEC-002/pass_settings_debug_from_env.py
+++ b/tests/fixtures/python/DJ-SEC-002/pass_settings_debug_from_env.py
@@ -1,0 +1,8 @@
+"""Fixture for DJ-SEC-002: DEBUG resolved from configuration, not a True literal."""
+
+import os
+
+import django  # noqa: F401  -- activates the django library gate
+
+SECRET_KEY = os.environ["DJANGO_SECRET_KEY"]
+DEBUG = os.environ.get("DJANGO_DEBUG") == "1"


### PR DESCRIPTION
## Summary
- Adds fixture directories for DJ-SEC-001 (DjangoSecretKeyExposed) and DJ-SEC-002 (DjangoDebugTrue).
- DJ-SEC-001: literal `SECRET_KEY` in a settings module vs the env-resolved escape vs `pass_models.py` (a non-settings module where even a literal assignment must not fire — proves the rule keys on the path containing 'settings').
- DJ-SEC-002: `DEBUG = True` in settings vs `DEBUG = False` vs env-derived `DEBUG`, exercising literal-true detection.

### Near-miss caught

My first pass-fixture filename was `pass_non_settings_module.py`. After the fixture-prefix strip the runner produces `non_settings_module.py` — which still contains the substring `'settings'`, so the rule activated and the case failed loudly. Renamed to `pass_models.py` to genuinely defeat the path filter. Worth keeping in mind for any future fixture targeting a path-substring rule (`settings`, `conftest`, `test_`, `migrations`, ...): the stripped name is what the rule sees.

Part of #71.

## Test plan
- [x] `pytest tests/test_fixture_corpus.py -k DJ-SEC` — 6 passed
- [x] Full `pytest` — 258 passed
- [x] `gaudi-fixture-coverage` — DJ-SEC-001 and DJ-SEC-002 both `OK`
- [x] `gaudi check src/` — unchanged dogfood baseline

🤖 Generated with [Claude Code](https://claude.com/claude-code)