### PR TITLE
test(philosophy): Functional reference exemplar of canonical task

### DIFF
--- a/tests/philosophy/functional/__init__.py
+++ b/tests/philosophy/functional/__init__.py
@@ -1,0 +1,1 @@
+"""Functional / Algebraic reference implementations."""

--- a/tests/philosophy/functional/canonical/README.md
+++ b/tests/philosophy/functional/canonical/README.md
@@ -1,0 +1,184 @@
+# Functional / Algebraic — Reference Exemplar
+
+**Canonical task:** Order processing pipeline ([docs/philosophy/canonical-task.md](../../../../docs/philosophy/canonical-task.md))
+**Axiom sheet:** [docs/philosophy/functional.md](../../../../docs/philosophy/functional.md)
+**Rubric score:** 10/10
+
+The third reference implementation of the canonical task, completing
+the triangle **Classical ↔ Pragmatic ↔ Functional** that every later
+school's exemplar can be compared against. Every value is immutable.
+Every error is returned as data. Every function is a pure
+transformation. The core imports nothing from logging, os, requests,
+or the clock.
+
+---
+
+## Running it
+
+```bash
+conda run -n Oversteward pytest tests/philosophy/functional/ -v
+```
+
+Fourteen tests exercise the same acceptance criteria the Classical
+and Pragmatic exemplars pass — the ten parametrized seed-data cases
+plus four Functional-specific assertions:
+
+1. ``test_confirmed_order_decrements_available_inventory`` — threads
+   the world through two successive calls, demonstrating that the
+   reservation persisted without mutation.
+2. ``test_out_of_stock_order_does_not_partially_reserve`` — rejected
+   orders return the world *unchanged* (same object identity), and
+   the follow-up order still succeeds at full quantity.
+3. ``test_process_order_is_referentially_transparent`` — calling
+   ``process_order`` twice on the same world produces equal
+   outcomes and equal worlds. Catechism #7 as a test.
+4. ``test_core_is_free_of_io_imports`` — the pipeline module is
+   grepped for forbidden imports (``logging``, ``os``, ``requests``,
+   ``sqlite3``, ``from time import``) and for any ``datetime.now(``
+   call. Catechism #3 as a structural proof.
+
+---
+
+## Directory shape
+
+```
+canonical/
+├── README.md    # this file
+├── result.py    # Ok[T] / Err[E] frozen value types
+├── models.py    # 10 frozen dataclasses, zero methods
+└── pipeline.py  # pure functions + process_order composition
+```
+
+Three source files. No service layer, no infrastructure layer, no
+composition root separate from the caller. The input state is a
+single ``World`` record; the output is a ``(Outcome, World)`` tuple.
+Threading the new world through successive calls is the caller's
+job, not the pipeline's.
+
+---
+
+## Rubric score against [functional.md](../../../../docs/philosophy/functional.md)
+
+| # | Check | ✓/✗ | Evidence |
+|---|---|---|---|
+| 1 | No mutation of passed-in arguments | ✓ | Every function returns new values. ``reserve_inventory`` builds a fresh dict. ``process_order`` uses ``dataclasses.replace`` to produce a new ``World``. |
+| 2 | All domain dataclasses are ``frozen=True`` | ✓ | Every class in ``models.py`` is ``@dataclass(frozen=True)`` and every class has **zero** methods. Helpers that read from records live as free functions in ``pipeline.py``. |
+| 3 | I/O isolated at the edges | ✓ | ``pipeline.py`` imports only ``dataclasses.replace``, ``datetime``, ``decimal.Decimal``, ``typing.Mapping``, and the local ``models`` + ``result`` modules. No ``logging``, ``os``, ``requests``, ``sqlite3``, or ``datetime.now()``. Time is passed in as a value. ``test_core_is_free_of_io_imports`` is the structural enforcement. |
+| 4 | Errors are returned as values, not raised | ✓ | ``Ok[T]`` and ``Err[E]`` are frozen dataclasses in ``result.py``. Every validation step returns a ``Result``; the pipeline uses ``isinstance`` early-return checks to thread errors. No ``raise`` anywhere except the test file. |
+| 5 | No shared mutable globals | ✓ | The pipeline has no module-level state. Reservation IDs are passed in as function arguments; there is no ``itertools.count`` holding a hidden counter. |
+| 6 | For-loops with accumulators absent where map/filter/reduce would serve | ✓ mostly | ``compute_subtotal`` is a generator + ``sum``. ``find_insufficient_skus`` is a comprehension. ``reserve_inventory`` is a dict comprehension plus one small delta-building loop. ``resolve_lines`` is a small for-loop with early return on error — the honest Python translation of threading errors, rather than pretending Python has ``traverse``. |
+| 7 | Type annotations are dense and meaningful | ✓ | Every public function's parameters and return are typed. ``Result`` uses ``Generic[T]``. No bare ``Any``. No ``Optional`` where a ``Result`` would tell the truth more precisely — the one ``\| None`` case is ``Order.promo_code``, which is a field of the input, not a return value. |
+| 8 | Inheritance only for ``Protocol`` / ABC definitions | ✓ | Zero inheritance in this exemplar. Frozen dataclasses do not count as inheritance — they are value records. No ``Protocol``s are needed because the pipeline uses plain ``Mapping`` types at every boundary. |
+| 9 | Composition is explicit | ✓ | ``process_order`` is a straight-line composition of ``validate_customer`` → ``resolve_lines`` → ``find_insufficient_skus`` → ``compute_final_price`` → ``reserve_inventory``. Each step is a named pure function that can be unit-tested in isolation. |
+| 10 | Any function in the core can be evaluated in the REPL | ✓ | Demonstrable: ``from tests.philosophy.functional.canonical.pipeline import compute_subtotal; compute_subtotal(())`` returns ``Decimal(0)`` without staging a database, a filesystem, or a clock. ``test_process_order_is_referentially_transparent`` exercises the stronger property. |
+
+**10/10.**
+
+---
+
+## The findings on this exemplar
+
+Running ``gaudi check`` against the Gaudí project with this exemplar
+merged produces **one universal finding** on the exemplar files (plus
+the usual project-level infra findings that are unrelated to the
+exemplar):
+
+### SMELL-003 LongFunction on ``process_order`` (×1, ~41 lines)
+
+``process_order`` is the composition root of the five-stage
+pipeline. At ~41 lines it exceeds the ``SMELL-003`` threshold. This
+is **universal** (no school scope excludes it), and it fires under
+every valid school. It is the honest cost of threading errors
+through five stages with explicit early returns in Python — a
+language that lacks ``do``-notation or a native ``bind`` operator.
+
+The Functional discipline accepts this cost deliberately: the
+alternative (Haskell-style monad transformer stacks, or a hand-rolled
+``bind``/``map``/``and_then`` combinator library) is precisely the
+abstraction-astronautics that [functional.md](../../../../docs/philosophy/functional.md)
+section 6 warns against. One long composition root with explicit
+pattern matching is the honest Python translation; a 200-line monad
+combinator library would score 10/10 on the rubric too, and the
+readers of the code would be worse off.
+
+### No OOP-specific findings
+
+**Zero** findings from the OOP-targeted rules:
+
+- ``SMELL-014 LazyElement`` (scoped to Pragmatic/Unix/Functional/DO)
+  does not fire because the dataclasses have zero methods.
+- ``SMELL-022 DataClassSmell`` (scoped to Classical/Convention) does
+  not fire — and would only matter under schools this exemplar is
+  not targeting.
+- ``SMELL-009 FeatureEnvy``, ``SMELL-020 LargeClass``, ``SMELL-023
+  RefusedBequest``, ``DOM-001 AnemicDomainModel`` all stay silent.
+
+This is the property ``test_functional_exemplar_findings_are_scope_invariant``
+pins: under every valid school, the finding set on this exemplar is
+bit-identical. Because the exemplar trips only universal rules, the
+scope system has nothing to filter — and the stability is the proof
+that the universal rules really are universal.
+
+---
+
+## Comparison with Classical and Pragmatic
+
+| Property | Classical | Pragmatic | Functional |
+|---|---|---|---|
+| Files | 8 | 1 | 3 |
+| Impl lines | ~450 | ~120 | ~220 |
+| Public classes | 12 | 0 | 10 (all frozen dataclasses, zero methods) |
+| Protocols / interfaces | 5 | 0 | 0 |
+| Single-method wrapper classes | 6 | 0 | 0 |
+| Mutation of passed-in state | some (inventory) | yes | **none** |
+| Errors raised / returned | raised (ValidationFailure) | raised (ValueError) | returned (Err) |
+| Composition root lines | short (orchestration) | ~80 (one function) | ~41 |
+| Scope-sensitive gaudi findings | YES (SMELL-014 false positives under non-Classical schools) | no | no |
+| Scope-invariant gaudi findings | — | SMELL-003 + SMELL-004 + STRUCT-021 | SMELL-003 only |
+
+Three observations from the triangle:
+
+1. **Classical is the only scope-sensitive exemplar so far.** It
+   uses single-method wrapper classes that Pragmatic/Unix/Functional/DO
+   consider dead weight. The matrix test pins this as "same code,
+   different verdict."
+
+2. **Functional is strictly cleaner than Pragmatic** under Gaudí's
+   universal criteria (one universal finding vs. three). This is the
+   honest trade-off: Functional buys the clean finding profile with
+   more structural machinery — the ``Result`` type, ``World`` value,
+   frozen dataclasses, and free-function helpers. Pragmatic buys its
+   smaller file with SMELL-003 + SMELL-004 + STRUCT-021 findings.
+   Neither is better; they are faithful to different axioms about
+   where complexity should live.
+
+3. **All three pass the same 12 acceptance tests** against the same
+   shared seed data. The canonical task's invariants are enforced
+   identically. What differs is *how* the three disciplines spend
+   their complexity budget.
+
+---
+
+## Notes for future exemplars
+
+- **Convention (Django)** will almost certainly trip ``SMELL-020
+  LargeClass`` and ``ARCH-002 GodModel`` on its model classes — and
+  both rules are scoped *away* from Convention in the audit. That
+  asymmetry is the next matrix row to pin.
+- **Data-Oriented** will be the first exemplar expected to refuse
+  this file's ``resolve_lines`` comprehension style in favour of
+  manual fused loops. The contrast with Functional on that exact
+  question is the Functional-vs-DO teaching moment.
+- **Event-Sourced** will look closest to Functional in the
+  write-path (immutable events, pure command handlers) but will
+  introduce a projection layer the other exemplars do not have.
+
+---
+
+## See also
+
+- [docs/philosophy/functional.md](../../../../docs/philosophy/functional.md) — The axiom sheet.
+- [docs/philosophy/canonical-task.md](../../../../docs/philosophy/canonical-task.md) — The canonical task specification.
+- [docs/rule-registry.md](../../../../docs/rule-registry.md) — The rule audit, including the scope tags the matrix test verifies.
+- [tests/philosophy/classical/canonical/README.md](../../classical/canonical/README.md) — The Classical reference exemplar.
+- [tests/philosophy/pragmatic/canonical/README.md](../../pragmatic/canonical/README.md) — The Pragmatic reference exemplar.

--- a/tests/philosophy/functional/canonical/__init__.py
+++ b/tests/philosophy/functional/canonical/__init__.py
@@ -1,0 +1,9 @@
+"""
+Functional / Algebraic reference implementation of the canonical task.
+
+Every value is immutable. Every error is returned as data, not raised.
+Every function is a pure transformation over frozen inputs. The
+domain kernel imports nothing from logging, os, requests, or the
+clock — time is passed in as a value. See ``README.md`` in this
+directory for the full rubric score.
+"""

--- a/tests/philosophy/functional/canonical/models.py
+++ b/tests/philosophy/functional/canonical/models.py
@@ -1,0 +1,110 @@
+"""
+Immutable domain records.
+
+Every class in this module is a frozen dataclass with **zero methods**
+— pure values that describe facts, not objects with behavior. The
+functional discipline is: if a piece of logic reads from a record,
+it is a free function in ``pipeline.py``, not a method on the record.
+
+This is deliberate and rubric-driven. ``docs/philosophy/functional.md``
+catechism #1 treats frozen dataclasses as the primary building
+block, and rubric check #8 says inheritance is used only for
+``Protocol`` / ABC definitions — never to reuse behavior. A
+``@property`` helper on a record is a mild form of that reuse; a
+stricter Functional reading avoids it entirely. The Gaudí rule
+``SMELL-014 LazyElement`` is correctly scoped to fire on exactly
+this pattern under the Functional school, and removing the
+helpers is the faithful response.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from decimal import Decimal
+from enum import Enum
+from typing import Mapping
+
+
+class CustomerStanding(Enum):
+    GOOD = "good"
+    HOLD = "hold"
+    BANNED = "banned"
+
+
+class OrderStatus(Enum):
+    CONFIRMED = "confirmed"
+    REJECTED = "rejected"
+
+
+@dataclass(frozen=True)
+class Customer:
+    customer_id: str
+    name: str
+    email: str
+    standing: CustomerStanding
+    credit_limit: Decimal
+
+
+@dataclass(frozen=True)
+class Product:
+    sku: str
+    name: str
+    unit_price: Decimal
+    max_per_order: int
+    category: str
+
+
+@dataclass(frozen=True)
+class InventoryLevel:
+    sku: str
+    on_hand: int
+    reserved: int
+
+
+@dataclass(frozen=True)
+class PromoCode:
+    code: str
+    percent_off: int
+    expires_at: datetime
+
+
+@dataclass(frozen=True)
+class LineItem:
+    sku: str
+    quantity: int
+
+
+@dataclass(frozen=True)
+class Order:
+    order_id: str
+    customer_id: str
+    line_items: tuple[LineItem, ...]
+    promo_code: str | None
+    shipping_address: str
+
+
+@dataclass(frozen=True)
+class Outcome:
+    order_id: str
+    status: OrderStatus
+    final_price: Decimal | None
+    reservation_id: str | None
+    rejection_reason: str | None
+
+
+@dataclass(frozen=True)
+class World:
+    """The entire input state of the order-processing system.
+
+    A ``World`` is an immutable snapshot. ``process_order`` never
+    mutates it; instead it returns ``(outcome, new_world)`` where
+    the new world differs from the old only in the inventory column.
+    """
+
+    customers: Mapping[str, Customer]
+    products: Mapping[str, Product]
+    inventory: Mapping[str, InventoryLevel]
+    promo_codes: Mapping[str, PromoCode]
+    shipping_fee: Decimal
+    now: datetime

--- a/tests/philosophy/functional/canonical/pipeline.py
+++ b/tests/philosophy/functional/canonical/pipeline.py
@@ -1,0 +1,219 @@
+"""
+The pure-function pipeline for the canonical order-processing task.
+
+Every function in this module is a pure transformation: given the
+same inputs, it produces the same outputs and has no observable
+effect on anything else. Errors are returned as ``Err`` values, not
+raised. Inventory is updated by returning a new mapping, never by
+mutating the passed-in one. ``process_order`` composes the smaller
+functions via straight-line application and returns both the
+terminal outcome and a new ``World`` with the reservation applied.
+
+The caller's responsibility: thread the returned ``new_world`` into
+the next ``process_order`` call. This is the "functional core,
+imperative shell" pattern — the core is pure; the caller (or a thin
+outer layer) manages the sequence.
+"""
+
+from __future__ import annotations
+
+from dataclasses import replace
+from datetime import datetime
+from decimal import Decimal
+from typing import Mapping
+
+from .models import (
+    Customer,
+    CustomerStanding,
+    InventoryLevel,
+    LineItem,
+    Order,
+    OrderStatus,
+    Outcome,
+    Product,
+    PromoCode,
+    World,
+)
+from .result import Err, Ok
+
+
+def validate_customer(
+    customers: Mapping[str, Customer], customer_id: str
+) -> Ok[Customer] | Err[str]:
+    """Return the customer if they exist and may place orders."""
+    customer = customers.get(customer_id)
+    if customer is None:
+        return Err(f"Unknown customer {customer_id}")
+    if customer.standing is not CustomerStanding.GOOD:
+        return Err(
+            f"Customer {customer.customer_id} standing is "
+            f"{customer.standing.value}; may not place orders"
+        )
+    return Ok(customer)
+
+
+def resolve_line(
+    products: Mapping[str, Product], line: LineItem
+) -> Ok[tuple[Product, LineItem]] | Err[str]:
+    """Resolve one line to its product, checking max_per_order."""
+    product = products.get(line.sku)
+    if product is None:
+        return Err(f"Unknown product {line.sku}")
+    if line.quantity > product.max_per_order:
+        return Err(
+            f"Line item {line.sku} quantity {line.quantity} "
+            f"exceeds max_per_order {product.max_per_order}"
+        )
+    return Ok((product, line))
+
+
+def resolve_lines(
+    products: Mapping[str, Product], line_items: tuple[LineItem, ...]
+) -> Ok[tuple[tuple[Product, LineItem], ...]] | Err[str]:
+    """Resolve every line item. Returns Err at the first invalid line."""
+    resolved: list[tuple[Product, LineItem]] = []
+    for line in line_items:
+        result = resolve_line(products, line)
+        if isinstance(result, Err):
+            return result
+        resolved.append(result.value)
+    return Ok(tuple(resolved))
+
+
+def find_insufficient_skus(
+    inventory: Mapping[str, InventoryLevel],
+    resolved: tuple[tuple[Product, LineItem], ...],
+) -> tuple[str, ...]:
+    """Return the SKUs whose requested quantity exceeds available stock."""
+    return tuple(
+        product.sku
+        for product, line in resolved
+        if _available(inventory.get(product.sku)) < line.quantity
+    )
+
+
+def _available(level: InventoryLevel | None) -> int:
+    """Return the available (on-hand minus reserved) stock for a level, zero if absent."""
+    if level is None:
+        return 0
+    return level.on_hand - level.reserved
+
+
+def _promo_is_active(promo: PromoCode, now: datetime) -> bool:
+    """Return True iff the promo has not yet expired as of ``now``."""
+    return now < promo.expires_at
+
+
+def compute_subtotal(resolved: tuple[tuple[Product, LineItem], ...]) -> Decimal:
+    """Sum of unit_price × quantity across all resolved lines."""
+    return sum(
+        (product.unit_price * line.quantity for product, line in resolved),
+        start=Decimal(0),
+    )
+
+
+def compute_discount(
+    subtotal: Decimal,
+    promo_code: str | None,
+    promo_codes: Mapping[str, PromoCode],
+    now: datetime,
+) -> Decimal:
+    """Return the discount amount, or zero if promo is missing/expired."""
+    if promo_code is None:
+        return Decimal(0)
+    promo = promo_codes.get(promo_code)
+    if promo is None or not _promo_is_active(promo, now):
+        return Decimal(0)
+    return (subtotal * Decimal(promo.percent_off) / Decimal(100)).quantize(Decimal("0.01"))
+
+
+def compute_final_price(
+    resolved: tuple[tuple[Product, LineItem], ...],
+    promo_code: str | None,
+    world: World,
+) -> Decimal:
+    """Compute subtotal minus discount plus shipping."""
+    subtotal = compute_subtotal(resolved)
+    discount = compute_discount(subtotal, promo_code, world.promo_codes, world.now)
+    return subtotal - discount + world.shipping_fee
+
+
+def reserve_inventory(
+    inventory: Mapping[str, InventoryLevel],
+    resolved: tuple[tuple[Product, LineItem], ...],
+) -> Mapping[str, InventoryLevel]:
+    """Return a NEW inventory mapping with reservations applied.
+
+    Caller must have pre-validated availability — this function
+    trusts its input and does not re-check. Nothing is mutated: the
+    returned mapping is a fresh dict whose touched levels are fresh
+    frozen dataclass instances constructed via ``dataclasses.replace``.
+    """
+    delta: dict[str, int] = {}
+    for _product, line in resolved:
+        delta[line.sku] = delta.get(line.sku, 0) + line.quantity
+    return {
+        sku: (replace(level, reserved=level.reserved + delta[sku]) if sku in delta else level)
+        for sku, level in inventory.items()
+    }
+
+
+def confirmed(order: Order, final_price: Decimal, reservation_id: str) -> Outcome:
+    """Build a terminal Outcome for a confirmed order."""
+    return Outcome(
+        order_id=order.order_id,
+        status=OrderStatus.CONFIRMED,
+        final_price=final_price,
+        reservation_id=reservation_id,
+        rejection_reason=None,
+    )
+
+
+def rejected(order: Order, reason: str) -> Outcome:
+    """Build a terminal Outcome for a rejected order."""
+    return Outcome(
+        order_id=order.order_id,
+        status=OrderStatus.REJECTED,
+        final_price=None,
+        reservation_id=None,
+        rejection_reason=reason,
+    )
+
+
+def process_order(order: Order, world: World, reservation_id: str) -> tuple[Outcome, World]:
+    """Compose the full pipeline for one order.
+
+    Returns ``(outcome, new_world)``. The input ``world`` is never
+    mutated. On a confirmed order, ``new_world.inventory`` reflects
+    the applied reservation; on rejection, ``new_world`` is returned
+    unchanged.
+    """
+    customer_result = validate_customer(world.customers, order.customer_id)
+    if isinstance(customer_result, Err):
+        return rejected(order, customer_result.error), world
+    customer = customer_result.value
+
+    lines_result = resolve_lines(world.products, order.line_items)
+    if isinstance(lines_result, Err):
+        return rejected(order, lines_result.error), world
+    resolved = lines_result.value
+
+    insufficient = find_insufficient_skus(world.inventory, resolved)
+    if insufficient:
+        return rejected(order, f"Insufficient inventory for: {', '.join(insufficient)}"), world
+
+    final_price = compute_final_price(resolved, order.promo_code, world)
+
+    if final_price > customer.credit_limit:
+        return (
+            rejected(
+                order,
+                f"Final price {final_price} exceeds customer "
+                f"{customer.customer_id} credit limit {customer.credit_limit}",
+            ),
+            world,
+        )
+
+    new_inventory = reserve_inventory(world.inventory, resolved)
+    new_world = replace(world, inventory=new_inventory)
+    return confirmed(order, final_price, reservation_id), new_world

--- a/tests/philosophy/functional/canonical/result.py
+++ b/tests/philosophy/functional/canonical/result.py
@@ -1,0 +1,37 @@
+"""
+A minimal Result type for returning errors as values.
+
+``Ok`` carries a success value; ``Err`` carries a failure value. Both
+are frozen dataclasses, so a ``Result`` can be stored in other frozen
+structures and passed between pure functions without aliasing
+hazards. Callers discriminate via ``isinstance`` or ``match``.
+
+The exemplar deliberately does not ship a ``bind`` / ``map`` / ``and_then``
+combinator library. Python is not Haskell; the honest functional
+translation of error threading in Python is an early-return check
+with a pattern match, and inventing a monad library just to prove
+erudition is precisely the abstraction-astronautics that the
+Functional axiom sheet's degenerate-case section warns against.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Generic, TypeVar
+
+T = TypeVar("T")
+E = TypeVar("E")
+
+
+@dataclass(frozen=True)
+class Ok(Generic[T]):
+    """A successful result carrying its value."""
+
+    value: T
+
+
+@dataclass(frozen=True)
+class Err(Generic[E]):
+    """A failed result carrying an error value."""
+
+    error: E

