### PR TITLE
feat(cli): philosophy attribution in findings output

### DIFF
--- a/src/gaudi/cli.py
+++ b/src/gaudi/cli.py
@@ -18,7 +18,7 @@ import click
 from rich.console import Console
 from rich.text import Text
 
-from gaudi.config import load_config
+from gaudi.config import get_school, load_config
 from gaudi.core import Severity
 from gaudi.engine import Engine
 from gaudi.formats import format_github, format_markdown_report
@@ -85,7 +85,10 @@ def check(
             sys.exit(1)
 
     # Run checks
-    findings = engine.check(project_path, pack_names=pack_names, min_severity=min_severity)
+    school = get_school(config)
+    findings = engine.check(
+        project_path, pack_names=pack_names, min_severity=min_severity, school=school
+    )
 
     # Output results
     if output_format == "json":
@@ -117,6 +120,10 @@ def check(
                 header.append(" [", style="dim")
                 header.append(label, style=style)
                 header.append("]", style="dim")
+
+                # Philosophy scope (only for scoped rules)
+                if finding.scope_label:
+                    header.append(f" ({finding.scope_label})", style="magenta")
 
                 # Location
                 if finding.file:
@@ -198,7 +205,10 @@ def report(
             console.print(f"Available packs: {', '.join(engine.packs.keys()) or 'none installed'}")
             sys.exit(1)
 
-    findings = engine.check(project_path, pack_names=pack_names, min_severity=min_severity)
+    school = get_school(config)
+    findings = engine.check(
+        project_path, pack_names=pack_names, min_severity=min_severity, school=school
+    )
     markdown = format_markdown_report(findings, project_path, snippet_context=snippet_context)
 
     if output:

--- a/src/gaudi/core.py
+++ b/src/gaudi/core.py
@@ -92,6 +92,7 @@ class Finding:
     file: str | None = None
     line: int | None = None
     context: dict[str, Any] = field(default_factory=dict)
+    philosophy_scope: frozenset[str] = field(default_factory=frozenset)
 
     def to_dict(self) -> dict[str, Any]:
         d = {
@@ -107,10 +108,19 @@ class Finding:
             d["line"] = self.line
         if self.context:
             d["context"] = self.context
+        if self.philosophy_scope and "universal" not in self.philosophy_scope:
+            d["philosophy_scope"] = sorted(self.philosophy_scope)
         return d
 
     def to_json(self) -> str:
         return json.dumps(self.to_dict(), indent=2)
+
+    @property
+    def scope_label(self) -> str:
+        """Human-readable scope label, empty for universal rules."""
+        if not self.philosophy_scope or "universal" in self.philosophy_scope:
+            return ""
+        return ", ".join(sorted(self.philosophy_scope))
 
     def format_human(self) -> str:
         severity_tag = self.severity.value.upper()
@@ -120,7 +130,8 @@ class Finding:
             if self.line:
                 location += f":{self.line}"
 
-        lines = [f"{self.code} [{severity_tag}]{location} - {self.message}"]
+        scope = f" ({self.scope_label})" if self.scope_label else ""
+        lines = [f"{self.code} [{severity_tag}]{scope}{location} - {self.message}"]
         if self.recommendation:
             lines.append(f"  -> {self.recommendation}")
         return "\n".join(lines)
@@ -230,4 +241,5 @@ class Rule:
             file=file,
             line=line,
             context=kwargs,
+            philosophy_scope=self.philosophy_scope,
         )

--- a/src/gaudi/engine.py
+++ b/src/gaudi/engine.py
@@ -48,6 +48,7 @@ class Engine:
         path: Path,
         pack_names: list[str] | None = None,
         min_severity: Severity = Severity.INFO,
+        school: str | None = None,
     ) -> list[Finding]:
         """
         Run architectural checks on the given path.
@@ -56,6 +57,7 @@ class Engine:
             path: File or directory to check.
             pack_names: Specific packs to use. If None, auto-detect.
             min_severity: Minimum severity level to include in results.
+            school: Philosophy school to filter rules by.
 
         Returns:
             List of findings sorted by severity then code.
@@ -70,7 +72,7 @@ class Engine:
 
         findings: list[Finding] = []
         for pack in packs:
-            pack_findings = pack.check(path)
+            pack_findings = pack.check(path, school=school)
             findings.extend(pack_findings)
 
         # Filter by minimum severity

--- a/src/gaudi/formats.py
+++ b/src/gaudi/formats.py
@@ -71,7 +71,10 @@ def format_github(findings: list[Finding], project_path: Path | None = None) -> 
         if f.line is not None:
             props.append(f"line={f.line}")
 
-        props.append(f"title={_escape_github_property(f.code)}")
+        title = f.code
+        if f.scope_label:
+            title += f" ({f.scope_label})"
+        props.append(f"title={_escape_github_property(title)}")
 
         prop_str = ",".join(props)
         message = _escape_github_data(f.message)
@@ -165,9 +168,12 @@ def format_markdown_report(
             label = f"{rel_str}:{f.line}" if f.line is not None else rel_str
             location_link = f"[{label}]({rel_str}{anchor})"
 
-        out.append(f"### {f.code} — {f.severity.label}")
+        scope_tag = f" ({f.scope_label})" if f.scope_label else ""
+        out.append(f"### {f.code}{scope_tag} — {f.severity.label}")
         out.append("")
         out.append(f"- **Category:** {f.category.value}")
+        if f.scope_label:
+            out.append(f"- **Schools:** {f.scope_label}")
         if location_link:
             out.append(f"- **Location:** {location_link}")
         out.append(f"- **Message:** {f.message}")

--- a/tests/test_report_formats.py
+++ b/tests/test_report_formats.py
@@ -119,6 +119,84 @@ class TestMarkdownReport:
         assert "Project-level findings" in out
 
 
+class TestPhilosophyAttribution:
+    def test_universal_finding_has_empty_scope_label(self) -> None:
+        f = _make_finding()
+        assert f.scope_label == ""
+
+    def test_scoped_finding_has_sorted_scope_label(self) -> None:
+        f = Finding(
+            code="DOM-001",
+            severity=Severity.WARN,
+            category=Category.DOMAIN_MODEL,
+            message="anemic",
+            recommendation="fix",
+            philosophy_scope=frozenset({"convention", "classical"}),
+        )
+        assert f.scope_label == "classical, convention"
+
+    def test_to_dict_omits_scope_for_universal(self) -> None:
+        f = _make_finding()
+        assert "philosophy_scope" not in f.to_dict()
+
+    def test_to_dict_includes_scope_for_scoped(self) -> None:
+        f = Finding(
+            code="DOM-001",
+            severity=Severity.WARN,
+            category=Category.DOMAIN_MODEL,
+            message="anemic",
+            recommendation="fix",
+            philosophy_scope=frozenset({"classical", "convention"}),
+        )
+        d = f.to_dict()
+        assert d["philosophy_scope"] == ["classical", "convention"]
+
+    def test_format_human_includes_scope(self) -> None:
+        f = Finding(
+            code="DOM-001",
+            severity=Severity.WARN,
+            category=Category.DOMAIN_MODEL,
+            message="anemic",
+            recommendation="fix",
+            philosophy_scope=frozenset({"classical"}),
+        )
+        assert "(classical)" in f.format_human()
+
+    def test_format_human_omits_scope_for_universal(self) -> None:
+        f = _make_finding()
+        human = f.format_human()
+        assert "(" not in human.split(" - ")[0]
+
+    def test_github_title_includes_scope(self) -> None:
+        f = Finding(
+            code="DOM-001",
+            severity=Severity.WARN,
+            category=Category.DOMAIN_MODEL,
+            message="anemic",
+            recommendation="fix",
+            philosophy_scope=frozenset({"classical"}),
+        )
+        out = format_github([f])
+        assert "title=DOM-001 (classical)" in out
+
+    def test_markdown_heading_includes_scope(self, tmp_path: Path) -> None:
+        src = tmp_path / "m.py"
+        src.write_text("x = 1\n")
+        f = Finding(
+            code="DOM-001",
+            severity=Severity.WARN,
+            category=Category.DOMAIN_MODEL,
+            message="anemic",
+            recommendation="fix",
+            file=str(src),
+            line=1,
+            philosophy_scope=frozenset({"classical", "convention"}),
+        )
+        out = format_markdown_report([f], tmp_path)
+        assert "### DOM-001 (classical, convention)" in out
+        assert "**Schools:** classical, convention" in out
+
+
 class TestCliWiring:
     def test_check_format_github_runs_on_clean_dir(self, tmp_path: Path) -> None:
         runner = CliRunner()


### PR DESCRIPTION
## Summary

- Add `philosophy_scope` field to `Finding` dataclass, populated from `Rule.philosophy_scope`
- Scoped rules show their school list in all output formats (text, JSON, GitHub, Markdown)
- Universal rules show no scope tag — only school-specific rules are annotated
- Wire school from CLI config through engine to packs

Example output:
```
DOM-001 [WARN] (classical, convention) models.py:327 - Domain model...
ARCH-001 [WARN] - Project has 13 related models...
```

## Test plan

- [x] 8 new tests in `TestPhilosophyAttribution` covering scope_label, to_dict, format_human, GitHub title, Markdown heading
- [x] Full suite: 730 passed (no regressions)
- [x] Visual verification on Convention exemplar output

🤖 Generated with [Claude Code](https://claude.com/claude-code)