### PR TITLE
fix(rules): SCHEMA-001 reference-data exemption + SEC-001 sensitive-models-only

### DIFF
--- a/src/gaudi/packs/python/rules/architecture.py
+++ b/src/gaudi/packs/python/rules/architecture.py
@@ -281,7 +281,26 @@ class MissingTimestamps(Rule):
         "date_modified",
         "modified_date",
         "timestamp",
+        "sent_at",
+        "published_at",
+        "occurred_at",
+        "recorded_at",
     }
+
+    # Fields whose presence signals the model tracks mutable state
+    _MUTABLE_FIELD_NAMES = {"status", "state", "is_active", "is_deleted", "is_archived"}
+
+    @staticmethod
+    def _is_transactional(model: "ModelInfo") -> bool:
+        """Heuristic: a model that has ForeignKey relationships or mutable-state
+        fields is transactional and benefits from audit timestamps. Reference/
+        lookup models (Product, PromoCode) typically have neither."""
+        for col in model.columns:
+            if col.is_foreign_key:
+                return True
+            if col.name.lower() in MissingTimestamps._MUTABLE_FIELD_NAMES:
+                return True
+        return False
 
     def check(self, context: PythonContext) -> list[Finding]:
         findings = []
@@ -294,14 +313,21 @@ class MissingTimestamps(Rule):
                 col.name.lower() in self.TIMESTAMP_PATTERNS for col in model.columns
             )
 