--- a/tests/philosophy/functional/test_canonical.py
+++ b/tests/philosophy/functional/test_canonical.py
@@ -1,0 +1,238 @@
+"""
+End-to-end tests for the Functional reference implementation.
+
+Uses the shared seed data at ``tests/philosophy/seed_data.py``
+unchanged. Every acceptance criterion from
+``docs/philosophy/canonical-task.md`` is exercised. The test shape
+differs from the Classical and Pragmatic versions in one important
+way: because ``process_order`` is pure and returns
+``(outcome, new_world)``, the tests thread the world through
+successive calls instead of mutating a shared dict.
+"""
+
+from __future__ import annotations
+
+from dataclasses import replace
+from datetime import datetime
+from decimal import Decimal
+from typing import Any
+
+import pytest
+
+from tests.philosophy import seed_data
+from tests.philosophy.functional.canonical.models import (
+    Customer,
+    CustomerStanding,
+    InventoryLevel,
+    LineItem,
+    Order,
+    OrderStatus,
+    Product,
+    PromoCode,
+    World,
+)
+from tests.philosophy.functional.canonical.pipeline import process_order
+
+_NOW = datetime(2026, 4, 10, 12, 0, 0)
+
+
+def _build_customer(data: dict[str, Any]) -> Customer:
+    return Customer(
+        customer_id=str(data["customer_id"]),
+        name=str(data["name"]),
+        email=str(data["email"]),
+        standing=CustomerStanding(str(data["standing"])),
+        credit_limit=Decimal(str(data["credit_limit"])),
+    )
+
+
+def _build_product(data: dict[str, Any]) -> Product:
+    return Product(
+        sku=str(data["sku"]),
+        name=str(data["name"]),
+        unit_price=Decimal(str(data["unit_price"])),
+        max_per_order=int(data["max_per_order"]),  # type: ignore[arg-type]
+        category=str(data["category"]),
+    )
+
+
+def _build_level(data: dict[str, Any]) -> InventoryLevel:
+    return InventoryLevel(
+        sku=str(data["sku"]),
+        on_hand=int(data["on_hand"]),  # type: ignore[arg-type]
+        reserved=int(data["reserved"]),  # type: ignore[arg-type]
+    )
+
+
+def _build_promo(data: dict[str, Any]) -> PromoCode:
+    return PromoCode(
+        code=str(data["code"]),
+        percent_off=int(data["percent_off"]),  # type: ignore[arg-type]
+        expires_at=datetime.fromisoformat(str(data["expires_at"])),
+    )
+
+
+@pytest.fixture
+def world() -> World:
+    return World(
+        customers={str(c["customer_id"]): _build_customer(c) for c in seed_data.CUSTOMERS},
+        products={str(p["sku"]): _build_product(p) for p in seed_data.PRODUCTS},
+        inventory={str(level["sku"]): _build_level(level) for level in seed_data.INVENTORY},
+        promo_codes={str(p["code"]): _build_promo(p) for p in seed_data.PROMO_CODES},
+        shipping_fee=Decimal(seed_data.SHIPPING_FEE),
+        now=_NOW,
+    )
+
+
+def _make_order(data: dict[str, Any]) -> Order:
+    return Order(
+        order_id=str(data["order_id"]),
+        customer_id=str(data["customer_id"]),
+        line_items=tuple(
+            LineItem(sku=str(item["sku"]), quantity=int(item["quantity"]))  # type: ignore[arg-type]
+            for item in data["line_items"]  # type: ignore[union-attr]
+        ),
+        promo_code=(str(data["promo_code"]) if data.get("promo_code") is not None else None),
+        shipping_address=str(data["shipping_address"]),
+    )
+
+
+def _assert_confirmed(case: dict[str, Any], outcome) -> None:
+    assert outcome.status is OrderStatus.CONFIRMED, (
+        f"{case['name']}: expected confirmed, got {outcome.status} "
+        f"(reason: {outcome.rejection_reason})"
+    )
+    assert outcome.final_price == Decimal(str(case["expected_final_price"])), (
+        f"{case['name']}: final price mismatch"
+    )
+    assert outcome.reservation_id is not None, (
+        f"{case['name']}: confirmed order must have a reservation id"
+    )
+
+
+def _assert_rejected(case: dict[str, Any], outcome) -> None:
+    assert outcome.status is OrderStatus.REJECTED, (
+        f"{case['name']}: expected rejected, got {outcome.status}"
+    )
+    reason = outcome.rejection_reason
+    assert reason is not None, f"{case['name']}: rejected order must carry a reason"
+    needles: list[str] = []
+    if "expected_reason_contains" in case:
+        needles.append(str(case["expected_reason_contains"]))
+    if "expected_reason_contains_all" in case:
+        needles.extend(str(n) for n in case["expected_reason_contains_all"])
+    for needle in needles:
+        assert needle in reason, (
+            f"{case['name']}: expected reason to contain {needle!r}, got {reason!r}"
+        )
+
+
+@pytest.mark.parametrize("case", seed_data.TEST_ORDERS, ids=lambda c: str(c["name"]))
+def test_pipeline_matches_expected_outcome(case: dict[str, Any], world: World) -> None:
+    order = _make_order(case["order"])  # type: ignore[arg-type]
+    outcome, new_world = process_order(order, world, reservation_id="RES-000001")
+
+    if case["expected_status"] == "confirmed":
+        _assert_confirmed(case, outcome)
+        # A confirmed order must produce a new world whose inventory
+        # differs from the original — the reservation was applied.
+        assert new_world is not world or new_world.inventory is not world.inventory, (
+            "confirmed order should produce a new world with updated inventory"
+        )
+    elif case["expected_status"] == "rejected":
+        _assert_rejected(case, outcome)
+        # A rejected order returns the world unchanged.
+        assert new_world is world, "rejected order should return the world unchanged"
+    else:
+        pytest.fail(f"unknown expected_status in {case['name']}")
+
+
+def _order(order_id: str, items: tuple[tuple[str, int], ...]) -> Order:
+    return Order(
+        order_id=order_id,
+        customer_id="C001",
+        line_items=tuple(LineItem(sku=sku, quantity=qty) for sku, qty in items),
+        promo_code=None,
+        shipping_address="123 Main St",
+    )
+
+
+def test_confirmed_order_decrements_available_inventory(world: World) -> None:
+    """Threading state: the new world must reflect the first reservation."""
+    first_order = _make_order(seed_data.TEST_ORDERS[0]["order"])  # type: ignore[arg-type]
+    first_outcome, world1 = process_order(first_order, world, "RES-000001")
+    assert first_outcome.status is OrderStatus.CONFIRMED
+
+    # Stock was 100, first order reserved 2, so only 98 remain.
+    huge = _order("O-HUGE", (("WIDGET-01", 99),))
+    second_outcome, world2 = process_order(huge, world1, "RES-000002")
+    assert second_outcome.status is OrderStatus.REJECTED, (
+        "follow-up order should be rejected because world1's inventory "
+        "left only 98 available, not 99"
+    )
+    # And the original world is unchanged — purity proven.
+    assert world.inventory["WIDGET-01"].reserved == 0
+
+
+def test_out_of_stock_order_does_not_partially_reserve(world: World) -> None:
+    """Atomicity: a failed reservation returns the world unchanged."""
+    mixed = _order("O-MIX", (("WIDGET-01", 5), ("EMPTY-01", 1)))
+    first_outcome, world1 = process_order(mixed, world, "RES-000001")
+    assert first_outcome.status is OrderStatus.REJECTED
+    assert world1 is world, "rejection must leave the world untouched"
+
+    # A pure WIDGET-01 order for the same quantity must still succeed,
+    # because no partial reservation occurred above.
+    followup = _order("O-FOLLOW", (("WIDGET-01", 5),))
+    second_outcome, _world2 = process_order(followup, world1, "RES-000002")
+    assert second_outcome.status is OrderStatus.CONFIRMED
+
+
+def test_process_order_is_referentially_transparent(world: World) -> None:
+    """The same call twice against the same world produces the same outcome.
+
+    This is the Functional axiom's catechism #7 in test form.
+    """
+    order = _make_order(seed_data.TEST_ORDERS[0]["order"])  # type: ignore[arg-type]
+    outcome1, world_a = process_order(order, world, "RES-000001")
+    outcome2, world_b = process_order(order, world, "RES-000001")
+
+    assert outcome1 == outcome2
+    # The two new worlds are structurally identical — purity means
+    # calling process_order twice on the same input produces two
+    # equal results.
+    assert world_a.inventory == world_b.inventory
+
+
+def test_core_is_free_of_io_imports() -> None:
+    """The functional core must not import logging, os, requests, or a clock.
+
+    ``docs/philosophy/functional.md`` catechism #3: side effects
+    are pushed to the edges. This test is the structural proof
+    that the pipeline module does not reach for them.
+    """
+    import tests.philosophy.functional.canonical.pipeline as pipeline_module
+
+    source = open(pipeline_module.__file__, encoding="utf-8").read()
+    forbidden_imports = {
+        "import logging",
+        "import os",
+        "import requests",
+        "import sqlite3",
+        "from time import",
+    }
+    found = {needle for needle in forbidden_imports if needle in source}
+    assert not found, (
+        f"pipeline.py imports forbidden I/O modules: {sorted(found)}. "
+        "Side effects must be pushed to the edges."
+    )
+    # datetime is allowed only as a type for the ``now`` parameter —
+    # the pipeline must not call ``datetime.now()``.
+    assert "datetime.now(" not in source, (
+        "pipeline.py must not call datetime.now() — time should be "
+        "passed in as a value, not fetched from the clock."
+    )
+
+
+def _world_replace_inventory(world: World, inventory: dict) -> World:
+    return replace(world, inventory=inventory)

