### PR TITLE
fix(rules): DOM-001 generic Manager + DJ-SEC-001/SEC-003 test placeholders

### DIFF
--- a/src/gaudi/packs/python/rules/django.py
+++ b/src/gaudi/packs/python/rules/django.py
@@ -7,6 +7,17 @@ import ast
 from gaudi.core import Rule, Finding, Severity, Category
 from gaudi.packs.python.context import PythonContext
 
+_TEST_PLACEHOLDER_PREFIXES = ("test-", "test_", "test.", "dummy-", "dummy_", "fake-", "fake_")
+_TEST_PLACEHOLDER_SUBSTRINGS = ("example", "placeholder", "not-used", "not_used")
+
+
+def _is_test_placeholder(value: str) -> bool:
+    """Detect SECRET_KEY values that are clearly test placeholders."""
+    lowered = value.lower()
+    if any(lowered.startswith(prefix) for prefix in _TEST_PLACEHOLDER_PREFIXES):
+        return True
+    return any(marker in lowered for marker in _TEST_PLACEHOLDER_SUBSTRINGS)
+
 
 class DjangoSecretKeyExposed(Rule):
     """Detect Django SECRET_KEY hardcoded in settings.
@@ -41,6 +52,8 @@ class DjangoSecretKeyExposed(Rule):
                         if isinstance(node.value, ast.Constant) and isinstance(
                             node.value.value, str
                         ):
+                            if _is_test_placeholder(node.value.value):
+                                continue
                             findings.append(self.finding(file=f.relative_path, line=node.lineno))
         return findings
 

--- a/src/gaudi/packs/python/rules/domain.py
+++ b/src/gaudi/packs/python/rules/domain.py
@@ -89,11 +89,19 @@ def _count_behavior_methods(cls: ast.ClassDef) -> int:
     return count
 
 
+def _unwrap_subscript(node: ast.expr) -> ast.expr:
+    """Unwrap generic type annotations like Manager["Product"] to Manager."""
+    if isinstance(node, ast.Subscript):
+        return _unwrap_subscript(node.value)
+    return node
+
+
 def _inherits_manager_base(cls: ast.ClassDef) -> bool:
     for base in cls.bases:
-        if isinstance(base, ast.Attribute) and base.attr in _MANAGER_BASE_HINTS:
+        unwrapped = _unwrap_subscript(base)
+        if isinstance(unwrapped, ast.Attribute) and unwrapped.attr in _MANAGER_BASE_HINTS:
             return True
-        if isinstance(base, ast.Name) and base.id in _MANAGER_BASE_HINTS:
+        if isinstance(unwrapped, ast.Name) and unwrapped.id in _MANAGER_BASE_HINTS:
             return True
     return False
 

--- a/src/gaudi/packs/python/rules/security.py
+++ b/src/gaudi/packs/python/rules/security.py
@@ -134,10 +134,16 @@ def _looks_like_credential_name(name: str) -> bool:
     return True
 
 
+_TEST_PREFIXES = ("test-", "test_", "test.", "fake-", "fake_", "dummy-", "dummy_")
+
+
 def _looks_like_placeholder_value(value: str) -> bool:
     if value.lower() in _PLACEHOLDER_VALUES:
         return True
-    if "your-" in value.lower() or "your_" in value.lower():
+    lowered = value.lower()
+    if "your-" in lowered or "your_" in lowered:
+        return True
+    if any(lowered.startswith(prefix) for prefix in _TEST_PREFIXES):
         return True
     return False
 

--- a/tests/fixtures/python/DJ-SEC-001/expected.json
+++ b/tests/fixtures/python/DJ-SEC-001/expected.json
@@ -16,6 +16,9 @@
     },
     "pass_models.py": {
       "expected_findings": []
+    },
+    "pass_settings_test_placeholder.py": {
+      "expected_findings": []
     }
   }
 }

--- a/tests/fixtures/python/DJ-SEC-001/pass_settings_test_placeholder.py
+++ b/tests/fixtures/python/DJ-SEC-001/pass_settings_test_placeholder.py
@@ -1,0 +1,7 @@
+"""Fixture for DJ-SEC-001: SECRET_KEY with a test-placeholder value.
+
+A settings file whose SECRET_KEY is clearly a test placeholder (contains
+"test", "insecure", "dummy", etc.) should not trigger the rule.
+"""
+
+SECRET_KEY = "test-secret-not-used-in-production"

--- a/tests/fixtures/python/DOM-001/expected.json
+++ b/tests/fixtures/python/DOM-001/expected.json
@@ -37,6 +37,9 @@
     },
     "pass_manager_has_behavior.py": {
       "expected_findings": []
+    },
+    "pass_manager_generic_type.py": {
+      "expected_findings": []
     }
   }
 }

--- a/tests/fixtures/python/DOM-001/pass_manager_generic_type.py
+++ b/tests/fixtures/python/DOM-001/pass_manager_generic_type.py
@@ -1,0 +1,23 @@
+"""Fixture for DOM-001: Manager with generic type annotation Manager["Model"].
+
+When a Manager subclass uses the generic form ``models.Manager["Model"]``,
+DOM-001 should still recognize it as a Manager and count its methods as
+behavior belonging to the model.
+"""
+
+from django.db import models
+
+
+class ProductManager(models.Manager["Product"]):
+    def by_sku(self, sku: str) -> "Product | None":
+        return self.filter(sku=sku).first()
+
+
+class Product(models.Model):
+    sku = models.CharField(max_length=32, unique=True)
+    name = models.CharField(max_length=200)
+    unit_price = models.DecimalField(max_digits=12, decimal_places=2)
+    max_per_order = models.PositiveIntegerField()
+    category = models.CharField(max_length=64)
+
+    objects = ProductManager()

--- a/tests/fixtures/python/SEC-003/expected.json
+++ b/tests/fixtures/python/SEC-003/expected.json
@@ -31,6 +31,9 @@
     },
     "pass_placeholder_values.py": {
       "expected_findings": []
+    },
+    "pass_test_prefix_values.py": {
+      "expected_findings": []
     }
   }
 }

--- a/tests/fixtures/python/SEC-003/pass_test_prefix_values.py
+++ b/tests/fixtures/python/SEC-003/pass_test_prefix_values.py
@@ -1,0 +1,9 @@
+"""Fixture for SEC-003: credential variables with test-placeholder values.
+
+Values prefixed with "test-", "fake-", "dummy-" etc. are clearly not
+real secrets and should not trigger the rule.
+"""
+
+SECRET_KEY = "test-secret-not-used-in-production"
+api_key = "fake-api-key-for-unit-tests"
+auth_token = "dummy-token-12345"


### PR DESCRIPTION
## Summary

- **DOM-001**: Handle `ast.Subscript` in Manager base detection so generic types like `models.Manager["Product"]` are recognized. Fixes false positives on Convention exemplar's Product and Order models.
- **DJ-SEC-001**: Skip SECRET_KEY values that are clearly test placeholders (prefixed with "test-", "dummy-", "fake-", or containing "example", "placeholder", "not-used"). Django's `django-insecure-` prefix still fires correctly.
- **SEC-003**: Expand `_looks_like_placeholder_value` to detect test-prefixed credential values.

Phase 2 detector precision fixes, batch 2 of 4. Items 1b, 5, 6 from the Convention exemplar README Category B list.

## Test plan

- [x] New fixture: `DOM-001/pass_manager_generic_type.py` — Manager with generic annotation passes
- [x] New fixture: `DJ-SEC-001/pass_settings_test_placeholder.py` — test placeholder SECRET_KEY passes
- [x] New fixture: `SEC-003/pass_test_prefix_values.py` — test-prefixed credentials pass
- [x] Existing DJ-SEC-001 fail fixture (`django-insecure-*`) still fires correctly
- [x] Full suite: 717 passed
- [x] Convention exemplar: DJ-SEC-001 and SEC-003 no longer fire on test settings; DOM-001 only fires on Notification (no Manager, correct)

🤖 Generated with [Claude Code](https://claude.com/claude-code)