-            if not has_timestamps:
-                findings.append(
-                    self.finding(
-                        file=model.source_file,
-                        line=model.source_line,
-                        model=model.name,
-                    )
+            if has_timestamps:
+                continue
+
+            # Reference/lookup models without FKs or mutable-state fields
+            # don't need audit timestamps
+            if not self._is_transactional(model):
+                continue
+
+            findings.append(
+                self.finding(
+                    file=model.source_file,
+                    line=model.source_line,
+                    model=model.name,
                 )
+            )
         return findings
 
 
@@ -392,12 +418,33 @@ class NoStringLengthLimit(Rule):
 # ---------------------------------------------------------------------------
 
 
+_SENSITIVE_MODEL_NAMES = frozenset(
+    {"user", "account", "role", "group", "permission", "token", "session", "credential"}
+)
+_SENSITIVE_PATH_PARTS = frozenset({"auth", "authz", "security", "permissions", "accounts"})
+
+
+def _is_security_sensitive(model: "ModelInfo") -> bool:
+    """Heuristic: models with security-sensitive names or in auth-related paths
+    should declare explicit permissions. Django's auto-generated add/change/
+    delete/view permissions are sufficient for ordinary domain models."""
+    if any(part in model.name.lower() for part in _SENSITIVE_MODEL_NAMES):
+        return True
+    path_parts = model.source_file.replace("\\", "/").lower().split("/")
+    return bool(_SENSITIVE_PATH_PARTS & set(path_parts))
+
+
 class NoMetaPermissions(Rule):
     """
-    SEC-001: Django model without explicit permissions in Meta.
+    SEC-001: Security-sensitive Django model without explicit permissions in Meta.
 
     Principles: #4 (Failure must be named).
     Source: FWDOCS Django auth framework — implicit permissions are silent failure under hostile input.
+
+    Django auto-generates add/change/delete/view permissions for every model,
+    which is sufficient for ordinary domain models. This rule only fires on
+    models with security-sensitive names or paths where custom permissions
+    are likely needed.
     """
 
     code = "SEC-001"
@@ -416,6 +463,8 @@ class NoMetaPermissions(Rule):
         findings = []
         for model in context.models:
             if model.has_meta and "permissions" not in model.meta_options:
+                if not _is_security_sensitive(model):
+                    continue
                 findings.append(
                     self.finding(
                         file=model.source_file,

--- a/tests/fixtures/python/SCHEMA-001/expected.json
+++ b/tests/fixtures/python/SCHEMA-001/expected.json
@@ -1,6 +1,6 @@
 {
   "rule_id": "SCHEMA-001",
-  "description": "MissingTimestamps -- models without created_at/updated_at",
+  "description": "MissingTimestamps -- transactional models without created_at/updated_at",
   "fixtures": {
     "fail_no_timestamps.py": {
       "expected_findings": [
@@ -10,10 +10,21 @@
         }
       ]
     },
+    "fail_transactional_no_timestamps.py": {
+      "expected_findings": [
+        {
+          "severity": "info",
+          "message_contains": "OrderLine"
+        }
+      ]
+    },
     "pass_with_timestamps.py": {
       "expected_findings": []
     },
     "pass_through_table.py": {
+      "expected_findings": []
+    },
+    "pass_reference_model.py": {
       "expected_findings": []
     }
   }

--- a/tests/fixtures/python/SCHEMA-001/fail_no_timestamps.py
+++ b/tests/fixtures/python/SCHEMA-001/fail_no_timestamps.py
@@ -1,8 +1,9 @@
-"""Fixture for SCHEMA-001: a model with no created/updated timestamp columns."""
+"""Fixture for SCHEMA-001: transactional model with no timestamp columns."""
 
 from django.db import models
 
 
 class Order(models.Model):
-    customer = models.CharField(max_length=200)
+    customer = models.ForeignKey("Customer", on_delete=models.CASCADE)
     amount = models.IntegerField()
+    status = models.CharField(max_length=16)

--- a/tests/fixtures/python/SCHEMA-001/fail_transactional_no_timestamps.py
+++ b/tests/fixtures/python/SCHEMA-001/fail_transactional_no_timestamps.py
@@ -1,0 +1,13 @@
+"""Fixture for SCHEMA-001: transactional model with FK but no timestamps.
+
+A model with a ForeignKey relationship is transactional data that
+should have created_at/updated_at audit columns.
+"""
+
+from django.db import models
+
+
+class OrderLine(models.Model):
+    order = models.ForeignKey("Order", on_delete=models.CASCADE)
+    product = models.ForeignKey("Product", on_delete=models.PROTECT)
+    quantity = models.PositiveIntegerField()

--- a/tests/fixtures/python/SCHEMA-001/pass_reference_model.py
+++ b/tests/fixtures/python/SCHEMA-001/pass_reference_model.py
@@ -1,0 +1,15 @@
+"""Fixture for SCHEMA-001: reference/lookup model without timestamps.
+
+A model with no ForeignKey and no mutable-state fields (status, is_active)
+is reference data that doesn't need audit timestamps.
+"""
+
+from django.db import models
+
+
+class Product(models.Model):
+    sku = models.CharField(max_length=32, unique=True)
+    name = models.CharField(max_length=200)
+    unit_price = models.DecimalField(max_digits=12, decimal_places=2)
+    max_per_order = models.PositiveIntegerField()
+    category = models.CharField(max_length=64)

--- a/tests/fixtures/python/SEC-001/expected.json
+++ b/tests/fixtures/python/SEC-001/expected.json
@@ -1,12 +1,12 @@
 {
   "rule_id": "SEC-001",
-  "description": "NoMetaPermissions -- Django Meta class must declare explicit permissions",
+  "description": "NoMetaPermissions -- security-sensitive Django models must declare explicit permissions",
   "fixtures": {
     "fail_meta_no_permissions.py": {
       "expected_findings": [
         {
           "severity": "info",
-          "message_contains": "Order"
+          "message_contains": "UserAccount"
         }
       ]
     },
@@ -14,6 +14,9 @@
       "expected_findings": []
     },
     "pass_no_meta_class.py": {
+      "expected_findings": []
+    },
+    "pass_ordinary_model.py": {
       "expected_findings": []
     }
   }

--- a/tests/fixtures/python/SEC-001/fail_meta_no_permissions.py
+++ b/tests/fixtures/python/SEC-001/fail_meta_no_permissions.py
@@ -1,9 +1,9 @@
-"""Fixture for SEC-001: Django model with a Meta class but no permissions key."""
+"""Fixture for SEC-001: security-sensitive model with Meta but no permissions."""
 
 from django.db import models
 
 
-class Order(models.Model):
+class UserAccount(models.Model):
     name = models.CharField(max_length=200)
 
     class Meta:

--- a/tests/fixtures/python/SEC-001/pass_ordinary_model.py
+++ b/tests/fixtures/python/SEC-001/pass_ordinary_model.py
@@ -1,0 +1,15 @@
+"""Fixture for SEC-001: ordinary domain model without explicit permissions.
+
+Non-security-sensitive models (Order, Product, etc.) don't need explicit
+Meta.permissions — Django's auto-generated add/change/delete/view
+permissions are sufficient.
+"""
+
+from django.db import models
+
+
+class Order(models.Model):
+    name = models.CharField(max_length=200)
+
+    class Meta:
+        ordering = ["-name"]


### PR DESCRIPTION
## Summary

- **SCHEMA-001**: Skip reference/lookup models (no ForeignKey, no mutable-state fields like status/is_active). Recognize more timestamp patterns (sent_at, published_at, occurred_at, recorded_at). Eliminates 5 false positives on Convention exemplar.
- **SEC-001**: Only fire on security-sensitive models (names containing "user", "account", "role", etc. or in auth-related paths). Django auto-generates default permissions for all models, so ordinary domain models don't need explicit Meta.permissions. Eliminates 7 false positives on Convention exemplar.

Phase 2 detector precision fixes, batch 3 of 4. Items 2, 3 from the Convention exemplar README Category B list.

## Test plan

- [x] New fixture: `SCHEMA-001/pass_reference_model.py` — reference model without timestamps passes
- [x] New fixture: `SCHEMA-001/fail_transactional_no_timestamps.py` — FK model without timestamps fails
- [x] Updated fixture: `SCHEMA-001/fail_no_timestamps.py` — now uses transactional model shape
- [x] New fixture: `SEC-001/pass_ordinary_model.py` — ordinary model without permissions passes
- [x] Updated fixture: `SEC-001/fail_meta_no_permissions.py` ��� now uses security-sensitive model name
- [x] Convention exemplar: SCHEMA-001 only fires on OrderLine (correct); SEC-001 no longer fires
- [x] Full suite: 717 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)