### PR TITLE
Flip fixture coverage to strict mode

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,6 +69,5 @@ jobs:
       - name: Test with coverage
         run: pytest --tb=short --cov=gaudi --cov-report=term-missing --cov-fail-under=60
 
-      - name: Fixture corpus coverage (warn-mode)
-        run: gaudi-fixture-coverage
-        continue-on-error: true
+      - name: Fixture corpus coverage
+        run: gaudi-fixture-coverage --strict

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -103,9 +103,8 @@ Show people how to use Gaudí in their pipelines:
 - New rules use the per-rule fixture corpus under `tests/fixtures/python/<RULE-ID>/`
   with an `expected.json` rubric (see [docs/testing-fixtures.md](docs/testing-fixtures.md))
 - Run the full suite with `pytest`
-- Run `gaudi-fixture-coverage` to see which rules still lack a fixture
-  directory (CI runs this in warn-mode today and will become strict once the
-  migration backlog is drained)
+- Run `gaudi-fixture-coverage --strict` — every rule must have a complete
+  fixture directory; CI enforces this
 - CI enforces a minimum coverage threshold
 
 ## Pull Request Process


### PR DESCRIPTION
## Summary

Closes #71. Every rule in the Python pack (105 total) now has a complete fixture directory; the migration backlog is drained.

This PR removes the warn-mode escape hatch:
- \`.github/workflows/ci.yml\`: replaces \`gaudi-fixture-coverage\` + \`continue-on-error: true\` with \`gaudi-fixture-coverage --strict\`
- \`CLAUDE.md\`: documents that CI is strict, no warn-mode, no escape hatch
- \`CONTRIBUTING.md\`: same

## Verification

- Live PythonPack discovery: 105 rules
- \`tests/fixtures/python/\`: 105 directories
- \`gaudi-fixture-coverage --strict\` exits 0 locally
- 1:1 set diff between loaded rules and fixture directories — no orphans either way
- Full \`pytest\`: 375 passed
- Dogfood baseline unchanged (104 warnings, 9 infos)

## Test plan

- [x] Local strict run exits 0
- [ ] CI strict run passes (this PR is the proof)

🤖 Generated with [Claude Code](https://claude.com/claude-code)