### PR TITLE
feat(engine): Rule.philosophy_scope and [philosophy].school wiring

### DIFF
--- a/src/gaudi/config.py
+++ b/src/gaudi/config.py
@@ -19,11 +19,14 @@ else:
         import tomli as tomllib
 
 
-DEFAULT_CONFIG = {
+from gaudi.core import DEFAULT_SCHOOL, VALID_SCHOOLS
+
+DEFAULT_CONFIG: dict[str, Any] = {
     "packs": [],  # empty = auto-detect
     "severity": "info",
     "exclude": [],
     "rules": {},
+    "philosophy": {"school": DEFAULT_SCHOOL},
 }
 
 
@@ -31,19 +34,45 @@ def load_config(project_path: Path) -> dict[str, Any]:
     """
     Load configuration from gaudi.toml in the project root.
 
-    Falls back to defaults if no config file exists.
+    Falls back to defaults if no config file exists. Merges the
+    ``[gaudi]`` table (general settings) with the ``[philosophy]``
+    table (architectural school selection).
     """
     config_path = project_path / "gaudi.toml"
 
     if not config_path.exists():
-        return dict(DEFAULT_CONFIG)
+        return _clone_defaults()
 
     with open(config_path, "rb") as f:
         raw = tomllib.load(f)
 
-    gaudi_config = raw.get("gaudi", {})
+    config = _clone_defaults()
 
-    config = dict(DEFAULT_CONFIG)
-    config.update({k: v for k, v in gaudi_config.items() if k in DEFAULT_CONFIG})
+    gaudi_config = raw.get("gaudi", {})
+    config.update({k: v for k, v in gaudi_config.items() if k in config and k != "philosophy"})
+
+    philosophy_table = raw.get("philosophy")
+    if isinstance(philosophy_table, dict):
+        merged = dict(config["philosophy"])
+        merged.update(philosophy_table)
+        config["philosophy"] = merged
+
+    school = config["philosophy"].get("school", DEFAULT_SCHOOL)
+    if school not in VALID_SCHOOLS:
+        raise ValueError(
+            f"gaudi.toml [philosophy].school is {school!r}; must be one of {sorted(VALID_SCHOOLS)}"
+        )
 
     return config
+
+
+def _clone_defaults() -> dict[str, Any]:
+    clone = dict(DEFAULT_CONFIG)
+    clone["philosophy"] = dict(DEFAULT_CONFIG["philosophy"])
+    return clone
+
+
+def get_school(config: dict[str, Any]) -> str:
+    """Return the active philosophy school for a loaded config dict."""
+    philosophy = config.get("philosophy") or {}
+    return philosophy.get("school", DEFAULT_SCHOOL)

--- a/src/gaudi/core.py
+++ b/src/gaudi/core.py
@@ -126,12 +126,40 @@ class Finding:
         return "\n".join(lines)
 
 
+UNIVERSAL_SCOPE: frozenset[str] = frozenset({"universal"})
+
+VALID_SCHOOLS: frozenset[str] = frozenset(
+    {
+        "classical",
+        "pragmatic",
+        "functional",
+        "unix",
+        "resilient",
+        "data-oriented",
+        "convention",
+        "event-sourced",
+    }
+)
+
+VALID_SCOPE_TOKENS: frozenset[str] = VALID_SCHOOLS | {"universal"}
+
+DEFAULT_SCHOOL: str = "classical"
+
+
 class Rule:
     """
     Base class for all Gaudí rules.
 
     Subclass this to create custom architectural checks. Each rule
     must define a code, severity, category, and implement the check() method.
+
+    Every rule also declares a ``philosophy_scope`` — the set of architectural
+    schools under which the rule is defensible. The default ``{"universal"}``
+    means the rule descends from the three pillars and holds in every school;
+    a rule that depends on school-specific axioms should list the schools
+    explicitly (e.g. ``{"pragmatic", "functional"}``). See
+    ``docs/philosophy/`` for the axiom sheets and ``docs/rule-registry.md``
+    for the scope audit.
 
     Example:
         class CheckTenantIsolation(Rule):
@@ -156,6 +184,7 @@ class Rule:
     message_template: str = ""
     recommendation_template: str = ""
     requires_library: str | None = None
+    philosophy_scope: frozenset[str] = UNIVERSAL_SCOPE
 
     def check(self, context: Any) -> list[Finding]:
         """

--- a/src/gaudi/pack.py
+++ b/src/gaudi/pack.py
@@ -14,7 +14,19 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any
 
-from gaudi.core import Finding, Rule
+from gaudi.core import DEFAULT_SCHOOL, Finding, Rule
+
+
+def rule_applies_to_school(rule: Rule, school: str) -> bool:
+    """Return True iff this rule should run under the given school.
+
+    A rule runs when its ``philosophy_scope`` either includes the active
+    school or declares ``"universal"``. Rules that declare no scope at
+    all default to ``{"universal"}`` via the class attribute on
+    ``Rule``, so no rule is ever silently skipped.
+    """
+    scope = rule.philosophy_scope
+    return "universal" in scope or school in scope
 
 
 class Pack:
@@ -66,15 +78,18 @@ class Pack:
         """
         raise NotImplementedError(f"Pack '{self.name}' must implement parse()")
 
-    def check(self, path: Path) -> list[Finding]:
+    def check(self, path: Path, school: str = DEFAULT_SCHOOL) -> list[Finding]:
         """
-        Parse the project and run all registered rules.
+        Parse the project and run all registered rules that apply under
+        the given architectural school.
 
         Returns a list of findings sorted by severity.
         """
         context = self.parse(path)
         findings: list[Finding] = []
         for rule in self._rules:
+            if not rule_applies_to_school(rule, school):
+                continue
             results = rule.check(context)
             if results:
                 findings.extend(results)

--- a/src/gaudi/packs/ops/pack.py
+++ b/src/gaudi/packs/ops/pack.py
@@ -4,8 +4,9 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from gaudi.core import Finding
-from gaudi.pack import Pack
+from gaudi.config import get_school, load_config
+from gaudi.core import DEFAULT_SCHOOL, Finding
+from gaudi.pack import Pack, rule_applies_to_school
 from gaudi.packs.ops.context import OpsContext
 from gaudi.packs.ops.parser import parse_project
 from gaudi.packs.ops.rules import ALL_RULES
@@ -24,10 +25,16 @@ class OpsPack(Pack):
     def parse(self, path: Path) -> OpsContext:
         return parse_project(path)
 
-    def check(self, path: Path) -> list[Finding]:
+    def check(self, path: Path, school: str | None = None) -> list[Finding]:
+        if school is None:
+            project_root = path if path.is_dir() else path.parent
+            school = get_school(load_config(project_root))
+        active_school = school or DEFAULT_SCHOOL
         context = self.parse(path)
         findings: list[Finding] = []
         for rule in self._rules:
+            if not rule_applies_to_school(rule, active_school):
+                continue
             results = rule.check(context)
             if results:
                 findings.extend(results)

--- a/src/gaudi/packs/python/context.py
+++ b/src/gaudi/packs/python/context.py
@@ -118,6 +118,9 @@ class PythonContext:
     has_requirements: bool = False
     has_pyproject: bool = False
     detected_libraries: set[str] = field(default_factory=set)
+    # The architectural school this project has declared in gaudi.toml.
+    # Defaults to "classical" when unset, matching the engine default.
+    school: str = "classical"
 
     @property
     def model_names(self) -> set[str]:

--- a/src/gaudi/packs/python/pack.py
+++ b/src/gaudi/packs/python/pack.py
@@ -2,9 +2,9 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from gaudi.config import load_config
-from gaudi.core import Finding
-from gaudi.pack import Pack
+from gaudi.config import get_school, load_config
+from gaudi.core import DEFAULT_SCHOOL, Finding
+from gaudi.pack import Pack, rule_applies_to_school
 from gaudi.packs.python.context import PythonContext
 from gaudi.packs.python.parser import parse_project
 from gaudi.packs.python.rules import ALL_RULES
@@ -26,13 +26,18 @@ class PythonPack(Pack):
         project_root = path if path.is_dir() else path.parent
         config = load_config(project_root)
         extra_excludes = list(config.get("exclude") or [])
-        return parse_project(path, extra_excludes=extra_excludes)
+        context = parse_project(path, extra_excludes=extra_excludes)
+        context.school = get_school(config)
+        return context
 
-    def check(self, path: Path) -> list[Finding]:
+    def check(self, path: Path, school: str | None = None) -> list[Finding]:
         context = self.parse(path)
+        active_school = school or context.school or DEFAULT_SCHOOL
         findings: list[Finding] = []
         for rule in self._rules:
             if rule.requires_library and rule.requires_library not in context.detected_libraries:
+                continue
+            if not rule_applies_to_school(rule, active_school):
                 continue
             results = rule.check(context)
             if results:

--- a/tests/test_philosophy_scope.py
+++ b/tests/test_philosophy_scope.py
@@ -1,0 +1,131 @@
+"""Unit tests for the Phase 1 philosophy-scope engine change.
+
+These tests cover three discrete concerns and nothing else:
+
+1. ``rule_applies_to_school`` obeys the one-predicate rule described in
+   ``docs/philosophy/README.md``.
+2. ``load_config`` parses ``[philosophy].school``, defaults it when
+   absent, and raises on invalid schools.
+3. Every currently-registered Python rule has a valid ``philosophy_scope``
+   — a frozenset of known tokens. This is the guardrail that protects
+   the eventual PR B tagging work from typos and stale tokens.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from gaudi.config import get_school, load_config
+from gaudi.core import (
+    DEFAULT_SCHOOL,
+    UNIVERSAL_SCOPE,
+    VALID_SCHOOLS,
+    VALID_SCOPE_TOKENS,
+    Rule,
+    Severity,
+)
+from gaudi.pack import rule_applies_to_school
+from gaudi.packs.python.rules import ALL_RULES
+
+
+class _ScopedRule(Rule):
+    code = "TEST-SCOPE-001"
+    severity = Severity.INFO
+    philosophy_scope = frozenset({"pragmatic", "unix"})
+
+    def check(self, context):  # pragma: no cover - never invoked
+        return []
+
+
+class _UniversalRule(Rule):
+    code = "TEST-SCOPE-002"
+    severity = Severity.INFO
+
+    def check(self, context):  # pragma: no cover
+        return []
+
+
+class TestRuleAppliesToSchool:
+    def test_universal_rule_runs_under_every_school(self) -> None:
+        rule = _UniversalRule()
+        for school in VALID_SCHOOLS:
+            assert rule_applies_to_school(rule, school), (
+                f"universal rule should apply under {school!r}"
+            )
+
+    def test_scoped_rule_runs_only_under_its_declared_schools(self) -> None:
+        rule = _ScopedRule()
+        assert rule_applies_to_school(rule, "pragmatic")
+        assert rule_applies_to_school(rule, "unix")
+        assert not rule_applies_to_school(rule, "classical")
+        assert not rule_applies_to_school(rule, "functional")
+
+    def test_rule_with_universal_and_specific_scope_always_runs(self) -> None:
+        rule = _UniversalRule()
+        rule.philosophy_scope = frozenset({"universal", "classical"})
+        # universal token short-circuits — this rule runs everywhere.
+        for school in VALID_SCHOOLS:
+            assert rule_applies_to_school(rule, school)
+
+
+class TestConfigPhilosophy:
+    def test_defaults_to_classical_when_file_missing(self, tmp_path: Path) -> None:
+        config = load_config(tmp_path)
+        assert get_school(config) == DEFAULT_SCHOOL == "classical"
+
+    def test_respects_explicit_school(self, tmp_path: Path) -> None:
+        (tmp_path / "gaudi.toml").write_text(
+            '[philosophy]\nschool = "functional"\n',
+            encoding="utf-8",
+        )
+        config = load_config(tmp_path)
+        assert get_school(config) == "functional"
+
+    def test_preserves_existing_gaudi_table(self, tmp_path: Path) -> None:
+        (tmp_path / "gaudi.toml").write_text(
+            '[gaudi]\nexclude = ["build/"]\n\n[philosophy]\nschool = "unix"\n',
+            encoding="utf-8",
+        )
+        config = load_config(tmp_path)
+        assert get_school(config) == "unix"
+        assert config["exclude"] == ["build/"]
+
+    def test_invalid_school_raises(self, tmp_path: Path) -> None:
+        (tmp_path / "gaudi.toml").write_text(
+            '[philosophy]\nschool = "gibberish"\n',
+            encoding="utf-8",
+        )
+        with pytest.raises(ValueError, match="philosophy"):
+            load_config(tmp_path)
+
+    def test_defaults_when_philosophy_table_absent(self, tmp_path: Path) -> None:
+        (tmp_path / "gaudi.toml").write_text(
+            '[gaudi]\nexclude = ["build/"]\n',
+            encoding="utf-8",
+        )
+        config = load_config(tmp_path)
+        assert get_school(config) == "classical"
+
+
+class TestRegisteredRuleScopes:
+    def test_every_python_rule_has_a_frozenset_scope(self) -> None:
+        for rule_cls in ALL_RULES:
+            scope = rule_cls.philosophy_scope
+            assert isinstance(scope, frozenset), (
+                f"{rule_cls.__name__} philosophy_scope must be a frozenset, "
+                f"got {type(scope).__name__}"
+            )
+            assert scope, f"{rule_cls.__name__} philosophy_scope must not be empty"
+
+    def test_every_python_rule_uses_known_tokens(self) -> None:
+        for rule_cls in ALL_RULES:
+            unknown = rule_cls.philosophy_scope - VALID_SCOPE_TOKENS
+            assert not unknown, (
+                f"{rule_cls.__name__} philosophy_scope contains unknown tokens: "
+                f"{sorted(unknown)}. Valid tokens: {sorted(VALID_SCOPE_TOKENS)}"
+            )
+
+    def test_default_scope_on_base_rule_is_universal(self) -> None:
+        assert Rule.philosophy_scope == UNIVERSAL_SCOPE


### PR DESCRIPTION
## Summary

- Adds the scope-filtering machinery the audit (#156) and Classical exemplar (#158) established as necessary, without yet tagging any existing rule as scoped.
- **Behavior-preserving by design.** Every current rule defaults to `frozenset({"universal"})` via the class attribute on `Rule`, so `gaudi check` output on every existing project is unchanged.
- 11 new unit tests, total now 517 (was 506).

## The machinery

| File | Change |
|---|---|
| `src/gaudi/core.py` | `UNIVERSAL_SCOPE`, `VALID_SCHOOLS`, `VALID_SCOPE_TOKENS`, `DEFAULT_SCHOOL = "classical"`, and `Rule.philosophy_scope: frozenset[str] = UNIVERSAL_SCOPE` on the base class. |
| `src/gaudi/config.py` | `[philosophy]` table parsed separately from `[gaudi]`, defaulted, and validated. `get_school(config)` helper reads it back. Invalid school → `ValueError`. |
| `src/gaudi/pack.py` | `rule_applies_to_school(rule, school)` — the one predicate the base `Pack.check()` uses to filter rules. |
| `src/gaudi/packs/python/pack.py` | Plumbs school through, honors the filter, and sets `context.school` so rules can inspect the active school if they need to. |
| `src/gaudi/packs/ops/pack.py` | Same treatment for the ops pack. |
| `src/gaudi/packs/python/context.py` | `PythonContext.school: str = "classical"` field. |

## The rule

```python
def rule_applies_to_school(rule: Rule, school: str) -> bool:
    scope = rule.philosophy_scope
    return "universal" in scope or school in scope
```

That is the entire engine change. One predicate. Everything else is plumbing.

## Why behavior is preserved

Every existing rule inherits `philosophy_scope = frozenset({"universal"})` from `Rule`. The predicate short-circuits to True on `"universal"` for any school, so no rule is filtered out until PR B explicitly tags it.

Before PR B lands, a tag conflict or scope typo cannot silently drop a rule.

## Tests

- `TestRuleAppliesToSchool` — universal rules run under every school; scoped rules run only under declared schools; a scope containing both `"universal"` and a specific school still runs everywhere.
- `TestConfigPhilosophy` — defaults to `"classical"` when file/table is missing, respects explicit school, preserves `[gaudi]` alongside `[philosophy]`, raises on invalid tokens.
- `TestRegisteredRuleScopes` — **the guardrail:** every currently-registered Python rule has a non-empty frozenset scope built from known tokens. This is what protects PR B's tagging work from typos and stale tokens.

## Test plan

- [x] `ruff check .` — clean
- [x] `ruff format --check .` — 531 files formatted
- [x] `pytest --tb=short -q` — **517 passed** (was 506; +11 new)
- [x] `gaudi check` on the project itself — no change in findings on production code
- [x] Docs-first-class rules still fire correctly (SMELL-014, ARCH-002, etc. all report unchanged counts)

## What lands next

- **PR B** — tag the ~22 scoped rules per the audit in `docs/rule-registry.md`. This is where the six SMELL-014 false positives on the Classical exemplar will disappear.
- **PR C** — matrix test pinning expected-finding deltas per school, so future regressions are caught.

## Security considerations

N/A — no new dependencies, no network, no filesystem outside the existing config-loading path. The new `ValueError` on invalid school is fail-fast and surfaces a clear error message.