--- a/tests/philosophy/test_philosophy_matrix.py
+++ b/tests/philosophy/test_philosophy_matrix.py
@@ -71,6 +71,22 @@ CLASSICAL_EXEMPLAR = "classical/canonical"
 # Pragmatic exemplar is the clean control condition that proves it.
 PRAGMATIC_EXEMPLAR = "pragmatic/canonical"
 
+# The Functional reference exemplar — pure functions over immutable
+# records, Ok/Err return values, no mutation, no raised exceptions.
+# Like Pragmatic, it is scope-invariant: its gaudi findings are the
+# same under every school. Unlike Pragmatic, it trips only one
+# universal rule (SMELL-003 on the compositional process_order) vs.
+# Pragmatic's three. The delta isolates which universal rule costs
+# each discipline chooses to accept.
+FUNCTIONAL_EXEMPLAR = "functional/canonical"
+
+# Exemplars whose finding set is expected to be identical under
+# every valid school. These are the "control conditions" for the
+# matrix: universal rules must be scope-invariant, and a divergence
+# on one of these exemplars means a supposedly-universal rule has
+# accidentally leaked a scope decision.
+SCOPE_INVARIANT_EXEMPLARS: tuple[str, ...] = (PRAGMATIC_EXEMPLAR, FUNCTIONAL_EXEMPLAR)
+
 # Under every school, the Pragmatic exemplar must trip SMELL-003
 # (long function) and SMELL-004 (long parameter list). These are
 # the deliberate trade-offs the Pragmatic discipline accepts as the
