### PR TITLE
docs(philosophy): axiom sheets for eight architectural schools

### DIFF
--- a/docs/philosophy/README.md
+++ b/docs/philosophy/README.md
@@ -1,0 +1,181 @@
+# Architectural Philosophies
+
+> *Beauty is not philosophy-neutral. A Gothic cathedral and a Japanese tea
+> house both possess integritas, proportio, and claritas — but a rule that
+> says "beauty requires flying buttresses" would fail to recognize the tea
+> house. The transcendentals are universal; their material expression is not.*
+
+---
+
+## Purpose
+
+Gaudí's editorial constitution — [docs/principles.md](../principles.md) — is
+built around three pillars (Truthfulness, Economy, Cost-honesty) that every
+rule must appeal to. Those pillars are deliberately school-agnostic: they
+describe beauty in code without committing to a particular style of
+beautiful code.
+
+But most architectural rules are not school-agnostic. A rule that says
+"extract an interface for any class with more than one caller" is beautiful
+under Classical assumptions and heretical under Pragmatic ones. A rule that
+says "prefer composition over inheritance" is trivially true for Functional
+programmers and an active anti-pattern under Data-Oriented layouts where
+inheritance would scatter related fields across the heap.
+
+The axiom sheets in this directory name the philosophies under which
+Gaudí's rules make sense. Each sheet is a falsifiable description of one
+school — its prime axiom, what it rejects, its canonical sources, its
+catechism, the shape of rules it generates, its degenerate case, the
+temptations an exemplar must refuse, and a ten-item rubric for recognizing
+a faithful fixture of that school.
+
+These sheets are the scaffolding for three downstream pieces of work:
+
+1. **The rule audit** — every rule in [docs/rule-registry.md](../rule-registry.md)
+   gets tagged with a philosophy scope (`universal` or a specific school),
+   appealing to the axiom sheet that makes the tag defensible.
+2. **The canonical task** — a single domain problem (order processing
+   pipeline) implemented eight ways, once per school, each implementation
+   scored against the rubric in its school's axiom sheet.
+3. **The engine change** (deferred) — the `Rule.philosophy_scope` field
+   and `[philosophy].school` config key, which together let Gaudí filter
+   its catalog to the rules that are honest under the project's declared
+   school.
+
+---
+
+## The Eight Schools
+
+| School | Prime axiom | Axiom sheet |
+|---|---|---|
+| **Classical / Structural** | Order is the precondition for beauty. Structure reveals intent. | [classical.md](classical.md) |
+| **Pragmatic / Evolutionary** | Design is discovered, not declared. Refactor toward the shape the problem is asking for. | [pragmatic.md](pragmatic.md) |
+| **Functional / Algebraic** | Computation is transformation. Values flow; state does not hide. | [functional.md](functional.md) |
+| **Unix / Minimalist** | Do one thing well. Compose via text. | [unix.md](unix.md) |
+| **Resilience-First / Distributed Systems** | Failure is the design input, not the edge case. | [resilient.md](resilient.md) |
+| **Data-Oriented** | The data layout is the architecture. Cache lines are the unit of decision. | [data-oriented.md](data-oriented.md) |
+| **Convention-Over-Configuration** | The framework is the architecture. | [convention.md](convention.md) |
+| **Event-Sourced / CQRS** | The log of events is the state. Current state is a projection, not a source. | [event-sourced.md](event-sourced.md) |
+
+---
+
+## Why Eight, and Not Seven or Nine
+
+The RFC that opened this work proposed seven schools. Event-Sourced was
+added after a second-pass review because it meets the only test that
+matters for admitting a new school to this catalog:
+
+> **A school earns its place when it generates rules that contradict
+> rules from existing schools.** If a candidate only *adds* rules that
+> stack with any existing school without contradicting any of them, it
+> is a cross-cutting concern, not a school.
+
+Event-Sourced contradicts Classical DDD's default of in-place aggregate
+mutation, Pragmatic's YAGNI treatment of event-type extraction, and
+CRUD-as-default under any school — while being genuinely distinct from
+Functional (which forbids mutation everywhere, not just on aggregates)
+and Resilient (which cares about recovery, not about intent preservation).
+It passes the test.
+
+Candidates that were considered and rejected as full schools:
+
+- **Type-Driven / Proof-Carrying** (Idris, Agda, heavy Haskell). The
+  rules it generates — `no Any`, `no partial functions`, "make illegal
+  states unrepresentable" — mostly *stack* with Functional without
+  contradicting it. Treated as a sub-scope of Functional, not a separate
+  school.
+- **Actor / Message-Passing** (Erlang, Akka). Already subsumed by
+  Resilience-First, whose catechism leans heavily on Armstrong's thesis.
+- **Literate Programming** (Knuth). A cross-cutting concern that stacks
+  with every school without contradicting any. Captured in Principle #11
+  of the universal core, not in a dedicated sheet.
+- **Live / Image-Based** (Smalltalk, Lisp REPL-driven). A real distinct
+  axiom, but too niche for a Python linter to serve honestly at this
+  stage.
+
+If a future contributor argues that a ninth school deserves inclusion,
+the argument must pass the contradiction test: name at least one rule
+the school would enforce that no existing school's rule catalog already
+contains, and explain why that rule is correct under the new school's
+axiom and incorrect under every existing one's.
+
+---
+
+## The Sheet Format
+
+Every axiom sheet follows the same eight-section structure:
+
+1. **Prime axiom** — one sentence. The single claim from which everything
+   else descends.
+2. **The rejected alternative** — what the school refuses. A school is
+   defined as much by its refusals as by its endorsements.
+3. **Canonical citations** — published, citable sources that ground the
+   school. Required by [Rule Acceptance Test #1](../principles.md).
+4. **The catechism** — five to seven derived commitments in plain English.
+5. **Rule shape** — the *kinds* of rules this axiom generates: forbid,
+   require, prefer.
+6. **The degenerate case** — the failure mode that looks like extreme
+   faithfulness but is actually the axiom's inversion.
+7. **Exemplar temptation** — the shortcuts a reference implementation
+   must refuse to stay faithful, and the opposite shortcuts it must also
+   refuse to avoid parody.
+8. **Rubric** — a ten-item checklist for scoring whether a given fixture
+   is actually an exemplar of the school.
+
+The rubric at the end of each sheet is the operational piece. It lets a
+reviewer say "this exemplar fails check #4" instead of "this feels off,"
+and it lets the later canonical-task exemplars be scored against a
+defensible standard rather than against taste.
+
+---
+
+## Relationship to `docs/principles.md`
+
+The fourteen principles in [docs/principles.md](../principles.md) are the
+universal core — the claims beautiful code must satisfy under *any*
+philosophy. The eight schools are the material expressions — the specific,
+contradictory, school-bound ways that beauty shows up in real codebases.
+
+The relationship is Thomistic by design:
+
+- The Three Pillars (Truthfulness, Economy, Cost-honesty) are the
+  transcendentals.
+- The fourteen principles are the universal derived commitments.
+- The eight schools are the material expressions.
+- A rule is *universal* if it descends directly from the principles.
+- A rule is *school-bound* if it descends from the axioms of one school
+  and cannot be defended against the axioms of another.
+
+When Phase 0b (the rule audit) lands, every rule in
+[docs/rule-registry.md](../rule-registry.md) will be tagged with its
+philosophy scope. Most rules will come back `universal` — they descend
+from the pillars and hold in every school. A smaller number will come
+back tagged with one or more specific schools, because they depend on
+axioms that not every school accepts.
+
+---
+
+## What Is Not Here Yet
+
+- **The rule audit column** — Phase 0b. Every rule gets tagged; the
+  column lives in [docs/rule-registry.md](../rule-registry.md).
+- **The canonical task statement** — Phase 0c. The order-processing
+  problem, acceptance criteria, and interface for the eight
+  implementations.
+- **The reference exemplars** — Phase 0d and beyond. Eight working
+  implementations of the canonical task, one per school, each scoring
+  ten-out-of-ten on its school's rubric.
+- **The engine change** — deferred until the audit's outcome tells us
+  how much machinery the catalog actually needs.
+
+---
+
+## See also
+
+- [docs/principles.md](../principles.md) — The editorial constitution
+  and universal core.
+- [docs/rule-registry.md](../rule-registry.md) — The rule catalog,
+  which will gain a philosophy-scope column during Phase 0b.
+- [docs/testing-fixtures.md](../testing-fixtures.md) — The fixture-first
+  TDD rubric; the philosophy exemplars extend this discipline to the
+  meta-level.

--- a/docs/philosophy/classical.md
+++ b/docs/philosophy/classical.md
@@ -1,0 +1,205 @@
+# Classical / Structural — Axiom Sheet
+
+> *Order is the precondition for beauty. Structure reveals intent.*
+
+**Status:** Draft template (the first of eight). Sheet format is under review — if
+this shape is accepted, the remaining seven schools will be written against it.
+
+---
+
+## 1. Prime axiom
+
+> **Software is beautiful when its structure reveals its intent, and that
+> structure is the product of disciplined, intentional decomposition.**
+
+Order is not decoration layered on top of working code. Order *is* the code's
+honesty about what it does. A system whose layout tells you nothing about its
+behavior is a system that has refused to be understood, and that refusal is a
+lie about the work being done.
+
+## 2. The rejected alternative
+
+Classical architecture is defined as much by what it refuses as by what it
+builds. It refuses:
+
+- **Emergent chaos as a virtue.** "The design will appear if we keep writing"
+  is, to a Classical architect, an abdication of design.
+- **Duplication-as-humility.** The Pragmatic school treats early duplication as
+  epistemic honesty ("we don't know the shape yet"). Classical treats persistent
+  duplication as a structural defect — the shape was always there, we just
+  refused to see it.
+- **Implicit contracts.** If a module can be called with any type, it has
+  promised nothing. A promise that cannot be broken cannot be trusted.
+- **God objects and reach-through coupling.** A class that knows everything
+  about everything has boundaries of convenience, not of meaning.
+- **Service locators and global registries.** Dependencies that are fetched
+  rather than declared are dependencies that hide. See Principle #5.
+- **Framework-as-architecture.** The framework is a detail that should be
+  swappable; the domain is the kernel that persists. (This is the hard-line
+  conflict with the Convention school.)
+
+## 3. Canonical citations
+
+- Martin, Robert C. *Clean Architecture: A Craftsman's Guide to Software
+  Structure and Design.* Prentice Hall, 2017. — The dependency rule, component
+  cohesion principles (REP/CCP/CRP), component coupling principles (ADP/SDP/SAP).
+- Martin, Robert C. *Agile Software Development: Principles, Patterns, and
+  Practices.* Prentice Hall, 2002. — The original SOLID formulation.
+- Evans, Eric. *Domain-Driven Design: Tackling Complexity in the Heart of
+  Software.* Addison-Wesley, 2003. — Bounded contexts, ubiquitous language,
+  aggregates, the domain as kernel.
+- Gamma, Helm, Johnson, Vlissides. *Design Patterns: Elements of Reusable
+  Object-Oriented Software.* Addison-Wesley, 1994. — Named patterns as shared
+  architectural vocabulary.
+- Fowler, Martin. *Patterns of Enterprise Application Architecture.*
+  Addison-Wesley, 2002. — Repository, Unit of Work, Service Layer, Data Mapper.
+- Aquinas, Thomas. *Summa Theologica* I, q. 39, a. 8. — *Integritas, proportio,
+  claritas* as the constitution of beauty in a composed thing. Gaudí's own
+  foundational text.
+
+## 4. The catechism
+
+Seven derived commitments. A Classical implementation demonstrates all seven,
+or it is not Classical — it is pastiche.
+
+1. **Dependencies flow inward, always.** Stable, abstract code is the core;
+   volatile, concrete detail is the rim. Infrastructure depends on the domain,
+   never the reverse. (Principle #9.)
+2. **Every boundary is named and typed.** A layer has a face (its interface)
+   and a back (its implementation). Crossing a boundary means calling through
+   the face. (Principle #10.)
+3. **Single responsibility at every scale.** A function does one thing. A class
+   owns one concept. A module serves one concern. A service provides one
+   capability. The scale changes; the rule does not.
+4. **Composition is explicit.** Objects receive their collaborators via their
+   constructor. No service locators, no ambient context, no framework magic
+   reaching into private state. (Principle #5.)
+5. **Named patterns are vocabulary, not decoration.** A "Repository" means the
+   same thing to every reader on the team. Patterns earn their names by hiding
+   nameable complexity (Principle #7), not by matching a diagram in a book.
+6. **The domain is the kernel, and it has no dependencies.** The pure domain
+   model knows nothing about HTTP, SQL, queues, or files. It is the part of
+   the system that would survive a total infrastructure rewrite.
+7. **Structure is documentation that cannot drift.** Reading the top-level
+   package layout tells you what the system does. The compiler reads the same
+   layout you do, so the layout cannot quietly lie. (Principle #1.)
+
+## 5. Rule shape this axiom generates
+
+This axiom produces rules of three kinds:
+
+- **Forbid** — circular imports, God objects, domain-imports-infrastructure,
+  reach-through coupling, layer-skipping, global mutable state, service
+  locators, bare `except`, hidden dependencies on the environment.
+- **Require** — explicit interfaces at named boundaries, constructor injection,
+  single-responsibility units, typed public APIs, bounded contexts when the
+  domain has distinct meanings.
+- **Prefer** — named patterns over ad-hoc structure, composition over
+  inheritance, immutable value objects for domain concepts, small focused
+  classes over large flexible ones.
+
+Most of Gaudí's current `ARCH`, `DEP`, and `STRUCT` rules derive from this
+axiom. A classification check: if removing the rule would make it harder to
+state the dependency rule, the layering rule, or the single-responsibility
+rule with a straight face, the rule descends from this axiom and belongs —
+at minimum — in Classical's scope.
+
+## 6. The degenerate case
+
+Every axiom has a failure mode that looks like extreme faithfulness but is
+actually its opposite. For Classical, that failure mode is **pattern worship**.
+
+- Seventeen classes for a CSV parser because a book once drew a pipeline.
+- Factories that build factories that build the thing that was going to be
+  instantiated in one line.
+- Interfaces extracted for types that have exactly one implementation and
+  will never have a second.
+- Ports-and-adapters scaffolding around a 40-line script that reads one file
+  and prints a number.
+- A `DomainEventPublisherFactoryProviderStrategy`.
+
+The test for pattern worship is Principle #7: *every layer must earn its
+existence in clarity gained.* A layer that hides nothing you can name in a
+sentence is decoration. Classical architecture, practiced faithfully,
+contains *fewer* classes than its caricature suggests, not more. The
+discipline is in what structure you refuse to add, not only in what structure
+you demand.
+
+The Cathedral of Abstractions is the opposite of a cathedral — it is a
+scaffold that forgot it was supposed to be taken down once the arch could
+bear its own weight.
+
+## 7. Exemplar temptation
+
+When writing the Classical implementation of the canonical task, the exemplar
+must navigate two opposite temptations:
+
+- **The procedural shortcut.** At some point in the order-processing pipeline,
+  it will be *shorter* to write one 40-line function that validates, prices,
+  reserves inventory, and sends the notification inline. The Classical
+  exemplar must refuse this shortcut — and the refusal is the *point*, not
+  a bug. The exemplar demonstrates that separation of concerns is worth the
+  line count in exchange for the reader knowing where each responsibility lives.
+- **The pattern-worship shortcut.** It will also be *more impressive* to
+  introduce a `PricingStrategyFactory`, a `NotificationDispatcherRegistry`,
+  and an `InventoryReservationPolicyProvider`. The Classical exemplar must
+  refuse this temptation too, because pattern worship is the degenerate case
+  of the axiom, and an exemplar that surrenders to the degenerate case
+  teaches the wrong thing.
+
+The faithful Classical exemplar is the one that adds a class or an interface
+if and only if the reader would be *less* confused after its introduction
+than before. Every abstraction earns a sentence in its name. Every name
+survives the Principle #3 test.
+
+## 8. Rubric — how to recognize a faithful Classical fixture
+
+A fixture exemplifies Classical architecture if and only if *all* of the
+following are true. Any unchecked box means the fixture is not yet
+Classical-exemplary and must be revised before it is used as a reference
+implementation or a rule-scope test.
+
+- [ ] **Dependency direction is diagrammable and strictly inward.** You can
+      draw the module graph on a whiteboard and every arrow points toward the
+      domain kernel. No arrow points outward.
+- [ ] **At least one boundary is crossed via an interface**, and the interface
+      hides complexity that can be stated in one sentence.
+- [ ] **At least one named pattern is used meaningfully** — Repository, Factory,
+      Strategy, Service Layer, Unit of Work, etc. — and the pattern is used
+      because the reader benefits from the shared vocabulary, not because the
+      exemplar wanted to showcase it.
+- [ ] **The domain model has zero infrastructure imports.** No HTTP, SQL, ORM,
+      logging framework, or environment access inside the domain package.
+- [ ] **Dependencies are passed, not fetched.** Constructors receive
+      collaborators; no service locator, no module-level singleton, no
+      `os.getenv()` anywhere outside a composition root.
+- [ ] **Every class has a responsibility statable in one sentence** without the
+      word "and." If the sentence needs "and," the responsibility is two.
+- [ ] **The top-level package layout readably describes the system.** A
+      first-time reader, shown only the directory tree, can state the system's
+      purpose and roughly identify where each concern lives.
+- [ ] **It refuses the procedural shortcut** in at least one place where the
+      shortcut would have saved lines but lost clarity.
+- [ ] **It refuses the pattern-worship shortcut** in at least one place where
+      a plausible pattern would have been available but was deliberately
+      omitted because it would hide nothing.
+- [ ] **All public APIs are type-annotated.** The contract is readable from
+      signatures alone.
+
+A fixture that passes all ten checks is a faithful Classical exemplar. A
+fixture that passes eight or nine is a draft. A fixture that passes seven or
+fewer is pastiche and should be rewritten, not patched.
+
+---
+
+## See also
+
+- [docs/principles.md](../principles.md) — Gaudí's editorial constitution. The
+  Classical axiom is the school closest to these principles, but not identical
+  to them; the principles are the universal core, Classical is one material
+  expression of the core.
+- [docs/rule-registry.md](../rule-registry.md) — The rule catalog and its
+  provenance column (to be extended with a `philosophy_scope` column during
+  Phase 0b).
+- `docs/philosophy/README.md` — Index of all eight axiom sheets (to be written
+  once the template is accepted).

--- a/docs/philosophy/convention.md
+++ b/docs/philosophy/convention.md
@@ -1,0 +1,245 @@
+# Convention-Over-Configuration — Axiom Sheet
+
+> *The framework is the architecture. Conformance requires no justification;
+> deviation requires explicit defense.*
+
+---
+
+## 1. Prime axiom
+
+> **A well-chosen framework encodes thousands of hours of design work by
+> people who thought about these problems longer than any individual team
+> will. Adopting the framework's conventions wholesale is the single
+> highest-leverage architectural decision a project can make — and fighting
+> them is the single most expensive mistake.**
+
+The Convention school treats framework conformance as a structural asset.
+Every decision the framework has already made is a decision the team does
+not have to make, defend, document, test, or maintain. The cost of "just
+our way" is paid not only in the initial implementation but in every new
+hire's onboarding, every library that assumes the framework's conventions,
+every Stack Overflow answer that works out of the box, and every debugging
+session that does not require reading custom code. A team that conforms
+inherits a vast, invisible infrastructure of shared assumptions; a team
+that deviates pays to rebuild it, usually badly.
+
+## 2. The rejected alternative
+
+Convention architecture refuses:
+
+- **Bespoke solutions for problems the framework already solves.** If
+  Django ships a form validator, writing your own is a choice that must
+  be defended in blood, not in preference.
+- **Non-standard project layouts.** The default directory tree is
+  load-bearing — every book, tutorial, generator, and third-party
+  library assumes it. Moving files to match personal taste breaks the
+  invisible contract with the ecosystem.
+- **Custom abstractions layered on top of framework abstractions.** A
+  "service layer" that wraps ActiveRecord or Django's ORM without adding
+  real behavior loses the framework's benefits (admin integration,
+  migrations, querysets) and adds none of its own.
+- **"Not invented here" pride.** The framework has solved authentication,
+  routing, templating, migrations, admin panels, and form handling. Each
+  reimplementation is a vote of no confidence in engineers with more
+  context than the current team.
+- **Fighting the framework.** When a problem requires going against the
+  framework's grain, the right answer is usually "pick a different
+  framework" or "this is not a framework problem" — rarely "patch
+  around the framework's assumptions."
+- **Framework upgrades treated as operational work.** Upgrading Django
+  from 4.x to 5.x is architectural work. It is how you get the next
+  thousand hours of thought, free.
+- **Convention followed without understanding.** The failure mode of
+  this school is cargo cult; the remedy is understanding *why* the
+  convention exists, not refusing the convention because others don't.
+
+## 3. Canonical citations
+
+- Heinemeier Hansson, David. "The Rails Doctrine." rubyonrails.org, 2016.
+  — The explicit articulation of convention over configuration,
+  omakase, and the other pillars of the Rails philosophy. The clearest
+  single-source statement of the school.
+- Django Software Foundation. "Design philosophies." Django
+  documentation. — The Django project's own statement of its
+  assumptions and why they take the shape they do.
+- Thomas, Dave & Heinemeier Hansson, David. *Agile Web Development with
+  Rails.* Pragmatic Bookshelf, first published 2005, many editions. —
+  The canonical tutorial that encodes "the Rails Way" as a teachable
+  discipline.
+- Pivotal. *Spring Boot Reference Documentation*, auto-configuration
+  chapters. — The Java ecosystem's mature implementation of the same
+  ideas: sensible defaults, opinionated starter poms, minimal
+  configuration for common cases.
+- Stenberg, Daniel. *The Laravel Philosophy.* laravel.com documentation.
+  — The PHP ecosystem's version, showing that the idea generalizes
+  across language traditions.
+- Fowler, Martin. "InversionOfControl" and "DependencyInjection."
+  martinfowler.com, 2004. — The theory behind container-driven design
+  and why frameworks can be called "opinionated" in a technical rather
+  than aesthetic sense.
+
+## 4. The catechism
+
+Seven derived commitments:
+
+1. **Follow the framework's prescribed patterns.** The framework authors
+   have thought about this problem longer than you have. Start from the
+   blessed path; deviate only under pressure.
+2. **Default layouts are load-bearing.** The location of a file is part
+   of its contract with the rest of the ecosystem. `models.py` belongs
+   where Django put it. `app/controllers` belongs where Rails put it.
+3. **Convention eliminates decisions.** A decision not made is a decision
+   that cannot go wrong. The shared vocabulary the convention provides
+   is the team's most valuable architectural asset.
+4. **Generators and scaffolds are the blessed starting point.** They
+   encode the framework's intended way. Begin from them, then customize;
+   do not begin from empty files and fight your way toward the
+   convention by accident.
+5. **Deviate explicitly.** Every deviation from convention earns a
+   comment naming the specific pressure that required it, so the next
+   reader knows this was a decision and not an accident.
+6. **Integrate, do not wrap.** Use the framework's facilities directly.
+   A wrapper around the ORM that hides the ORM loses the ORM's
+   ecosystem (admin, migrations, third-party extensions) and gains only
+   the wrapper's maintenance cost.
+7. **The framework version is the architecture version.** Upgrading the
+   framework is how the project inherits the next iteration of
+   architectural thought. Treat upgrades as first-class work.
+
+## 5. Rule shape this axiom generates
+
+- **Forbid** — custom implementations of framework-provided features,
+  non-standard directory layouts, shadow ORMs layered over the
+  framework's ORM, service-layer wrappers that hide models without
+  adding behavior, bypassing framework middleware with ad-hoc request
+  handling, hand-rolled authentication when the framework ships it,
+  direct SQL where an ORM method would serve.
+- **Require** — framework-idiomatic file locations, framework-provided
+  facilities for routing, authentication, templating, migrations, and
+  form validation; migration files for every schema change; standard
+  test helpers.
+- **Prefer** — generated scaffolding as the starting point, framework
+  signals/hooks for cross-cutting concerns, framework admin for
+  operational tooling, framework-native test fixtures.
+
+Under Gaudí's rule catalog, this axiom is the native home of the `DJ-*`
+(Django) family. The Convention school is the one for which Gaudí must
+be *gentlest* about non-framework patterns, because what looks like a
+"God object" or an "over-eager model" in Classical eyes is the blessed
+ActiveRecord pattern here — not a defect, but the framework working as
+designed.
+
+## 6. The degenerate case
+
+Every axiom has a failure mode. For Convention, the failure mode is
+**cargo cult**.
+
+- Convention followed without understanding, producing N+1 query
+  disasters that Django's ORM makes easy to write and hard to notice.
+  The developer did what the tutorial did; the tutorial did not show
+  the `select_related` call because it was a tutorial, not a
+  production system.
+- Fat models, fat controllers, or fat serializers — places where the
+  convention ran out and nobody extended the pattern, so the code kept
+  piling into the last file that still had room.
+- Framework lock-in so deep that a framework bug becomes an existential
+  business problem, because the team built no abstraction layer
+  anywhere and now cannot even isolate the bug from the rest of the
+  system.
+- Treating the framework as infallible. Every framework has genuine
+  mistakes; Convention faithfulness is not "never question the
+  framework," it is "question with humility, and understand *why*
+  before you deviate."
+- Tutorials and Stack Overflow as architecture. The convention
+  encourages reaching for prior art, but prior art is not always
+  relevant, and the team that copies without checking inherits the
+  original's mistakes.
+- A codebase that cannot answer "why do we do it this way?" with
+  anything more than "it's the Rails Way." The correct answer is
+  "because the Rails Way is optimizing for X, which is what we need
+  here too." If the team cannot give that answer, they are not
+  following Convention — they are obeying it.
+
+The test for cargo cult: ask a developer to explain why a convention
+exists. A faithful Convention practitioner can name the problem the
+convention was solving. A cargo-cultist can only name the convention.
+
+## 7. Exemplar temptation
+
+When writing the Convention implementation of the canonical task, the
+exemplar must navigate two opposite temptations:
+
+- **The clean-architecture temptation.** It will be tempting to extract
+  an "OrderService" layer between the view and the model, "for
+  testability" or "to keep the model thin." The Convention exemplar
+  must refuse — Django's model layer is *supposed* to hold this logic,
+  the model's manager methods are *supposed* to encapsulate queries,
+  and the blessed pattern is fat-model, skinny-view. Extracting the
+  service layer means abandoning the convention without a concrete
+  reason, and abandoning the convention is the single mistake this
+  school most wants to avoid.
+- **The tutorial-grade parody.** It will also be tempting to write
+  tutorial code — unparameterized querysets, no `select_related`, no
+  pagination, no admin registration, no migration paths for schema
+  changes. The Convention exemplar must refuse this too. Faithful
+  Convention is the framework at its production best: admin wired,
+  migrations clean, querysets prefetched, signals used only where
+  appropriate, and the whole thing comprehensible to any Django
+  developer at a glance.
+
+The faithful Convention exemplar is the one where: the directory tree
+is immediately recognizable as a Django app; `Order` is a Django model
+with manager methods encapsulating queries; views use generic CBVs or
+DRF viewsets where appropriate; admin is registered; migrations exist
+and are reversible; no raw SQL is written where an ORM method would
+serve; authentication uses `django.contrib.auth`; and every deviation
+from convention is labeled with a one-sentence explanation.
+
+## 8. Rubric — how to recognize a faithful Convention fixture
+
+- [ ] **The project layout is immediately recognizable as Django** (or
+      Rails / Laravel / Spring Boot) by any practitioner of that
+      framework. The directory tree needs no explanation.
+- [ ] **All models inherit from the framework's base model class** and
+      live in the conventional location (`models.py` or `models/`).
+- [ ] **All routes are declared through the framework's routing system**
+      (`urls.py` patterns, Django router, etc.), not through a custom
+      dispatch layer.
+- [ ] **Migrations exist for every schema change** and are reversible
+      (forward and backward migration operations are specified).
+- [ ] **No custom middleware replaces a framework-provided facility.**
+      Where custom middleware exists, it adds a new concern rather than
+      substituting for a standard one.
+- [ ] **No hand-rolled ORM, serializer, or form validation.** Django
+      Forms, DRF Serializers, or equivalent framework machinery carry
+      all input handling.
+- [ ] **Admin (or equivalent dashboard) is wired** where the framework
+      provides it, demonstrating that ops tooling uses the blessed path.
+- [ ] **Deviations from convention are explicitly labeled.** Any place
+      the exemplar leaves the blessed path has a one-sentence comment
+      naming the pressure that required the deviation.
+- [ ] **The test suite uses the framework's own test helpers** (Django
+      `TestCase`, `pytest-django`, equivalent) rather than a hand-rolled
+      fixture system.
+- [ ] **A first-time reader who knows the framework can predict what
+      each file contains** from the filename alone, without opening it.
+
+Ten out of ten is Convention. Eight or nine is a draft. Seven or fewer
+is a custom application that happens to import a framework.
+
+---
+
+## See also
+
+- [docs/philosophy/unix.md](unix.md) — Convention's structural opposite.
+  A Django app and a Unix pipeline are built on irreconcilable
+  assumptions about where complexity should live and what a "program"
+  even is.
+- [docs/philosophy/classical.md](classical.md) — Classical says the
+  framework is a detail that should be swappable; Convention says the
+  framework *is* the architecture. These axioms cannot be reconciled;
+  a project must pick one.
+- [docs/principles.md](../principles.md) — Convention's contribution to
+  the universal core is mostly negative: it is the school that most
+  strongly limits how aggressively other schools' rules can fire on
+  framework-blessed patterns without producing false positives.

--- a/docs/philosophy/data-oriented.md
+++ b/docs/philosophy/data-oriented.md
@@ -1,0 +1,232 @@
+# Data-Oriented — Axiom Sheet
+
+> *The data layout is the architecture. Cache lines are the unit of decision.*
+
+---
+
+## 1. Prime axiom
+
+> **Software exists to transform data. The shape and layout of that data
+> determines everything meaningful about performance, and performance is
+> not an optimization concern applied at the end — it is a design input
+> from the first line.**
+
+The Data-Oriented school starts from a single empirical observation: modern
+hardware does not execute "code" in any abstract sense; it moves bytes
+between memory tiers and does arithmetic on them in SIMD lanes. The cost of
+a program is dominated by how well the data it touches fits in cache and
+how well the access pattern matches what the hardware was built to do
+quickly. Abstractions that obscure the access pattern hide the real cost
+of the code, and hidden costs compound the same way hidden bugs do.
+
+## 2. The rejected alternative
+
+Data-Oriented architecture refuses:
+
+- **Object-oriented encapsulation as the default.** An object that bundles
+  hot fields (updated every frame) with cold fields (touched once at
+  creation) forces the cache to load both every time either is needed.
+- **Virtual dispatch in the inner loop.** Every virtual call is an
+  indirection the CPU cannot predict and an allocation the compiler
+  cannot inline. Inside a loop that runs millions of times per frame,
+  this is the difference between 4ms and 40ms.
+- **Pointer chasing.** Linked lists, tree nodes with parent pointers,
+  graphs of small heap-allocated nodes — all of them scatter the data
+  the loop needs across pages the cache must then chase.
+- **"Expressive" code that hides allocations.** A comprehension that
+  looks clean but allocates three intermediate lists inside a hot loop
+  is expensive code disguised as elegant code. The elegance was a
+  costume.
+- **Assumptions about performance.** "This should be fast" is not a
+  performance claim; it is a wish. Only measurements are claims.
+- **Premature abstraction of the data layout.** The layout is the
+  architecture; abstracting it is abstracting the architecture. Do
+  that later, if ever — and only after measurement justifies the cost.
+- **OOP hierarchies for entities.** The inheritance tree optimizes for
+  conceptual clarity at the expense of memory locality. Data-Oriented
+  design inverts this ranking.
+
+## 3. Canonical citations
+
+- Acton, Mike. "Data-Oriented Design and C++." CppCon, 2014. — The
+  definitive talk. Reframes the entire discipline around three premises:
+  the purpose of a program is to transform data, hardware has a specific
+  shape, and different problems require different solutions.
+- Fabian, Richard. *Data-Oriented Design: Software Engineering for
+  Limited Resources and Short Schedules.* 2018. — The book-length
+  treatment, with worked examples in C++.
+- Muratori, Casey. *Handmade Hero.* handmadehero.org, 2014–present. —
+  A multi-year from-scratch implementation of a game engine with no
+  dependencies, with running commentary on why every abstraction is
+  being refused or accepted.
+- Blow, Jonathan. Jai language design talks, 2014–present. — The case
+  for a language designed around the needs of programmers who care
+  about data layout, with a sustained critique of C++'s abstraction
+  mechanisms.
+- Kelley, Andrew. Zig language design talks and blog posts. — A
+  contemporary language design that takes data-oriented principles as
+  first-class constraints.
+- Nystrom, Robert. *Game Programming Patterns.* Genever Benning, 2014.
+  — Chapter 17, "Data Locality," is the accessible introduction for
+  programmers coming from an OOP background.
+- Insomniac Games. Various engineering talks, 2010–present. — The
+  production-scale demonstration that DOD is not academic.
+
+## 4. The catechism
+
+Seven derived commitments:
+
+1. **Measure first.** Assumptions about performance are lies until a
+   profiler agrees. The profiler is the arbiter; intuition is the
+   hypothesis.
+2. **Data layout precedes algorithm.** A cache-coherent O(n²) beats a
+   cache-thrashing O(n log n) at realistic sizes, because the cache miss
+   is measured in hundreds of cycles and the instruction count is
+   measured in handfuls.
+3. **Struct-of-Arrays over Array-of-Structs** when the iteration
+   dominates the access pattern. Pack the fields you actually read; leave
+   the rest elsewhere.
+4. **Batch over individual.** Ten thousand orders processed in one pass
+   beats ten thousand method calls — both in wall-clock time and in
+   readability, because the batch version makes the work legible.
+5. **No virtual dispatch in the inner loop.** The indirection cost
+   dominates the work. If you need polymorphism, dispatch once outside
+   the loop and specialize inside.
+6. **Allocations are events to be budgeted**, not conveniences to be
+   consumed. The heap is slow; reuse is cheap. A pre-allocated buffer
+   outperforms a "clean" list comprehension every time the comprehension
+   is in a hot path.
+7. **The problem IS the data.** Objects are a convenient fiction; the
+   real thing is rows of data being transformed by functions. The
+   Data-Oriented mental model is a spreadsheet, not a class diagram.
+
+## 5. Rule shape this axiom generates
+
+- **Forbid** — virtual methods in iterated code, allocations inside hot
+  loops, linked lists where arrays would serve, OOP hierarchies that
+  scatter related data across the heap, abstractions that obscure memory
+  access patterns, "flexibility" knobs that turn inner loops into
+  dispatch tables.
+- **Require** — measurements before claims of speed, batch APIs for bulk
+  operations, contiguous storage for iterated data, explicit separation
+  of hot and cold fields.
+- **Prefer** — arrays over dicts for small keyspaces, parallel arrays
+  (SoA) for bulk, pre-allocated buffers over per-iteration allocation,
+  `__slots__` on dataclasses that will exist in quantity, `numpy` or
+  `array` where the access pattern justifies it.
+
+Under a Python linter, this axiom generates rules of a particular
+character: not "count your cache lines" (Python cannot honestly offer
+that), but "do not use a dict where a list would serve," "do not put
+a for-loop with a polymorphic method call on the hot path," "prefer
+`numpy.ndarray` when the size is known and the operations are
+vectorizable," "measure before you claim." The discipline is the
+mental model; the rules are its Python-legible shadow.
+
+## 6. The degenerate case
+
+Every axiom has a failure mode. For Data-Oriented, the failure mode is
+**premature optimization as identity**.
+
+- Code that is unreadable, not maintainable, and not actually faster
+  because the hot path was not where the author thought it was. The
+  author skipped the measurement because they "knew" where the cost
+  was, and they were wrong.
+- Counting cache lines in a script that runs once a day for a minute.
+  The total budget for the program's lifetime performance is dominated
+  by startup, and the author spent a week on the inner loop.
+- Rewriting a readable dict-comprehension into a manual loop "for
+  branch prediction" on code that is not on any hot path.
+- Performance theater in code that spends 99% of its time waiting on
+  the network. The right optimization would have been the `requests`
+  `Session` connection pool, not the struct-of-arrays rewrite of the
+  response parser.
+- Dogmatism that forgets Acton's first rule — *measure*. A purist who
+  rejects a clean solution on DOD grounds without profiling is no longer
+  doing DOD; they are doing folk performance theology.
+- Reaching for `numpy` on a problem with N=12 and then celebrating the
+  "speedup" as a win, when the overhead of entering `numpy` exceeds the
+  pure-Python alternative at that size.
+
+The test for premature-optimization-as-identity: ask for the profiler
+output. A faithful Data-Oriented change has one; an unfaithful one has
+a story.
+
+## 7. Exemplar temptation
+
+When writing the Data-Oriented implementation of the canonical task,
+the exemplar must navigate two opposite temptations:
+
+- **The OOP shortcut.** It will be tempting to model each order as an
+  `Order` object with `validate()`, `price()`, `reserve()`, and
+  `notify()` methods, and iterate through a list of them calling each
+  method in turn. The Data-Oriented exemplar must refuse this —
+  processing must be batched, hot fields must be packed, and the
+  per-order method call must give way to a per-stage bulk operation.
+- **The C-in-Python parody.** It will also be tempting to pretend Python
+  is a systems language, manually unroll loops, use `ctypes`, or contort
+  the code to count cycles Python does not actually expose. The exemplar
+  must refuse this too. The point is to demonstrate the *mental model*
+  in a form Python can honestly express — numpy arrays where the
+  operation is vectorizable, `__slots__` dataclasses where objects must
+  exist, explicit hot/cold field separation, and batch-oriented APIs.
+
+The faithful Data-Oriented exemplar is the one where: orders are stored
+as parallel arrays or structured numpy columns, not as a list of Order
+objects; processing is done stage-by-stage over the whole batch, not
+order-by-order over all stages; hot fields (price, quantity, status)
+live in one structure and cold fields (billing address, customer notes)
+live elsewhere; at least one benchmark exists with measured numbers;
+and a reader can state the hot loop in one sentence and explain why it
+is cache-friendly.
+
+## 8. Rubric — how to recognize a faithful Data-Oriented fixture
+
+- [ ] **Orders are processed in batches**, not one at a time in a method-
+      call-per-order loop.
+- [ ] **Hot data** (fields touched in every pass) **is separated from cold
+      data** (fields touched rarely or once). The separation is visible
+      in the data structure definitions.
+- [ ] **At least one structure uses Struct-of-Arrays layout** — parallel
+      lists, parallel numpy arrays, or a record with list-valued columns
+      — where an Array-of-Structs would have been the OO default.
+- [ ] **No virtual dispatch in the main processing loop.** Polymorphism,
+      if any, is resolved outside the loop. The inner loop calls concrete
+      functions on concrete data.
+- [ ] **At least one benchmark exists** and is referenced in a comment or
+      sibling file, with measured numbers and a brief note on the
+      hardware.
+- [ ] **Allocations in the main loop are minimized.** Where Python allows,
+      buffers are pre-allocated and reused. Hot loops do not build new
+      lists that will be immediately discarded.
+- [ ] **Data structures are described by their access pattern** in
+      comments or naming, not by their "entity identity."
+- [ ] **Python-native performance tools are used honestly** — `numpy`,
+      `array`, `__slots__`, `dataclasses(frozen=True, slots=True)` — not
+      as cosplay of C, but as the honest Python expression of a
+      data-oriented mental model.
+- [ ] **Performance assumptions are explicit.** The code or an adjacent
+      comment states which loops matter, which do not, and why.
+- [ ] **A reader can state, in one sentence, what the hot loop is and
+      why it is cache-friendly** (or, in Python's honest idiom, why it
+      is vectorizable / memory-local).
+
+Ten out of ten is Data-Oriented. Eight or nine is a draft. Seven or
+fewer is OOP code wearing a performance hat.
+
+---
+
+## See also
+
+- [docs/philosophy/functional.md](functional.md) — The sharpest conflict
+  in the entire matrix. Functional requires immutability (copy on
+  change); Data-Oriented requires in-place batch updates for cache
+  locality. These two axioms are nearly irreconcilable on shared memory.
+- [docs/philosophy/classical.md](classical.md) — Classical OOP
+  hierarchies are this school's canonical anti-pattern. The Shape
+  hierarchy example from every OOP textbook is the Data-Oriented
+  school's example of how not to lay out data.
+- [docs/principles.md](../principles.md) — This school's contribution
+  to the universal core is narrower: it mostly adds rules, rather than
+  changing them, because its prime concern (memory layout) is largely
+  orthogonal to the three pillars.

--- a/docs/philosophy/event-sourced.md
+++ b/docs/philosophy/event-sourced.md
@@ -1,0 +1,258 @@
+# Event-Sourced / CQRS — Axiom Sheet
+
+> *The log of events is the state. Current state is a projection, not a source.*
+
+---
+
+## 1. Prime axiom
+
+> **The fundamental record of what a system is, is the ordered log of what
+> has happened to it. Current state is a derived view over that log — one
+> projection among many possible — and the system's design must treat the
+> log as authoritative and the projections as replaceable.**
+
+Conventional data modeling records outcomes: the order status is "cancelled."
+Event-sourced modeling records causes: the order was cancelled because the
+customer reached a fraud-check threshold at 14:22:03 on Tuesday. The first
+model throws away the information that would have let an auditor, a
+regulator, a future product manager, or a machine-learning model reconstruct
+what the business actually did. The second preserves that information
+permanently, at the cost of shifting where the complexity lives — and the
+Event-Sourced school claims that shift is a bargain.
+
+## 2. The rejected alternative
+
+Event-sourced architecture refuses:
+
+- **In-place mutation of aggregates.** An `order.status = "cancelled"`
+  statement throws away the record of what the status was before, why it
+  changed, and when. The cancellation is a *fact*; the update is a lie
+  about the shape of that fact.
+- **CRUD as the default persistence model for transactional systems.**
+  Create-Read-Update-Delete records only the current state; the history
+  is whatever the audit log happened to catch. Under Event-Sourcing, the
+  audit log *is* the database, not an afterthought.
+- **Losing intent by storing only outcomes.** `status_changed_from_X_to_Y`
+  is weaker than `OrderCancelledByCustomer` because the latter names the
+  actor and the cause. The former is a mechanical trace; the latter is a
+  business fact.
+- **Treating audit as an afterthought.** An audit system bolted onto a
+  CRUD database answers "what does it look like now?" but cannot answer
+  "what did we know at time T?" without heroic reconstruction. Event
+  sourcing answers both natively.
+- **Read-and-write models sharing the same schema.** CQRS separates the
+  write side (commands producing events) from the read side (projections
+  optimized for queries) because the two have different requirements and
+  fighting that difference in a single schema produces a schema that
+  serves neither well.
+- **UPDATE statements on event-store tables.** An event, once written,
+  is a historical fact. Rewriting it is rewriting history.
+- **Projections that cannot be rebuilt from the log.** A projection that
+  depends on state that is not in the event log is a projection whose
+  correctness cannot be verified and whose bugs cannot be fixed by
+  replay.
+
+## 3. Canonical citations
+
+- Young, Greg. "CQRS Documents." cqrs.wordpress.com, 2010. — The
+  foundational essay collection on command-query responsibility
+  separation and its relationship to event sourcing.
+- Young, Greg. "Event Sourcing." GOTO Conference, 2014. — The canonical
+  talk, with worked examples showing the shift from state-based to
+  event-based thinking.
+- Dahan, Udi. "Clarified CQRS." udidahan.com, 2009. — The clearest
+  explanation of when CQRS pays off and when it is overkill, from one
+  of the pattern's originators.
+- Vernon, Vaughn. *Implementing Domain-Driven Design.* Addison-Wesley,
+  2013. — Chapters 4 and 8 are the most accessible book-length
+  treatment of event sourcing and aggregates working together.
+- Kreps, Jay. "The Log: What every software engineer should know about
+  real-time data's unifying abstraction." LinkedIn Engineering, 2013.
+  — The durable-log perspective, which is the infrastructure spine
+  event sourcing rides on at scale.
+- Kleppmann, Martin. *Designing Data-Intensive Applications.* O'Reilly,
+  2017. — Chapter 11, "Stream Processing," is the modern reference for
+  log-based architectures and their consistency properties.
+- Fowler, Martin. "Event Sourcing." martinfowler.com, 2005. — The first
+  widely-read description of the pattern in the enterprise space.
+- Evans, Eric. *Domain-Driven Design.* Addison-Wesley, 2003. — The
+  aggregate concept that event sourcing relies on as its consistency
+  boundary.
+
+## 4. The catechism
+
+Seven derived commitments:
+
+1. **Events are facts, and facts are immutable.** An event happened; it
+   cannot un-happen. Event types are frozen value objects. Storing an
+   event is appending to a log; there is no such thing as "updating an
+   event."
+2. **Current state is a projection.** It is derived from the log, not
+   stored as the source of truth. The log is authoritative; the
+   projection is convenient.
+3. **Write models and read models are separated.** Commands are handled
+   by aggregates that enforce invariants and emit events. Queries are
+   served by projections that have been optimized for reading. The two
+   sides do not share a schema.
+4. **Intent is captured, not just outcome.** Event names are past-tense
+   and carry the business reason for the change: `OrderCancelledByCustomer`,
+   `OrderCancelledByFraudCheck`, `OrderCancelledBySystemTimeout`. Three
+   events, three causes, three meanings — not one event with a "reason"
+   field that everyone ignores.
+5. **Replay is cheap and legal.** Any projection can be rebuilt from
+   scratch by replaying the event log from zero. This is not a disaster
+   recovery capability; it is a normal operation, and the system is
+   designed assuming it will be exercised.
+6. **Time-travel is a first-class capability.** The system can answer
+   "what was the state of order X at time T?" for any past T, because
+   the log contains exactly the information needed to reconstruct it.
+7. **Aggregates enforce invariants on the write side.** The aggregate
+   is the consistency boundary; events that leave the aggregate are
+   facts the rest of the system can trust without re-validation.
+
+## 5. Rule shape this axiom generates
+
+- **Forbid** — mutation of event instances after creation, UPDATE or
+  DELETE statements against event-store tables, aggregate methods that
+  return "updated selves" instead of emitting events, direct queries
+  against read-side projections from the write side, projections that
+  depend on state not in the event log, non-idempotent projection
+  handlers, event names in present or imperative tense.
+- **Require** — events as immutable value objects (frozen dataclasses
+  or equivalent), append-only event stores, separate read-side
+  projections for every distinct query use case, past-tense event
+  names, idempotent projection handlers.
+- **Prefer** — explicit event versioning strategies (upcasting,
+  schema migration), event names that carry business intent, aggregate
+  command methods that return events rather than mutating fields.
+
+This axiom contributes a distinct slice of rules that sit awkwardly
+inside any other school: the "no mutation on aggregates" rule is not
+Functional (which forbids mutation everywhere), not Classical (which
+permits aggregate state changes), and not Pragmatic (which would not
+extract the event type at all until pressure arrived). Event sourcing
+earns its place on the map because these rules *contradict* other
+schools' rules without being subsumed by them.
+
+## 6. The degenerate case
+
+Every axiom has a failure mode. For Event-Sourced, the failure mode is
+**event sourcing as fetish**.
+
+- Every CRUD app contorted into an event log because a conference talk
+  was persuasive. The team pays the full price of event-sourced
+  infrastructure (projections, replay, eventual consistency, versioning)
+  on a problem that would have been solved by a single UPDATE statement.
+- Projection bugs discovered months later because the event is right but
+  the current-state view has been wrong the whole time, and nobody
+  rebuilt from the log often enough to notice. The log's authority is
+  rhetorical; the projection is what the business actually reads.
+- Eventual consistency used as an excuse for wrong answers. "The
+  projection will catch up" becomes the team's standard response to any
+  report that does not match expectations, until the report and the
+  reality have diverged enough to hurt someone.
+- A team that cannot answer a simple reporting question because every
+  query requires writing a new projection and waiting for it to rebuild.
+  The flexibility of "add projections retroactively" has become the
+  rigidity of "we cannot answer ad-hoc questions."
+- Storing events without ever reading them. The log as cargo cult: the
+  team writes events because the pattern demands it, but the projections
+  are all stale and the replay has never been tested, so the log is
+  really just an expensive audit trail of questionable integrity.
+- Event names that fail to capture intent: `OrderStatusChanged` as the
+  only event type, with a `from` and `to` field. This is CRUD wearing
+  an event costume. The whole point was to preserve intent; an event
+  that does not preserve intent is an event in name only.
+
+The test for event-sourcing-as-fetish: can the team demonstrate, with a
+running example, the rebuild of a projection from scratch? If replay
+has never been exercised, the log's authority is hypothetical, and
+hypothetical authority is not authority.
+
+## 7. Exemplar temptation
+
+When writing the Event-Sourced implementation of the canonical task,
+the exemplar must navigate two opposite temptations:
+
+- **The CRUD shortcut.** It will be tempting to model the order as a
+  row in a table with a `status` field and an `audit_log` column that
+  stores a JSON blob of changes. The Event-Sourced exemplar must refuse
+  — the events must be first-class records in an append-only store, the
+  aggregate must emit them rather than mutate the row, and the current
+  state must be a projection that can be rebuilt from the log.
+- **The infrastructure parody.** It will also be tempting to pull in
+  Kafka, EventStoreDB, or a full-weight CQRS framework to demonstrate
+  "realism." The exemplar must refuse this too. The infrastructure
+  should be the simplest honest thing that demonstrates the discipline:
+  an in-process append-only list of events, a few projection
+  dictionaries built by replay, and a handful of functions that show
+  the command → event → projection flow. Kafka is a deployment
+  detail; event sourcing is a modeling discipline.
+
+The faithful Event-Sourced exemplar is the one where: orders are
+represented as a stream of past-tense events (`OrderPlaced`,
+`LineItemAdded`, `PricingCalculated`, `InventoryReserved`,
+`OrderConfirmed`, `OrderCancelledByCustomer`); the order aggregate
+exposes command methods that emit events rather than mutate fields;
+every state change is an event; projections exist for current-state
+queries and can be rebuilt by replay; the exemplar demonstrates at
+least one replay in a test or script; and at least one time-travel
+query is shown.
+
+## 8. Rubric — how to recognize a faithful Event-Sourced fixture
+
+- [ ] **Orders are represented as a stream of past-tense events**, not
+      as a mutable row. The event stream is the canonical representation.
+- [ ] **The order aggregate exposes commands** (e.g., `place_order`,
+      `cancel_order`) that produce events; no setters, no direct field
+      mutation from outside the aggregate.
+- [ ] **Every state change is expressed as an event.** No UPDATE-in-place
+      on the aggregate, no "just this one field" exceptions.
+- [ ] **Events are frozen dataclasses** (or the language equivalent)
+      with no methods that return mutated copies and no fields that can
+      be reassigned after construction.
+- [ ] **At least one read-side projection exists** that materializes
+      current state for querying, and is clearly distinct from the
+      write-side aggregate.
+- [ ] **Projection rebuild is demonstrated** in the exemplar — a test
+      or script that tears down the projection, replays the log from
+      zero, and produces the same current state.
+- [ ] **Event names capture intent, not just outcome.** Not
+      `OrderStatusChanged`, but `OrderCancelledByCustomer` /
+      `OrderCancelledByFraudCheck` / `OrderConfirmed`.
+- [ ] **Aggregate invariants are enforced at command time**, before the
+      event is emitted. A command that would violate an invariant
+      (cancelling a shipped order) is rejected by the aggregate, not
+      caught by a downstream check.
+- [ ] **A new query use case can be added by writing a new projection**
+      without changing the write side. The exemplar documents how this
+      would work, or demonstrates it with a second projection.
+- [ ] **At least one time-travel query is demonstrated** — "what was the
+      state of order X at time T?" — showing that the history is real,
+      not ornamental.
+
+Ten out of ten is Event-Sourced. Eight or nine is a draft. Seven or
+fewer is CRUD with an audit log.
+
+---
+
+## See also
+
+- [docs/philosophy/functional.md](functional.md) — Event-sourcing and
+  functional programming are natural allies: events are immutable
+  values, projections are folds over a sequence, and the aggregate's
+  command handler is a pure function from `(state, command)` to events.
+  Much of the discipline translates cleanly between the two schools.
+- [docs/philosophy/classical.md](classical.md) — Event-sourcing
+  contradicts Classical DDD's default of in-place aggregate mutation.
+  Both schools care deeply about aggregates and invariants, but they
+  disagree about how aggregates should record what happens to them.
+- [docs/philosophy/resilient.md](resilient.md) — The append-only log is
+  the backbone of many resilience patterns (replay, reprocessing,
+  dead-letter handling). The two schools share infrastructure even
+  when they are optimizing for different properties.
+- [docs/principles.md](../principles.md) — This school's contribution
+  to the universal core is narrower than most: it mostly adds rules
+  rather than reshaping existing ones, because its central claim
+  (the log is authoritative) is genuinely novel and does not sit
+  comfortably inside any other school's frame.

--- a/docs/philosophy/functional.md
+++ b/docs/philosophy/functional.md
@@ -1,0 +1,210 @@
+# Functional / Algebraic — Axiom Sheet
+
+> *Computation is transformation. Values flow; state does not hide.*
+
+---
+
+## 1. Prime axiom
+
+> **A program is a composition of pure transformations over immutable values.
+> Side effects exist only at the edges, where the program meets the world —
+> and they are named, typed, and visible when they do.**
+
+Mutation is the root cause of the class of bugs where a function's behavior
+depends on what some other function did to shared memory between calls.
+Purity is not an aesthetic preference; it is the price of being able to
+reason about a piece of code by reading only that piece of code. The
+Functional school buys that reasoning ability by refusing the shortcut of
+hidden state.
+
+## 2. The rejected alternative
+
+Functional architecture refuses:
+
+- **Mutation on shared references.** A value that can change out from under
+  its reader is a lie about what that reader is looking at.
+- **Hidden side effects in business logic.** A pricing function that writes
+  to a log, queries a cache, and updates a metrics counter is three functions
+  pretending to be one.
+- **Classes with mutable private state.** Encapsulation hides the mutation;
+  the mutation is still there, and it still defeats local reasoning.
+- **Inheritance as a mechanism for reuse.** A subclass that changes behavior
+  by overriding methods is a back-door mutation of its superclass's meaning.
+- **Exceptions as control flow.** A function that may or may not return
+  depending on runtime state is a function with two hidden return paths and
+  no type that describes them.
+- **`None` / `null` as a legitimate value.** A type that silently admits
+  absence is a type whose contract is a lie. If absence is meaningful, it
+  deserves its own name (`Option`, `Maybe`, `Result`).
+- **Ambient I/O.** A function that reads from the environment, the clock,
+  or the filesystem without declaring it in its signature is a function
+  whose dependencies cannot be tested without staging the world.
+
+## 3. Canonical citations
+
+- Hickey, Rich. "Simple Made Easy." Strange Loop, 2011. — The distinction
+  between *simple* (disentangled) and *easy* (familiar), and why mutation
+  is never simple.
+- Okasaki, Chris. *Purely Functional Data Structures.* Cambridge University
+  Press, 1998. — Persistent data structures as the demonstration that
+  immutability is practical, not ideological.
+- Hutton, Graham. *Programming in Haskell.* 2nd ed., Cambridge University
+  Press, 2016. — The canonical introduction to pure functional programming
+  in the typed tradition.
+- Wadler, Philip. "The Essence of Functional Programming." POPL, 1992. —
+  Monads as the principled treatment of effects.
+- Czaplicki, Evan. *The Elm Architecture.* elm-lang.org. — Model, Update,
+  View as a practical discipline for building UIs without mutation.
+- Pierce, Benjamin. *Types and Programming Languages.* MIT Press, 2002. —
+  The formal foundation for treating types as proofs.
+- Bird, Richard & Wadler, Philip. *Introduction to Functional Programming.*
+  Prentice Hall, 1988. — The origin text for much of the discipline.
+- Backus, John. "Can Programming Be Liberated from the von Neumann Style?"
+  Turing Award lecture, 1977. — The foundational argument that mutation
+  and variables are historical accidents, not necessities.
+
+## 4. The catechism
+
+Seven derived commitments:
+
+1. **Immutable by default.** Values are not mutated; they are replaced. A
+   "change" is a new value that differs from the old in some respect.
+2. **Pure functions compose.** Given the same input, a pure function always
+   produces the same output and has no observable effect on anything else.
+   The composition of pure functions is itself pure, which is why pipelines
+   scale in complexity without scaling in difficulty.
+3. **Side effects are pushed to the edges.** The core of the program is
+   pure; I/O, network, database, and clock live in a thin shell that wraps
+   the pure core. This is the "functional core, imperative shell" pattern.
+4. **Types are the proof.** If the type checker accepts a program, that
+   program is at least as correct as its types demand. Rich types catch
+   more bugs at compile time; weak types catch them at 3am in production.
+5. **Composition over inheritance.** A program is assembled from functions
+   combined with `map`, `filter`, `fold`, `compose`, and their kin — not
+   from classes arranged in hierarchies.
+6. **Totality over exceptions.** A function that might fail returns a value
+   describing the failure (`Result`, `Either`, `Option`) — it does not
+   raise an exception and it does not return `None`. Errors become data,
+   and data is checkable.
+7. **Referential transparency.** Any expression may be replaced by its
+   value without changing the meaning of the surrounding program. This is
+   the property that makes the rest of the catechism tractable.
+
+## 5. Rule shape this axiom generates
+
+- **Forbid** — mutation of arguments, shared mutable globals, classes with
+  mutable state, side effects in the domain core, `None` as a legitimate
+  return value, exceptions as flow control, inheritance chains beyond
+  protocol/interface definitions, primitive obsession, functions whose
+  behavior depends on the clock or the filesystem without declaring it.
+- **Require** — a pure core, effect types (or clearly named edge modules)
+  at boundaries, total functions on all declared inputs, explicit error
+  values, type annotations dense enough to be used as documentation.
+- **Prefer** — frozen dataclasses over mutable classes, comprehensions over
+  accumulator loops, function composition over class hierarchies, named
+  result types over sentinel values.
+
+This axiom's direct contribution to Gaudí's universal core is Principle #5
+("state must be visible") and Principle #4 ("failure must be named") — both
+of which survive translation into every school, but which Functional states
+most strictly. Where Classical says "state should be owned by a class,"
+Functional says "state should, where possible, not exist at all."
+
+## 6. The degenerate case
+
+Every axiom has a failure mode. For Functional, the failure mode is
+**abstraction astronautics**.
+
+- Monad transformer stacks nobody can read — five layers of wrapping to do
+  the work that a try/except and a logging call would have done honestly.
+- Type-level programming that uses up the team's entire comprehension
+  budget to prove a property the tests would have caught anyway.
+- The word "just" in answers: "just lift it into the Reader monad," "just
+  use the Church encoding," "just applicative functors." When "just" is
+  the bridge between the question and the answer, the abstraction has
+  stopped earning its weight.
+- Purity dogma applied to tasks that are fundamentally about effects —
+  reading a config file turned into a three-file type-level choreography
+  because the word "impure" was not allowed to appear.
+- Treating every newcomer's mutable loop as a moral failing rather than a
+  teaching opportunity. Purity is a property of programs, not of
+  programmers.
+- Using Haskell-style names (`fmap`, `>>=`, `pure`, `traverse`) in a
+  language whose community calls them something else, so that the code
+  is readable only to those who have already been initiated.
+
+The test for abstraction astronautics: show the code to a competent
+programmer who is fluent in the language but not in the school. If they
+cannot state what the code does within one minute, the abstraction has
+failed its own axiom — referential transparency is supposed to make the
+code *easier* to reason about, not harder.
+
+## 7. Exemplar temptation
+
+When writing the Functional implementation of the canonical task, the
+exemplar must navigate two opposite temptations:
+
+- **The mutable shortcut.** It will be tempting, at some point in the
+  pricing or inventory logic, to use a mutable accumulator or a mutable
+  dictionary because "it is just local state." The Functional exemplar
+  must refuse — even local mutation defeats referential transparency
+  for the enclosing function, and the whole discipline is about keeping
+  that transparency available everywhere.
+- **The Haskell-in-Python parody.** It will also be tempting to build a
+  `Reader[Env, Result[OrderError, Order]]` monad transformer stack,
+  import `returns` or `expression`, and write Python that looks like
+  someone wanted Haskell but had to settle. The Functional exemplar must
+  refuse this too. The exemplar is in Python; it uses Python's native
+  tools (frozen dataclasses, tuples, comprehensions, union types,
+  `typing.Protocol`) in the functional *style* rather than in a cosplay
+  of another language.
+
+The faithful Functional exemplar is the one where: the core domain
+module has zero imports from `logging`, `os`, `requests`, or any
+database library; every dataclass is `frozen=True`; errors are returned
+as tagged values, not raised; and any newcomer who is fluent in Python
+(but not in Haskell) can read the code top to bottom without a glossary.
+
+## 8. Rubric — how to recognize a faithful Functional fixture
+
+- [ ] **No mutation of passed-in arguments.** Functions return new values;
+      they do not reach into their inputs and change them.
+- [ ] **All domain dataclasses are `frozen=True`.** Or the language's
+      equivalent immutable construct. Records describe facts, not slots.
+- [ ] **I/O is isolated at the edges.** The domain core module has zero
+      imports of `logging`, `os`, `requests`, `sqlite3`, database clients,
+      or the clock (`time`, `datetime.now`).
+- [ ] **Errors are returned as values**, not raised. A `Result`,
+      `Either`, or tagged-union pattern is used consistently for failure.
+- [ ] **No shared mutable globals.** No module-level dict, set, or list
+      that mutates during execution. Constants are allowed; registries
+      are not.
+- [ ] **For-loops with accumulators are absent** where `map`, `filter`,
+      comprehensions, or `functools.reduce` would serve honestly.
+- [ ] **Type annotations are dense and meaningful.** No bare `Any`. No
+      `Optional` where a `Result` would tell the truth more precisely.
+- [ ] **Inheritance is used only for `Protocol` or ABC definitions** —
+      never to reuse behavior by extending a concrete class.
+- [ ] **Composition is explicit.** Pipelines are built from named functions
+      combined with `compose`, `pipe`, or straight-line application; not
+      from classes whose methods call each other.
+- [ ] **Any function in the core can be evaluated in the REPL** without
+      staging files, databases, or network mocks. Referential transparency
+      is demonstrable, not merely claimed.
+
+A fixture that passes all ten is Functional. Eight or nine is a draft.
+Seven or fewer is probably imperative code wearing functional decoration.
+
+---
+
+## See also
+
+- [docs/philosophy/classical.md](classical.md) — Functional rejects
+  inheritance-based reuse and stateful encapsulation, both of which
+  Classical embraces.
+- [docs/philosophy/data-oriented.md](data-oriented.md) — Functional's
+  sharpest disagreement: immutability requires copying, which destroys
+  cache locality. These two schools are nearly irreconcilable on the
+  question of how values live in memory.
+- [docs/principles.md](../principles.md) — Principle #5 (state must be
+  visible) is Functional's purest contribution to the universal core.

--- a/docs/philosophy/pragmatic.md
+++ b/docs/philosophy/pragmatic.md
@@ -1,0 +1,207 @@
+# Pragmatic / Evolutionary — Axiom Sheet
+
+> *Design is discovered, not declared. Refactor toward the shape the problem is asking for.*
+
+---
+
+## 1. Prime axiom
+
+> **Software design is an empirical discovery, not a deductive declaration.
+> The right shape is found by writing the smallest honest code, running it,
+> and reshaping it when the next real requirement arrives — never before.**
+
+Upfront design is a prediction, and predictions about code are usually wrong.
+The Pragmatic school treats every speculative decision as a loan taken out
+against an imagined future, a loan whose interest compounds in exactly the
+cases where the imagination turned out to be wrong. The cheapest design is
+the one the code does not yet contain.
+
+## 2. The rejected alternative
+
+Pragmatic architecture is defined by what it refuses to build early:
+
+- **Upfront abstraction for callers that do not yet exist.** A class extracted
+  "for flexibility" is a commitment to a shape nobody has measured.
+- **Configuration knobs for scenarios nobody has seen.** Every flag is a
+  branch, every branch is a test matrix, every test matrix is debt.
+- **Design documents as substitute for code.** The whiteboard is a sketch;
+  the code is the thing. If the code is wrong, the whiteboard was optimistic.
+- **"We'll need it eventually" as justification.** Eventually is not evidence.
+  Build the thing you need now; revisit when the second requirement is a fact.
+- **Patterns applied because they are named.** A pattern is only an asset when
+  it solves a real problem at hand, not when it matches a diagram.
+- **Refactoring as a separate "cleanup phase."** Refactoring is a continuous
+  activity done under a green test suite, not a budget line to be deferred.
+- **Premature extraction of shared libraries.** The Rule of Three exists
+  because two occurrences are not yet a pattern; they are a coincidence.
+
+## 3. Canonical citations
+
+- Beck, Kent. *Extreme Programming Explained: Embrace Change.* Addison-Wesley,
+  2000. — Small releases, continuous refactoring, test-first as the rhythm of
+  design.
+- Beck, Kent. *Test-Driven Development: By Example.* Addison-Wesley, 2003. —
+  Red-green-refactor as the engine of emergent design.
+- Fowler, Martin. *Refactoring: Improving the Design of Existing Code.*
+  2nd ed., Addison-Wesley, 2018. — The catalog of safe transformations under a
+  green test suite.
+- Hunt, Andrew & Thomas, David. *The Pragmatic Programmer.* 20th Anniversary
+  ed., Addison-Wesley, 2019. — DRY, orthogonality, tracer bullets, and the
+  broken window theory of codebases.
+- Cunningham, Ward. "The WyCash Portfolio Management System." OOPSLA 1992. —
+  The original technical debt metaphor.
+- Feathers, Michael. *Working Effectively with Legacy Code.* Prentice Hall,
+  2004. — Characterization tests and the discipline of refactoring under
+  incomplete knowledge.
+- Jeffries, Ron. "We tried baseball and it didn't work." ronjeffries.com. —
+  The clearest rejection of the upfront-design substitute.
+
+## 4. The catechism
+
+Seven derived commitments. A Pragmatic implementation practices all seven as a
+single discipline, because the discipline only works as a whole — the tests
+enable the refactoring, which enables the small commits, which enable the
+emergent design.
+
+1. **YAGNI is sacred.** Do not build for callers that do not yet exist. The
+   cheapest abstraction is the one the code still lacks.
+2. **Rule of Three.** Duplicate once, duplicate twice, extract on the third
+   occurrence. Two shapes are a coincidence; three are a pattern.
+3. **Red-green-refactor.** Write the failing test first. Write the smallest
+   code that makes it pass. Refactor with the test green. No step may be
+   skipped, because the refactoring step is where the design actually appears.
+4. **Small commits that always compile.** The repository is a chain of
+   working states, not a plan of future perfection. Every commit must pass
+   its tests. Every commit must be safe to revert.
+5. **Refactoring is continuous, not phased.** A "refactor sprint" is an
+   admission that refactoring stopped happening during feature work. Under
+   the Pragmatic axiom, feature work *is* refactor-and-extend work.
+6. **Tests are the safety net for discovery.** Without tests, refactoring is
+   Russian roulette. Without refactoring, the design cannot respond to what
+   is learned. Without the tests enabling the refactoring, the Pragmatic loop
+   collapses into cowboy coding.
+7. **Debt is named and repaid.** Technical debt that is tracked is manageable
+   debt; debt that is hidden is the kind that bankrupts projects. Every
+   knowing compromise is labeled where the code will see it and scheduled
+   where the team will see it.
+
+## 5. Rule shape this axiom generates
+
+- **Forbid** — speculative generality, interfaces with one implementation,
+  configuration flags that are never toggled in tests, dead parameters, dead
+  code paths, "future use" extension points, TODO comments older than
+  N months without a linked issue, refactoring hidden inside feature commits.
+- **Require** — a failing test before the implementation, small commits,
+  green builds as the default state, named debt when debt is taken.
+- **Prefer** — three lines of duplication over one premature abstraction,
+  concrete types until a second caller appears, inlined helpers until a third
+  does, a deleted line over a cleverer one.
+
+Most of Gaudí's `SMELL-015 SpeculativeGenerality`, `SMELL-014 LazyElement`,
+and `SMELL-018 MiddleMan` descend directly from this axiom. So does the
+project's own doctrine under Principle #6 ("the best line is the one not
+written") and Principle #8 ("smallest reasonable change"). Where Classical
+architecture builds the cathedral up front, Pragmatic architecture asks
+whether a chapel would serve — and whether even the chapel is overkill for
+a congregation of two.
+
+## 6. The degenerate case
+
+Every axiom has a failure mode that looks like extreme faithfulness but is
+its opposite. For Pragmatic, that failure mode is **emergence as excuse**.
+
+- Codebases where "the design will emerge" is the standing defense against
+  ever stopping to think.
+- Technical debt that is always "tracked" in a spreadsheet nobody revisits,
+  because tracking is easier than repaying.
+- Test suites so detailed and so coupled to implementation that they prevent
+  refactoring instead of enabling it — the tests calcify the bad design and
+  Pragmatic's engine seizes.
+- "Refactoring" used as a synonym for "never finishing." The second caller
+  arrives, the Rule of Three fires, and the extraction is never done because
+  it would take an afternoon.
+- YAGNI applied with such dogmatism that the team cannot respond when the
+  anticipated requirement does arrive, because the code has zero seams.
+- Continuous cowboy coding justified as "being pragmatic" — the word doing
+  work that the discipline is supposed to do.
+
+The test for emergence-as-excuse: look for the refactoring commits. A
+faithful Pragmatic repository has them; they are small, they are frequent,
+and they are labeled. A repository with zero refactoring commits has either
+achieved perfection (unlikely) or confused "shipping features" with
+"evolving the design" (likely).
+
+## 7. Exemplar temptation
+
+When writing the Pragmatic implementation of the canonical task, the exemplar
+must navigate two opposite temptations:
+
+- **The Classical temptation.** It will be tempting to extract an
+  `OrderValidator` interface, a `PricingStrategy` class, and an
+  `InventoryReservationService` — because that is what "good design" looks
+  like in the Classical textbook. The Pragmatic exemplar must refuse all of
+  this until the *second* validator, the *second* pricing rule, or the
+  *second* reservation backend is a concrete requirement. Until then, the
+  code is a straight-through function with tests around it.
+- **The cowboy temptation.** It will also be tempting to use YAGNI as a
+  license for sloppiness — skip tests, skip naming, skip the small commits,
+  skip the refactoring. The Pragmatic exemplar must refuse this too. The
+  discipline that enables YAGNI is exactly what makes YAGNI safe. Without
+  the discipline, what is left is not Pragmatism — it is neglect.
+
+The faithful Pragmatic exemplar is the one where: every function has a test
+written first; the git log shows small commits that always compile; at least
+one place visibly contains duplication because the third occurrence has not
+yet arrived; and the code is the simplest honest thing that solves today's
+problem, no more and no less.
+
+## 8. Rubric — how to recognize a faithful Pragmatic fixture
+
+A fixture exemplifies Pragmatic architecture if and only if *all* of the
+following are true.
+
+- [ ] **At least one honest duplication exists.** Two similar pieces of
+      logic have not yet been extracted because the third occurrence has
+      not arrived, and the exemplar documents this (a comment, a TODO, or
+      a note in the accompanying README).
+- [ ] **Every function has a test written before it.** The git history
+      (or a commentary file) shows the test-first rhythm, not tests bolted
+      on after implementation.
+- [ ] **No interfaces exist for single implementations.** No abstract base
+      class, Protocol, or generic that has exactly one concrete inhabitant.
+- [ ] **No configuration flag is unused in tests.** If the code reads a
+      config knob, at least two values for that knob are exercised.
+- [ ] **Commits are small and each leaves the suite green.** If the
+      exemplar ships with a suggested commit sequence or changelog, the
+      sequence shows the red-green-refactor cadence.
+- [ ] **Refactoring commits are visible as distinct from feature commits.**
+      Feature work and design evolution are not conflated into a single
+      sprawling patch.
+- [ ] **Type hints are present on the public API but not speculative.**
+      No `Generic[T]` or `Protocol` introduced "for future flexibility."
+- [ ] **No framework scaffolding exists beyond what is actually used.**
+      Every file in the tree earns its place in the current behavior.
+- [ ] **Technical debt is named where it lives.** Any known compromise is
+      labeled with a one-sentence TODO that names the condition under which
+      it should be repaid.
+- [ ] **A new team member can read the code top-to-bottom without needing
+      to understand named patterns.** The pedagogy is the code itself, not
+      a prerequisite vocabulary.
+
+A fixture that passes all ten is Pragmatic. A fixture that passes eight or
+nine is a draft. A fixture that passes seven or fewer is probably not
+Pragmatic — it is either Classical in disguise or cowboy coding wearing a
+Pragmatic badge.
+
+---
+
+## See also
+
+- [docs/philosophy/classical.md](classical.md) — The school Pragmatic most
+  directly critiques, and from which many Pragmatic rules are defined as
+  negations.
+- [docs/principles.md](../principles.md) — Principles #6 (best line is the
+  one not written), #8 (smallest reasonable change), and #12 (tests are the
+  specification) are Pragmatic's direct contributions to the universal core.
+- [docs/rule-registry.md](../rule-registry.md) — `SMELL-014`, `SMELL-015`,
+  and `SMELL-018` are the catalog's current expressions of Pragmatic scope.

--- a/docs/philosophy/resilient.md
+++ b/docs/philosophy/resilient.md
@@ -1,0 +1,236 @@
+# Resilience-First / Distributed Systems — Axiom Sheet
+
+> *Failure is the design input, not the edge case.*
+
+---
+
+## 1. Prime axiom
+
+> **Every call can fail. Every process can die. Every dependency can stop
+> answering. A well-architected system treats these as the expected case
+> and designs for graceful degradation before it designs for the happy path.**
+
+The Resilience-First school starts from a simple observation: the happy path
+is the exceptional state of a production system, not the normal one. Disks
+fill, networks partition, memory leaks, certificates expire, DNS misbehaves,
+and downstream services go down for maintenance at 3am. A system designed
+around the happy path is a system designed for its best day, not its worst.
+Beauty, under this axiom, is the system that keeps running honestly even
+when half of its dependencies have stopped answering — and keeps telling its
+operators, loudly and clearly, what is wrong.
+
+## 2. The rejected alternative
+
+Resilience-First architecture refuses:
+
+- **Happy-path-only code.** A function that works when everything works is
+  not finished; it is half-written.
+- **Calls without timeouts.** A function that may wait forever is a function
+  that, under load, *will* wait forever, and take every caller with it.
+- **Unbounded retries.** A retry loop without backoff and a maximum is a
+  self-directed denial-of-service attack waiting for the right failure.
+- **Shared state across trust boundaries.** Two services that agree on a
+  database are not two services; they are one service pretending.
+- **Silent fallbacks.** A function that swallows its error and returns a
+  "safe default" is a function that makes its own failures unobservable.
+  Principle #13 made concrete.
+- **Assuming the network is reliable.** The first of Deutsch's Fallacies;
+  every system built on the assumption is building on sand.
+- **Treating observability as an afterthought.** Logs, metrics, and traces
+  are design inputs, not ops-team requirements handed down after launch.
+- **"Works on my machine" as a release criterion.** The machine that matters
+  is the one at 3am under load with half its dependencies failing.
+
+## 3. Canonical citations
+
+- Armstrong, Joe. "Making reliable distributed systems in the presence of
+  software errors." PhD thesis, Swedish Institute of Computer Science,
+  2003. — The original formal treatment of "let it crash" and supervision
+  trees, derived from Erlang/OTP.
+- Nygard, Michael. *Release It! Design and Deploy Production-Ready
+  Software.* 2nd ed., Pragmatic Bookshelf, 2018. — The canonical catalog
+  of stability patterns: circuit breakers, bulkheads, timeouts, steady
+  state, fail fast, handshaking, test harnesses, decoupling middleware,
+  shed load.
+- Beyer, Jones, Petoff, Murphy, eds. *Site Reliability Engineering: How
+  Google Runs Production Systems.* O'Reilly, 2016. — Service level
+  objectives, error budgets, toil, and the operational discipline of
+  running things at scale.
+- Deutsch, Peter. "The Fallacies of Distributed Computing." Sun
+  Microsystems, 1994. — The eight assumptions every distributed system
+  eventually learns it cannot make.
+- Kleppmann, Martin. *Designing Data-Intensive Applications.* O'Reilly,
+  2017. — The modern reference on partition tolerance, consensus, and
+  the real-world implications of the CAP theorem.
+- Kreps, Jay. "The Log: What every software engineer should know about
+  real-time data's unifying abstraction." LinkedIn Engineering, 2013. —
+  Durable append-only logs as a building block for resilient,
+  reprocessable systems.
+- Hohpe, Gregor & Woolf, Bobby. *Enterprise Integration Patterns.*
+  Addison-Wesley, 2003. — The vocabulary for messaging-based decoupling
+  between systems.
+
+## 4. The catechism
+
+Seven derived commitments:
+
+1. **Every external call has a timeout.** Indefinite waits are defects,
+   not defaults. A timeout with a reasoned value is honesty; a missing
+   timeout is a lie about what the function will do under pressure.
+2. **Every retry has backoff and a bound.** A retry without exponential
+   backoff is a failed-load amplifier. A retry without a maximum count
+   is an apology waiting to be written.
+3. **Supervisors own processes.** Armstrong's insight: "let it crash" is
+   only a viable strategy if something is watching the crash, restarting
+   the process, and bounding the blast radius. Unsupervised crashes are
+   not resilient; they are silent.
+4. **Bulkheads isolate failure domains.** One subsystem's saturation must
+   not drown the others. Thread pools, connection pools, and message
+   queues are partitioned so that a failure in the notification path
+   cannot consume the pricing path's resources.
+5. **Circuit breakers are default, not optional.** When a dependency is
+   failing repeatedly, stop calling it for a cooldown period. Fast
+   failure is almost always preferable to slow failure, because slow
+   failure cascades and fast failure degrades gracefully.
+6. **Idempotency by construction.** Every state-mutating operation carries
+   a key that makes retries safe. "Exactly once" is unachievable under
+   partitions; "at least once, with idempotency" is achievable and
+   sufficient.
+7. **Observability from day one.** Structured logs, correlation IDs,
+   health checks, metrics, and distributed traces are inputs to the
+   design. A system that cannot explain itself to its on-call engineer
+   is not resilient; it is merely working, which is a much weaker claim.
+
+## 5. Rule shape this axiom generates
+
+- **Forbid** — external calls without timeouts, retries without backoff,
+  unbounded queues, shared mutable state across services, health checks
+  that test nothing (returning 200 from a function that only verifies
+  the process is alive), log lines without correlation IDs, bare
+  `except:` clauses in anything that touches the network.
+- **Require** — timeouts on every call to anything not in memory,
+  idempotency keys on every state-mutating external call, structured
+  logging with correlation IDs, explicit fallback paths for every
+  dependency, named constants for timeout and retry values.
+- **Prefer** — async message queues for decoupling, circuit breakers for
+  synchronous calls, process isolation for failure domains, explicit
+  degradation modes over silent fallbacks.
+
+A significant fraction of Gaudí's `STAB` family descends from this axiom
+directly. Principle #4 ("failure must be named") is Resilience-First's
+sharpest contribution to the universal core, and Principle #13 ("the
+system must explain itself") is its second. Both are universal, but
+both are stated most uncompromisingly in this school.
+
+## 6. The degenerate case
+
+Every axiom has a failure mode. For Resilience-First, the failure mode
+is **distributed systems as identity**.
+
+- Microservices as resume-driven development. A ten-user internal tool
+  broken into seventeen services, each with its own database, its own
+  CI pipeline, its own deployment story. The operational budget exceeds
+  the problem budget by an order of magnitude, and the reliability is
+  *worse* than the monolith it replaced because now there are seventeen
+  things that can go wrong instead of one.
+- Kubernetes for a batch job that runs once a day and finishes in four
+  minutes.
+- Chaos engineering in a system that does not yet have basic monitoring.
+  You cannot learn from chaos you cannot observe.
+- Observability dashboards nobody reads, alerting on metrics nobody
+  understands, runbooks written by people who never had to follow them.
+- Pattern-worship of the same kind Classical suffers from, but wearing
+  a different hat: circuit breakers in code that has one dependency,
+  bulkheads around a function that runs once a week, idempotency keys
+  on a read-only query.
+- Complexity imported "for reliability" that actually *reduces*
+  reliability because the operational surface exceeds what the team can
+  reason about under pressure.
+
+The test for distributed-systems-as-identity: does the resilience
+machinery match the actual failure modes the system will encounter?
+A Python script that runs on cron does not need a service mesh. A
+consumer-facing payment flow probably does. The machinery should be
+dictated by the blast radius of failure, not by what is fashionable in
+the conference talks of the year.
+
+## 7. Exemplar temptation
+
+When writing the Resilience-First implementation of the canonical task,
+the exemplar must navigate two opposite temptations:
+
+- **The happy-path shortcut.** It will be tempting to write the order
+  pipeline as a straight-through function and hand-wave the failure
+  paths. The Resilience-First exemplar must refuse — timeouts, retries,
+  backoff, idempotency keys, circuit breakers, supervised subsystems,
+  structured logs, and health checks must all be present, and each must
+  be a real piece of the design rather than a stub with a TODO.
+- **The distributed-systems parody.** It will also be tempting to split
+  the exemplar into seven microservices communicating over a real
+  message broker running in Docker Compose. The exemplar must refuse
+  this too. Resilience is a *property*, not a deployment topology. The
+  order pipeline should be a single process with clearly delineated
+  subsystems, each of which could be split out later if the failure
+  modes demanded it, and none of which must be split to demonstrate
+  the axiom.
+
+The faithful Resilience-First exemplar is the one where: every external
+call has a timeout with a reasoned value; every retry has exponential
+backoff and a maximum; every state-mutating call carries an idempotency
+key; every log line is structured and carries a correlation ID that
+follows the order through every stage; at least one circuit breaker
+guards a dependency the exemplar explicitly treats as flaky; and the
+system can produce a meaningful health report when queried.
+
+## 8. Rubric — how to recognize a faithful Resilience-First fixture
+
+- [ ] **Every function that touches anything beyond memory has an
+      explicit timeout.** Database calls, HTTP calls, filesystem reads
+      on unknown-size inputs, subprocess invocations — all timeout
+      explicitly, and the timeout value is a named constant.
+- [ ] **Every retry loop uses exponential backoff and a maximum attempt
+      count.** The backoff is a real calculation, not a fixed sleep.
+- [ ] **Every state-mutating external call carries an idempotency key.**
+      The key generation is deterministic and the exemplar documents
+      how.
+- [ ] **Every log line is structured** (JSON or equivalent key-value
+      form) and carries a correlation ID that follows an order through
+      every stage of the pipeline.
+- [ ] **At least one circuit breaker or bulkhead is present** guarding
+      a dependency the exemplar treats as potentially flaky, and the
+      exemplar documents why.
+- [ ] **Timeouts, retry counts, and circuit-breaker thresholds are named
+      constants or config values**, not magic numbers scattered through
+      the code.
+- [ ] **A health check endpoint exists** that tests actual capability
+      (the database is reachable, the pricing service responds) rather
+      than merely reporting that the process is alive.
+- [ ] **No shared mutable state crosses a trust boundary** without a
+      synchronization primitive or an explicit owner documented in a
+      comment.
+- [ ] **Subsystems have explicit failure modes documented in the code**
+      — what happens to an order if pricing fails? If inventory fails?
+      If the notification service is down? Each answer is in the code
+      as a real path, not in a future TODO.
+- [ ] **The system produces enough telemetry** (logs, metrics, or both)
+      that an on-call engineer could diagnose a realistic failure mode
+      by reading the output, without attaching a debugger.
+
+Ten out of ten is Resilience-First. Eight or nine is a draft. Seven or
+fewer is happy-path code with a monitoring afterthought.
+
+---
+
+## See also
+
+- [docs/philosophy/event-sourced.md](event-sourced.md) — Event sourcing
+  and resilience are natural allies: an append-only log is durable, a
+  stream of events is replayable, and replay is the ultimate recovery
+  primitive.
+- [docs/philosophy/classical.md](classical.md) — Classical favors the
+  beautifully structured monolith; Resilience-First would break that
+  monolith apart along failure-domain lines even at the cost of
+  structural elegance. A real conflict.
+- [docs/principles.md](../principles.md) — Principles #4 (failure must
+  be named) and #13 (the system must explain itself) are this school's
+  direct contributions to the universal core.

