### PR TITLE
Migrate SCHEMA pack to fixture corpus

### DIFF
--- a/tests/fixtures/python/SCHEMA-001/expected.json
+++ b/tests/fixtures/python/SCHEMA-001/expected.json
@@ -1,0 +1,20 @@
+{
+  "rule_id": "SCHEMA-001",
+  "description": "MissingTimestamps -- models without created_at/updated_at",
+  "fixtures": {
+    "fail_no_timestamps.py": {
+      "expected_findings": [
+        {
+          "severity": "info",
+          "message_contains": "Order"
+        }
+      ]
+    },
+    "pass_with_timestamps.py": {
+      "expected_findings": []
+    },
+    "pass_through_table.py": {
+      "expected_findings": []
+    }
+  }
+}

--- a/tests/fixtures/python/SCHEMA-001/fail_no_timestamps.py
+++ b/tests/fixtures/python/SCHEMA-001/fail_no_timestamps.py
@@ -1,0 +1,8 @@
+"""Fixture for SCHEMA-001: a model with no created/updated timestamp columns."""
+
+from django.db import models
+
+
+class Order(models.Model):
+    customer = models.CharField(max_length=200)
+    amount = models.IntegerField()

--- a/tests/fixtures/python/SCHEMA-001/pass_through_table.py
+++ b/tests/fixtures/python/SCHEMA-001/pass_through_table.py
@@ -1,0 +1,7 @@
+"""Fixture for SCHEMA-001: through tables (< 2 columns) are exempt."""
+
+from django.db import models
+
+
+class OrderTag(models.Model):
+    order = models.ForeignKey("Order", on_delete=models.CASCADE)

--- a/tests/fixtures/python/SCHEMA-001/pass_with_timestamps.py
+++ b/tests/fixtures/python/SCHEMA-001/pass_with_timestamps.py
@@ -1,0 +1,10 @@
+"""Fixture for SCHEMA-001: a model with created_at and updated_at columns."""
+
+from django.db import models
+
+
+class Order(models.Model):
+    customer = models.CharField(max_length=200)
+    amount = models.IntegerField()
+    created_at = models.DateTimeField(auto_now_add=True)
+    updated_at = models.DateTimeField(auto_now=True)

--- a/tests/fixtures/python/SCHEMA-002/expected.json
+++ b/tests/fixtures/python/SCHEMA-002/expected.json
@@ -1,0 +1,20 @@
+{
+  "rule_id": "SCHEMA-002",
+  "description": "ColumnSprawl -- too many nullable columns suggests the table covers multiple concerns",
+  "fixtures": {
+    "fail_many_nullable.py": {
+      "expected_findings": [
+        {
+          "severity": "warn",
+          "message_contains": "nullable columns"
+        }
+      ]
+    },
+    "pass_few_nullable.py": {
+      "expected_findings": []
+    },
+    "pass_below_min_columns.py": {
+      "expected_findings": []
+    }
+  }
+}

--- a/tests/fixtures/python/SCHEMA-002/fail_many_nullable.py
+++ b/tests/fixtures/python/SCHEMA-002/fail_many_nullable.py
@@ -1,0 +1,12 @@
+"""Fixture for SCHEMA-002: 6-column model with 4 nullable columns (ratio 0.67)."""
+
+from django.db import models
+
+
+class Customer(models.Model):
+    name = models.CharField(max_length=200)
+    email = models.CharField(max_length=200)
+    phone = models.CharField(max_length=50, null=True)
+    fax = models.CharField(max_length=50, null=True)
+    secondary_email = models.CharField(max_length=200, null=True)
+    notes = models.CharField(max_length=2000, null=True)

--- a/tests/fixtures/python/SCHEMA-002/pass_below_min_columns.py
+++ b/tests/fixtures/python/SCHEMA-002/pass_below_min_columns.py
@@ -1,0 +1,11 @@
+"""Fixture for SCHEMA-002: a 5-column model is below MIN_COLUMNS, exempt regardless of ratio."""
+
+from django.db import models
+
+
+class Customer(models.Model):
+    name = models.CharField(max_length=200)
+    email = models.CharField(max_length=200, null=True)
+    phone = models.CharField(max_length=50, null=True)
+    fax = models.CharField(max_length=50, null=True)
+    notes = models.CharField(max_length=2000, null=True)

--- a/tests/fixtures/python/SCHEMA-002/pass_few_nullable.py
+++ b/tests/fixtures/python/SCHEMA-002/pass_few_nullable.py
@@ -1,0 +1,12 @@
+"""Fixture for SCHEMA-002: 6-column model with only 1 nullable column."""
+
+from django.db import models
+
+
+class Customer(models.Model):
+    name = models.CharField(max_length=200)
+    email = models.CharField(max_length=200)
+    phone = models.CharField(max_length=50)
+    address = models.CharField(max_length=500)
+    city = models.CharField(max_length=100)
+    notes = models.CharField(max_length=2000, null=True)