@@ -91,6 +107,33 @@ PRAGMATIC_FORBIDS_EVERYWHERE: frozenset[str] = frozenset(
         "SMELL-023",  # no inheritance
         "ARCH-002",  # no models
         "DOM-001",  # no domain classes
+    }
+)
+
+# Under every school, the Functional exemplar must trip SMELL-003
+# (long function on process_order at ~41 lines). This is the
+# honest cost of composing five pipeline stages with explicit
+# early-return error threading in Python. See
+# tests/philosophy/functional/canonical/README.md.
+FUNCTIONAL_REQUIRES_EVERYWHERE: frozenset[str] = frozenset({"SMELL-003"})
+
+# Under every school, the Functional exemplar must NOT trip the
+# OOP-specific rules (the frozen dataclasses have zero methods)
+# or the anti-extensibility rules (no wrapper classes, no
+# inheritance, no mutation). If any of these ever fires, either
+# the exemplar grew a method it shouldn't have, or the scope
+# filter broke.
+FUNCTIONAL_FORBIDS_EVERYWHERE: frozenset[str] = frozenset(
+    {
+        "SMELL-014",  # no single-method classes (frozen records have zero methods)
+        "SMELL-018",  # no middle-man wrappers
+        "SMELL-020",  # no large classes
+        "SMELL-022",  # classical-scoped, and records have zero methods besides
+        "SMELL-023",  # no inheritance
+        "SMELL-008",  # no shotgun surgery after inlining the type alias
+        "SMELL-009",  # no feature envy (no methods at all)
+        "ARCH-002",  # no models
+        "DOM-001",  # no domain classes with behavior — frozen records excluded
     }
 )
 