--- a/docs/philosophy/unix.md
+++ b/docs/philosophy/unix.md
@@ -1,0 +1,211 @@
+# Unix / Minimalist — Axiom Sheet
+
+> *Do one thing well. Compose via text.*
+
+---
+
+## 1. Prime axiom
+
+> **A program should do one thing well. Large behavior is built by composing
+> small programs through a shared, universal, human-readable interface —
+> and the smaller the program, the more honest it can be about what it does.**
+
+The Unix school treats complexity as the enemy and composition as the cure.
+A small tool can be held entirely in the reader's head. A pipeline of small
+tools inherits the readability of each of its stages, because the interface
+between stages is plain text that any engineer can inspect with `cat`. Large
+monolithic programs trade that inspectability for convenience, and then
+charge interest on the trade for the rest of their lives.
+
+## 2. The rejected alternative
+
+Unix architecture refuses:
+
+- **Frameworks that own the main loop.** The Rails/Django/Spring model —
+  where the framework calls your code and you can only hook into its
+  blessed extension points — is the direct negation of the Unix axiom.
+- **Binary protocols by default.** A protocol you cannot debug with
+  `less` is a protocol that will, sooner or later, require tooling the
+  Unix tradition has spent fifty years avoiding.
+- **Deep inheritance hierarchies.** An object whose behavior is distributed
+  across eight superclasses is opaque in a way no Unix program can afford.
+- **Abstraction layers that do not compose.** A wrapper, adapter, or
+  facade that exists to make one API look like another — but cannot be
+  used independently or piped into something else — adds mass without
+  adding composability.
+- **Dependencies for what the standard library provides.** Every dependency
+  is a future compatibility problem; the first question is always "can we
+  do without?"
+- **Vendor lock-in.** Any API surface that cannot be replaced with
+  equivalent plumbing in an afternoon is a liability held against the
+  project.
+- **Import-time side effects.** A module that changes the world when
+  imported is a module that cannot be trusted to do *only* what its
+  interface claims.
+
+## 3. Canonical citations
+
+- McIlroy, Doug. "Programming pearls: a little language." *Communications
+  of the ACM*, 1986. — The originating piece on Unix pipes as the
+  composition model.
+- Kernighan, Brian & Pike, Rob. *The Unix Programming Environment.*
+  Prentice Hall, 1984. — The canonical text. Every example is still
+  pedagogically alive.
+- Raymond, Eric S. *The Art of Unix Programming.* Addison-Wesley, 2003. —
+  The explicit enumeration of the seventeen rules (modularity, clarity,
+  composition, separation, simplicity, parsimony, transparency,
+  robustness, representation, least surprise, silence, repair, economy,
+  generation, optimization, diversity, extensibility).
+- Pike, Rob. "Notes on Programming in C." 1989. — The five rules that
+  compress much of the Unix sensibility into five paragraphs.
+- Pike, Rob. "Simplicity is Complicated." dotGo, 2015. — The Go
+  standard-library philosophy as modern Unix inheritance.
+- Gancarz, Mike. *The Unix Philosophy.* Digital Press, 1994. — An
+  independent, accessible gloss on the same principles.
+- Salus, Peter. *A Quarter-Century of Unix.* Addison-Wesley, 1994. —
+  The historical context for why this philosophy took the shape it did.
+
+## 4. The catechism
+
+Seven derived commitments:
+
+1. **Do one thing well.** A program whose description needs the word "and"
+   is two programs sharing a binary. Split them.
+2. **Compose via standard streams.** Text flowing through stdin and stdout
+   is the universal interface, because every tool ever written for Unix
+   can already speak it.
+3. **Flat is better than nested.** A directory tree with three levels is
+   a tree that can be held in the head. A tree with ten levels is a tree
+   that requires a map.
+4. **Configuration files over code.** Tuning is not recompilation. A
+   plain-text config (TOML, INI, even just environment variables) lets
+   the same program serve many masters.
+5. **Minimal dependencies.** The first question for any dependency is
+   "can the stdlib do this?" The second is "is the saving worth the
+   compatibility surface?" The default answer to "should we add a library?"
+   is no.
+6. **Worse is better.** A simple solution that is 90% correct today beats
+   a perfect solution shipped next year. Richard Gabriel's phrasing, but
+   the sentiment is older and the Unix tradition is its native home.
+7. **The standard library is the architecture.** Your project's
+   architecture should be derivable from what is in the stdlib, plus a
+   very small number of additions each of which you could justify aloud
+   in one sentence.
+
+## 5. Rule shape this axiom generates
+
+- **Forbid** — framework lock-in, deep inheritance, non-text configuration
+  when text would serve, dependencies the stdlib duplicates, monolithic
+  entry points that do multiple jobs, import-time side effects, modules
+  that cannot be imported independently.
+- **Require** — each module invokable as a standalone program, plain-text
+  data formats at boundaries, meaningful exit codes, stderr for diagnostics
+  and stdout for data, composable shell pipelines that reproduce behavior.
+- **Prefer** — flat package layouts, small independent scripts over one
+  large application, plain dicts and tuples at module boundaries over
+  custom classes, the `re` module over a PEG parser, `json` over a
+  bespoke serialization format.
+
+The Unix axiom is the one the Gaudí project itself most resembles at the
+tool level: `gaudi check` is a program that reads files and writes a
+report to stdout, with findings formatted so that `grep ERROR` works.
+That is not an accident — it is an inheritance.
+
+## 6. The degenerate case
+
+Every axiom has a failure mode. For Unix, the failure mode is
+**minimalism as pride**.
+
+- Shell script spaghetti — seven thousand lines of Bash because "it
+  avoided a dependency on Python." The dependency has been replaced by
+  a custom, untested, unmaintainable language embedded inside a shell.
+- Reinventing libraries to avoid importing them, producing weaker,
+  buggier versions of well-tested wheels.
+- A dozen tiny programs so fragmented that no single person can hold
+  the whole system in their head. The composition was supposed to be the
+  feature; instead it has become the liability.
+- "Small" that means "partial" — a tool that does its one thing, but
+  does it halfway, and leaves the other half as an exercise for the user
+  who expected it to work.
+- The Suckless-pilled engineer who ships a broken text editor because
+  any dependency is impure. Minimalism has become an identity, and the
+  identity is doing the work that judgment should do.
+- Hubris masquerading as humility: "We don't need Django; we'll write
+  our own web framework." Two years later the project has reinvented
+  three-quarters of Django, badly, and shipped nothing.
+
+The test for minimalism-as-pride: ask whether a reasonable reader would
+reach for the same tools. If the answer is "no, they would have used
+`requests` / `click` / `pytest` and saved themselves a month," the
+minimalism has turned into ceremony.
+
+## 7. Exemplar temptation
+
+When writing the Unix implementation of the canonical task, the exemplar
+must navigate two opposite temptations:
+
+- **The convenience shortcut.** It will be tempting to reach for Django,
+  SQLAlchemy, Pydantic, Click, or FastAPI. The Unix exemplar must refuse
+  — the point is that the stdlib and small independent scripts can carry
+  this load, and the discipline of refusing is the teaching. That refusal
+  is what makes the exemplar faithful.
+- **The ceremonial shortcut.** It will also be tempting to refuse the
+  `re` module, write a custom parser, refuse `json`, invent a framing
+  protocol. The Unix exemplar must refuse this too. The stdlib is not
+  the enemy; needless dependencies are. Using `json.dumps` to serialize
+  events between pipeline stages is exactly what the Unix tradition
+  recommends — plain text, a universal parser, nothing fancy.
+
+The faithful Unix exemplar is the one where: the order pipeline is a
+sequence of small Python scripts, each of which reads JSON-lines from
+stdin and writes JSON-lines to stdout; each script has a `main()` that
+can be invoked as `python order_validate.py < orders.jsonl`; the
+dependency list is `[]`; the directory tree is flat; and a shell
+one-liner can pipe all the stages together end-to-end.
+
+## 8. Rubric — how to recognize a faithful Unix fixture
+
+- [ ] **The implementation is composed of small, independent modules**,
+      each with a `main()` or equivalent CLI entry point.
+- [ ] **Inter-module communication is via plain data** — stdin/stdout
+      streams of JSON-lines, or function returns of plain dicts/tuples.
+      No class hierarchies cross module boundaries.
+- [ ] **Dependencies beyond the Python standard library are zero**, or
+      every non-stdlib dependency is justified in a one-sentence comment
+      naming the stdlib gap it fills.
+- [ ] **The directory tree is flat** — one or two levels, readable at a
+      glance with `ls`.
+- [ ] **Configuration lives in a plain-text file**, not in Python code.
+      The exemplar demonstrates a config being loaded and used.
+- [ ] **Every module can be invoked independently from the command line**
+      with meaningful behavior. `python validate.py --help` works. The
+      full pipeline is reproducible as a shell one-liner.
+- [ ] **Exit codes communicate success or failure** at the OS level.
+      Stderr carries diagnostics; stdout carries data.
+- [ ] **No framework magic.** No decorators that mutate globals, no
+      metaclasses, no import-time side effects, no auto-discovery of
+      classes by walking the module tree.
+- [ ] **Classes exist only where a module could not replace them.** If a
+      class is just a namespace for related functions, it is a module in
+      disguise and should be dissolved.
+- [ ] **A shell pipeline of the modules reproduces the end-to-end
+      behavior.** `cat orders.jsonl | python validate.py | python
+      price.py | python reserve.py | python notify.py` produces the
+      same results as the in-process run.
+
+Ten out of ten is Unix. Eight or nine is a draft. Seven or fewer is a
+framework application with a minimalist accent.
+
+---
+
+## See also
+
+- [docs/philosophy/convention.md](convention.md) — Unix's structural
+  opposite. A convention-driven framework and a Unix pipeline are
+  irreconcilable axioms about where complexity should live.
+- [docs/philosophy/classical.md](classical.md) — Classical architecture
+  builds cathedrals; Unix builds toolsheds. Both can be beautiful; they
+  are beautiful by different measures.
+- [docs/principles.md](../principles.md) — Principle #7 (layers must
+  earn their existence) is the principle closest to the Unix sensibility
+  in Gaudí's universal core.


