### PR TITLE
chore: bump version to 0.1.1 for first PyPI release

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "gaudi-linter"
-version = "0.1.0"
+version = "0.1.1"
 description = "Not just structurally sound. Beautiful. An architecture linter for Python projects."
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
## Summary

One-line version bump from 0.1.0 to 0.1.1. The existing v0.1.0 tag was created at project init and points at the initial commit, which predates the publish workflow, the principles doctrine, and ~140 rules. Rather than force-move that tag and delete its GitHub release, the first PyPI release ships as 0.1.1.

## Test plan

- [x] Build verified locally before bump (482 tests, clean wheel, gaudi --version works)
- [ ] CI green