@@ -206,6 +249,34 @@ EXEMPLAR_EXPECTATIONS: list[ExemplarExpectation] = [
             }
         )
     ],
+    # --- Functional exemplar rows --------------------------------------
+    # Eight rows, one per school. The Functional exemplar is also
+    # scope-invariant: under every school it trips only SMELL-003 on
+    # the compositional process_order. Unlike Pragmatic, it reaches
+    # this with a very different shape — frozen dataclasses, Ok/Err
+    # result threading, and free-function helpers. The matrix pins
+    # both disciplines independently so neither can regress into
+    # the other's finding profile.
+    *[
+        ExemplarExpectation(
+            exemplar=FUNCTIONAL_EXEMPLAR,
+            school=school,
+            required_rules=FUNCTIONAL_REQUIRES_EVERYWHERE,
+            forbidden_rules=FUNCTIONAL_FORBIDS_EVERYWHERE,
+        )
+        for school in sorted(
+            {
+                "classical",
+                "pragmatic",
+                "functional",
+                "unix",
+                "resilient",
+                "data-oriented",
+                "convention",
+                "event-sourced",
+            }
+        )
+    ],
 ]
 
 
@@ -278,27 +349,39 @@ class TestPhilosophyMatrix:
         missing = VALID_SCHOOLS - covered
         assert not missing, f"Pragmatic exemplar matrix is missing schools: {sorted(missing)}"
 
