### PR TITLE
fix(rules): SMELL-007 injected-dep exemption + SMELL-023 Protocol awareness

### DIFF
--- a/src/gaudi/packs/python/rules/change_preventers.py
+++ b/src/gaudi/packs/python/rules/change_preventers.py
@@ -29,6 +29,35 @@ def _method_attr_set(
     return attrs
 
 
+def _init_injected_attrs(cls: ast.ClassDef) -> set[str]:
+    """Attributes set in __init__ directly from constructor parameters.
+
+    When __init__ does ``self.x = x`` (parameter name matches attribute
+    name), that attribute is a dependency injected at construction time,
+    not internal state. Disjoint groups formed entirely from injected
+    dependencies indicate a coordinator/orchestrator pattern, not
+    divergent change.
+    """
+    for node in cls.body:
+        if not isinstance(node, ast.FunctionDef) or node.name != "__init__":
+            continue
+        param_names = {arg.arg for arg in node.args.args if arg.arg != "self"}
+        injected: set[str] = set()
+        for stmt in ast.walk(node):
+            if (
+                isinstance(stmt, ast.Assign)
+                and len(stmt.targets) == 1
+                and isinstance(stmt.targets[0], ast.Attribute)
+                and isinstance(stmt.targets[0].value, ast.Name)
+                and stmt.targets[0].value.id == "self"
+                and isinstance(stmt.value, ast.Name)
+                and stmt.value.id in param_names
+            ):
+                injected.add(stmt.targets[0].attr)
+        return injected
+    return set()
+
+
 class DivergentChange(Rule):
     """SMELL-007: Class methods touch disjoint attribute sets.
 
@@ -56,8 +85,9 @@ class DivergentChange(Rule):
                 methods = [n for n in node.body if isinstance(n, ast.FunctionDef)]
                 if len(methods) < 4:
                     continue
+                injected = _init_injected_attrs(node)
                 non_init = [m for m in methods if m.name != "__init__"]
-                attr_sets = [_method_attr_set(m) for m in non_init]
+                attr_sets = [_method_attr_set(m) - injected for m in non_init]
                 # Remove empty sets
                 attr_sets = [s for s in attr_sets if s]
                 if len(attr_sets) < 2:

--- a/src/gaudi/packs/python/rules/oo_abusers.py
+++ b/src/gaudi/packs/python/rules/oo_abusers.py
@@ -196,7 +196,7 @@ class TemporaryField(Rule):
 # SMELL-023  RefusedBequest
 # ---------------------------------------------------------------
 
-_IGNORED_BASES = frozenset({"object", "ABC"})
+_IGNORED_BASES = frozenset({"object", "ABC", "Protocol"})
 
 
 def _is_refused_body(body: list[ast.stmt]) -> bool:

--- a/tests/fixtures/python/SMELL-007/expected.json
+++ b/tests/fixtures/python/SMELL-007/expected.json
@@ -13,6 +13,9 @@
     },
     "pass_cohesive.py": {
       "expected_findings": []
+    },
+    "pass_injected_deps.py": {
+      "expected_findings": []
     }
   }
 }

--- a/tests/fixtures/python/SMELL-007/pass_injected_deps.py
+++ b/tests/fixtures/python/SMELL-007/pass_injected_deps.py
@@ -1,0 +1,27 @@
+"""Fixture for SMELL-007: coordinator class with injected dependencies.
+
+A class whose __init__ injects dependencies (self.x = x) and whose
+methods access disjoint subsets of those dependencies is an orchestrator,
+not a case of divergent change. The disjoint attribute sets come from
+coordinating different services, not from unrelated internal state.
+"""
+
+
+class OrderPipeline:
+    def __init__(self, validator, pricer, inventory, notifications):
+        self.validator = validator
+        self.pricer = pricer
+        self.inventory = inventory
+        self.notifications = notifications
+
+    def validate(self, order):
+        return self.validator.check(order)
+
+    def price(self, order):
+        return self.pricer.calculate(order)
+
+    def reserve(self, order):
+        return self.inventory.reserve(order)
+
+    def notify(self, order):
+        return self.notifications.send(order)

--- a/tests/fixtures/python/SMELL-023/expected.json
+++ b/tests/fixtures/python/SMELL-023/expected.json
@@ -13,6 +13,9 @@
     },
     "pass_full_override.py": {
       "expected_findings": []
+    },
+    "pass_protocol_class.py": {
+      "expected_findings": []
     }
   }
 }

--- a/tests/fixtures/python/SMELL-023/pass_protocol_class.py
+++ b/tests/fixtures/python/SMELL-023/pass_protocol_class.py
@@ -1,0 +1,16 @@
+"""Fixture for SMELL-023: Protocol class with stub method bodies.
+
+Protocol classes use ``...`` or ``pass`` as method bodies to define
+the interface contract. This is not a refused bequest — Protocol
+methods are declarations, not inherited behavior being refused.
+"""
+
+from typing import Protocol
+
+
+class Repository(Protocol):
+    def get(self, key: str) -> object: ...
+
+    def save(self, key: str, value: object) -> None: ...
+
+    def delete(self, key: str) -> None: ...


### PR DESCRIPTION
## Summary

- **SMELL-007**: Exclude constructor-injected dependency attributes (`self.x = x` where `x` is an `__init__` parameter) from disjoint group analysis. Coordinator classes that delegate to injected services aren't divergent — they're orchestrators by design. Fixes 3 false positives on Classical exemplar (OrderPipeline, PricingService, ValidationService).
- **SMELL-023**: Add `Protocol` to `_IGNORED_BASES`. Protocol classes define interface contracts via `...`/`pass` bodies — that's a declaration, not refused inherited behavior. Fixes false positive on Classical exemplar's `InventoryRepository(Protocol)`.

Phase 2 detector precision fixes, batch 4 of 4. Items 7, 8 from the SESSION_STATE.md list.

## Test plan

- [x] New fixture: `SMELL-007/pass_injected_deps.py` — orchestrator with injected deps passes
- [x] New fixture: `SMELL-023/pass_protocol_class.py` — Protocol class passes
- [x] Existing fail fixtures still fire correctly
- [x] Classical exemplar: SMELL-007 and SMELL-023 no longer fire
- [x] Full suite: 716 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)