### PR DESCRIPTION
## Summary

- Adds `docs/philosophy/` with eight axiom sheets (Classical, Pragmatic, Functional, Unix, Resilience-First, Data-Oriented, Convention, Event-Sourced) plus a README index.
- Each sheet follows a strict eight-section format: prime axiom, rejected alternatives, canonical citations, catechism, rule shape, degenerate case, exemplar temptation, and a ten-item rubric for scoring fixtures.
- Docs only. No code changes. No new dependencies.

## Motivation

Gaudí v0.1.0 implicitly assumes a single Classical/Structural philosophy of good architecture, which produces false positives when linting codebases that are well-architected under a different set of axioms (e.g., Django under Convention, a functional core under Functional, a game engine under Data-Oriented).

These sheets are the scaffolding for three downstream pieces of work:

1. **Phase 0b — the rule audit.** Every rule in `docs/rule-registry.md` will be tagged with its philosophy scope (`universal` or a specific school), appealing to the relevant axiom sheet to justify the tag.
2. **Phase 0c — the canonical task.** A single domain problem (order processing pipeline) will be implemented eight ways, once per school, each scored against its school's rubric.
3. **Phase 0d+ — reference exemplars.** Eight working implementations demonstrating each school's faithful expression of the canonical task.
4. **(Deferred) engine change.** `Rule.philosophy_scope` and `[philosophy].school` config wiring will be added *after* the audit tells us how much machinery the catalog actually needs.

The sheets appeal directly to Principle #12 (tests are the specification): a fixture cannot exemplify a philosophy that has not been stated in falsifiable terms first.

## Why eight, not seven

The original RFC proposed seven. Event-Sourced was added because it passes the only admission test that matters: it generates rules that *contradict* rules from existing schools (mutation on aggregates, UPDATE statements on event stores, current-state-as-source-of-truth) rather than merely stacking with them. The README documents this test and lists the candidates that were considered and rejected (Type-Driven, Actor, Literate, Live/Image-Based) along with the reasoning.

## Test plan

- [x] `ruff check .` — clean
- [x] `ruff format --check .` — 514 files formatted
- [x] `pytest --tb=short -q` — 494 passed
- [x] `gaudi check` — no new findings introduced (docs-only change)
- [x] Each sheet follows the same eight-section structure
- [x] Each sheet cites published, citable sources per Rule Acceptance Test #1
- [x] Each rubric has exactly ten items and is operationalized for fixture scoring

## Security considerations

N/A — docs only, no dependencies, no CI changes.