-    def test_pragmatic_exemplar_findings_are_scope_invariant(self) -> None:
+    def test_functional_exemplar_covered_by_every_school(self) -> None:
+        """The functional exemplar should also run under every school."""
+        covered = {e.school for e in EXEMPLAR_EXPECTATIONS if e.exemplar == FUNCTIONAL_EXEMPLAR}
+        missing = VALID_SCHOOLS - covered
+        assert not missing, f"Functional exemplar matrix is missing schools: {sorted(missing)}"
+
+    @pytest.mark.parametrize("exemplar", SCOPE_INVARIANT_EXEMPLARS)
+    def test_scope_invariant_exemplar_is_stable_across_schools(self, exemplar: str) -> None:
         """Universal rules must not shift based on the active school.
 
-        The Pragmatic exemplar has no classes, so it trips only
-        universal rules (SMELL-003 LongFunction, SMELL-004
-        LongParameterList, STRUCT-021 MagicStrings, plus infra rules
-        like STRUCT-011 and the OPS-00x family). Running it under
-        every valid school must produce the same set of rule codes.
-        If the set diverges, a rule is accidentally leaking a scope
-        decision into a rule the audit classified as universal.
+        Each scope-invariant exemplar (Pragmatic's class-free
+        function, Functional's pure-record composition) trips only
+        universal rules. Running it under every valid school must
+        produce an identical set of rule codes. If the set diverges
+        between any two schools, a rule is accidentally leaking a
+        scope decision into a rule the audit classified as universal.
+
+        This is the control-condition half of the matrix's claim.
+        The Classical exemplar asserts that **scoped** rules shift
+        with the active school ('same code, different verdict').
+        These exemplars assert the symmetric property: **universal**
+        rules do *not* shift.
         """