--- a/tests/fixtures/python/SCHEMA-003/expected.json
+++ b/tests/fixtures/python/SCHEMA-003/expected.json
@@ -1,0 +1,31 @@
+{
+  "rule_id": "SCHEMA-003",
+  "description": "NoStringLengthLimit -- TextField on a short-name column should be a CharField",
+  "fixtures": {
+    "fail_textfield_short_names.py": {
+      "expected_findings": [
+        {
+          "severity": "info",
+          "line": 7,
+          "message_contains": "name"
+        },
+        {
+          "severity": "info",
+          "line": 8,
+          "message_contains": "sku"
+        },
+        {
+          "severity": "info",
+          "line": 9,
+          "message_contains": "status"
+        }
+      ]
+    },
+    "pass_charfield_short_names.py": {
+      "expected_findings": []
+    },
+    "pass_textfield_long_form.py": {
+      "expected_findings": []
+    }
+  }
+}

--- a/tests/fixtures/python/SCHEMA-003/fail_textfield_short_names.py
+++ b/tests/fixtures/python/SCHEMA-003/fail_textfield_short_names.py
@@ -1,0 +1,9 @@
+"""Fixture for SCHEMA-003: TextField used for fields with short-name patterns."""
+
+from django.db import models
+
+
+class Item(models.Model):
+    name = models.TextField()
+    sku = models.TextField()
+    status = models.TextField()

--- a/tests/fixtures/python/SCHEMA-003/pass_charfield_short_names.py
+++ b/tests/fixtures/python/SCHEMA-003/pass_charfield_short_names.py
@@ -1,0 +1,9 @@
+"""Fixture for SCHEMA-003: short-name fields use CharField with max_length, the canonical escape."""
+
+from django.db import models
+
+
+class Item(models.Model):
+    name = models.CharField(max_length=200)
+    sku = models.CharField(max_length=64)
+    status = models.CharField(max_length=32)

--- a/tests/fixtures/python/SCHEMA-003/pass_textfield_long_form.py
+++ b/tests/fixtures/python/SCHEMA-003/pass_textfield_long_form.py
@@ -1,0 +1,9 @@
+"""Fixture for SCHEMA-003: TextField for body/description columns is fine -- no short-name pattern."""
+
+from django.db import models
+
+
+class Article(models.Model):
+    body = models.TextField()
+    description = models.TextField()
+    notes = models.TextField()

--- a/tests/test_python_pack.py
+++ b/tests/test_python_pack.py
@@ -85,16 +85,6 @@ class TestRules:
         assert len(arch_002) >= 1
         assert any("Donor" in f.message for f in arch_002)
 
-    def test_schema_001_missing_timestamps(self, findings):
-        """Should flag models without timestamp fields."""
-        schema_001 = [f for f in findings if f.code == "SCHEMA-001"]
-        assert len(schema_001) >= 1
-
-    def test_schema_003_textfield_for_names(self, findings):
-        """Should flag TextField used for name/title fields."""
-        schema_003 = [f for f in findings if f.code == "SCHEMA-003"]
-        assert len(schema_003) >= 1
-
     def test_struct_001_too_many_models(self, findings):
         """Should flag single file with 9 models."""
         struct_001 = [f for f in findings if f.code == "STRUCT-001"]


### PR DESCRIPTION
## Summary
- Adds fixture directories for SCHEMA-001 (MissingTimestamps), SCHEMA-002 (ColumnSprawl), and SCHEMA-003 (NoStringLengthLimit).
- SCHEMA-001: 2-column model without timestamps vs same model with `created_at`/`updated_at` vs a 1-column through table (below the rule's `< 2` exemption).
- SCHEMA-002: 6-column model with 4 nullable (ratio 0.67) vs 6-column with 1 nullable vs 5-column model below `MIN_COLUMNS = 6` (proves the threshold gate).
- SCHEMA-003: TextField on `name`/`sku`/`status` fields vs CharField with `max_length` vs TextField on `body`/`description`/`notes` (no short-name pattern).
- Drops the now-redundant SCHEMA-001 and SCHEMA-003 ad-hoc assertions from `tests/test_python_pack.py`.

Part of #71.

## Test plan
- [x] `pytest tests/test_fixture_corpus.py -k SCHEMA-00` — 9 passed
- [x] Full `pytest` — 265 passed
- [x] `gaudi-fixture-coverage` — SCHEMA-001..003 all `OK`
- [x] `gaudi check src/` — unchanged dogfood baseline

🤖 Generated with [Claude Code](https://claude.com/claude-code)