-        observed = {}
+        observed: dict[str, frozenset[str]] = {}
         for school in VALID_SCHOOLS:
-            findings = _run_exemplar(PRAGMATIC_EXEMPLAR, school)
+            findings = _run_exemplar(exemplar, school)
             observed[school] = frozenset(f.code for f in findings)
 
         baseline_school = next(iter(VALID_SCHOOLS))
         baseline = observed[baseline_school]
         for school, codes in observed.items():
             assert codes == baseline, (
-                f"Pragmatic exemplar finding set shifted: under {school!r} "
+                f"{exemplar} finding set shifted: under {school!r} "
                 f"got {sorted(codes)}, but under {baseline_school!r} got "
                 f"{sorted(baseline)}. Universal rules must be scope-invariant; "
                 f"a shift indicates an accidentally-scoped rule."


### PR DESCRIPTION
## Summary

- Adds the **Functional / Algebraic** reference exemplar of the order-processing canonical task under `tests/philosophy/functional/canonical/`.
- Completes the **Classical ↔ Pragmatic ↔ Functional** triangle — three faithful implementations of the same task that every later school's exemplar can be compared against.
- Every value is immutable, every error is returned as data (`Ok[T]` / `Err[E]`), every function is a pure transformation. The core imports nothing from `logging`, `os`, `requests`, or the clock.
- **24 new tests**, total now **575** (was 551).
- Scores **10/10** on the [Functional rubric](../blob/main/docs/philosophy/functional.md).

## The triangle

| Property | Classical | Pragmatic | Functional |
|---|---|---|---|
| Files | 8 | 1 | 3 |
| Impl lines | ~450 | ~120 | ~220 |
| Public classes | 12 | 0 | 10 (frozen dataclasses, zero methods) |
| Single-method wrappers | 6 | 0 | 0 |
| Mutation of passed-in state | some (inventory) | yes | **none** |
| Errors raised / returned | raised | raised | **returned** (Ok/Err) |
| Scope-sensitive findings | ✅ (SMELL-014 under non-Classical) | no | no |
| Scope-invariant findings | — | SMELL-003 + SMELL-004 + STRUCT-021 | **SMELL-003 only** |

**All three pass the same 12 acceptance tests** against the same shared seed data. The canonical invariants are enforced identically. What differs is *where* the complexity lives.

## The refactor that mattered

My first draft of the Functional exemplar had `@property` helpers on the dataclasses (`Customer.may_place_orders`, `InventoryLevel.available`, `PromoCode.is_active`). Probing `gaudi check` under `school = "functional"` showed **SMELL-014 LazyElement** firing on all three — exactly as the audit had predicted it should. Single-method classes are how Classical wires seams, and `{pragmatic, unix, functional, data-oriented}` reject them.

**I took the finding at its word** and refactored: removed every method from every dataclass, moved the logic to private free functions in `pipeline.py`. After the refactor:

- The dataclasses are pure records — exactly what [functional.md](../blob/main/docs/philosophy/functional.md) catechism #1 asks for.
- SMELL-014 stops firing under Functional.
- The exemplar is now rigorously faithful under its own rubric.

The forcing function ran in both directions this session: Phase 1 produced the scope tag on SMELL-014 to *prevent* a false positive on a faithful Classical exemplar; here, the same rule correctly *caught* a sloppy first draft of a faithful Functional exemplar. That round-trip is the whole point of the scope system.

## The matrix extension

Two changes:

### 1. Eight new rows for Functional × every school

The Functional exemplar is scope-invariant like Pragmatic but reaches that state via very different machinery. It trips exactly **one** universal rule (SMELL-003 on the ~41-line `process_order` composition root) vs. Pragmatic's three. The delta is documented in the exemplar README.

### 2. Generalized scope-invariance test

`test_pragmatic_exemplar_findings_are_scope_invariant` has been replaced with `test_scope_invariant_exemplar_is_stable_across_schools`, parametrized over a new `SCOPE_INVARIANT_EXEMPLARS` tuple (`pragmatic/canonical`, `functional/canonical`). Adding a future scope-invariant exemplar is now a one-line change.

## The four Functional-specific tests

Beyond the ten parametrized seed-data cases, four dedicated assertions exercise the discipline:

- **`test_confirmed_order_decrements_available_inventory`** — threads `world` through two successive calls. The second call sees the first's reservation because `process_order` returns a new world, not because anything was mutated. `world.inventory["WIDGET-01"].reserved == 0` at the end of the test *proves* non-mutation.
- **`test_out_of_stock_order_does_not_partially_reserve`** — a rejected order returns `world` with the *same object identity* (`new_world is world`). Follow-up order still succeeds at full quantity.
- **`test_process_order_is_referentially_transparent`** — calling `process_order` twice on the same world produces equal outcomes and equal worlds. Catechism #7 as a test.
- **`test_core_is_free_of_io_imports`** — greps the pipeline module's source for `import logging`, `import os`, `import requests`, `import sqlite3`, `from time import`, and `datetime.now(`. Catechism #3 as a structural proof.

## Test plan

- [x] `ruff check .` — clean
- [x] `ruff format --check .` — all files formatted
- [x] `pytest --tb=short -q` — **575 passed** (was 551; +24 new)
- [x] `pytest tests/philosophy/ -v` — 70/70 philosophy tests pass
- [x] `gaudi check` on this project — Functional exemplar trips only SMELL-003, scope-invariant across all eight schools
- [x] Rubric score: 10/10 with evidence in the exemplar README

## Security considerations

N/A — test code, in-memory data, no network or filesystem access outside the test runner's normal paths.