### PR TITLE
feat(cli): gaudi philosophy command for school inference

### DIFF
--- a/src/gaudi/cli.py
+++ b/src/gaudi/cli.py
@@ -239,5 +239,66 @@ def list_packs():
         console.print()
 
 
+@main.command()
+@click.argument("path", type=click.Path(exists=True), default=".")
+@click.option(
+    "--format",
+    "-f",
+    "output_format",
+    type=click.Choice(["text", "json"]),
+    default="text",
+    help="Output format.",
+)
+def philosophy(path: str, output_format: str):
+    """Infer the architectural philosophy of a project.
+
+    Analyzes dependencies, project structure, and code patterns to
+    recommend which philosophy school best matches the project. Use
+    this to decide what to put in [philosophy].school in gaudi.toml.
+    """
+    from gaudi.philosophy import infer_philosophy
+
+    project_path = Path(path).resolve()
+    result = infer_philosophy(project_path)
+
+    if output_format == "json":
+        import json as json_mod
+
+        output = {
+            "path": str(project_path),
+            "recommended": result.recommended,
+            "scores": result.scores,
+            "signals": [
+                {"school": s.school, "reason": s.reason, "weight": s.weight}
+                for s in result.signals
+            ],
+        }
+        click.echo(json_mod.dumps(output, indent=2))
+    else:
+        console.print()
+        if not result.signals:
+            console.print("[yellow]No strong signals detected.[/yellow]")
+            console.print("Default school: [bold]classical[/bold]")
+            console.print()
+            return
+
+        console.print("[bold]Philosophy inference[/bold]")
+        console.print()
+
+        # Show signals grouped by school
+        for school, score in result.scores.items():
+            console.print(f"  [cyan]{school}[/cyan] (score: {score})")
+            school_signals = [s for s in result.signals if s.school == school]
+            for s in school_signals:
+                console.print(f"    — {s.reason}")
+            console.print()
+
+        recommended = result.recommended
+        console.print(f"[bold green]Recommended:[/bold green] {recommended}")
+        console.print()
+        console.print(f'  [dim]echo \'[philosophy]\\nschool = "{recommended}"\' >> gaudi.toml[/dim]')
+        console.print()
+
+
 if __name__ == "__main__":
     main()

--- a/src/gaudi/cli.py
+++ b/src/gaudi/cli.py
@@ -269,8 +269,7 @@ def philosophy(path: str, output_format: str):
             "recommended": result.recommended,
             "scores": result.scores,
             "signals": [
-                {"school": s.school, "reason": s.reason, "weight": s.weight}
-                for s in result.signals
+                {"school": s.school, "reason": s.reason, "weight": s.weight} for s in result.signals
             ],
         }
         click.echo(json_mod.dumps(output, indent=2))
@@ -296,7 +295,9 @@ def philosophy(path: str, output_format: str):
         recommended = result.recommended
         console.print(f"[bold green]Recommended:[/bold green] {recommended}")
         console.print()
-        console.print(f'  [dim]echo \'[philosophy]\\nschool = "{recommended}"\' >> gaudi.toml[/dim]')
+        console.print(
+            f"  [dim]echo '[philosophy]\\nschool = \"{recommended}\"' >> gaudi.toml[/dim]"
+        )
         console.print()
 
 

--- a/src/gaudi/philosophy.py
+++ b/src/gaudi/philosophy.py
@@ -1,0 +1,185 @@
+# ABOUTME: Philosophy school inference from project signals.
+# ABOUTME: Analyzes dependencies, structure, and patterns to recommend a school.
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+
+if True:  # avoid tomllib being seen as unused when guarded by version check
+    import sys
+
+    if sys.version_info >= (3, 11):
+        import tomllib
+    else:
+        try:
+            import tomllib
+        except ImportError:
+            import tomli as tomllib
+
+
+@dataclass
+class SchoolSignal:
+    """One piece of evidence pointing toward a philosophy school."""
+
+    school: str
+    reason: str
+    weight: int = 1
+
+
+@dataclass
+class InferenceResult:
+    """The output of philosophy inference — a ranked list of schools with evidence."""
+
+    signals: list[SchoolSignal] = field(default_factory=list)
+
+    @property
+    def scores(self) -> dict[str, int]:
+        totals: dict[str, int] = {}
+        for s in self.signals:
+            totals[s.school] = totals.get(s.school, 0) + s.weight
+        return dict(sorted(totals.items(), key=lambda kv: -kv[1]))
+
+    @property
+    def recommended(self) -> str | None:
+        s = self.scores
+        return next(iter(s), None) if s else None
+
+
+# ---------------------------------------------------------------------------
+# Signal detectors
+# ---------------------------------------------------------------------------
+
+_FRAMEWORK_SIGNALS: dict[str, list[tuple[str, str]]] = {
+    "django": [
+        ("convention", "Django is a convention-over-configuration framework"),
+    ],
+    "flask": [
+        ("pragmatic", "Flask is a micro-framework favoring pragmatic simplicity"),
+    ],
+    "fastapi": [
+        ("pragmatic", "FastAPI favors pragmatic, function-based endpoints"),
+    ],
+    "sqlalchemy": [
+        ("classical", "SQLAlchemy's ORM encourages rich domain models"),
+    ],
+    "pydantic": [
+        ("classical", "Pydantic models are structured domain objects"),
+    ],
+    "numpy": [
+        ("data-oriented", "NumPy signals batch/array processing patterns"),
+    ],
+    "pandas": [
+        ("data-oriented", "Pandas signals tabular data processing"),
+    ],
+    "polars": [
+        ("data-oriented", "Polars signals columnar batch processing"),
+    ],
+    "celery": [
+        ("event-sourced", "Celery task queues signal event-driven architecture"),
+    ],
+    "kafka": [
+        ("event-sourced", "Kafka signals event streaming architecture"),
+    ],
+    "tenacity": [
+        ("resilient", "Tenacity signals retry/resilience patterns"),
+    ],
+    "circuitbreaker": [
+        ("resilient", "Circuit breaker library signals resilience-first design"),
+    ],
+}
+
+
+def _read_dependencies(project_path: Path) -> set[str]:
+    """Extract dependency names from pyproject.toml, requirements.txt, or setup.cfg."""
+    deps: set[str] = set()
+
+    pyproject = project_path / "pyproject.toml"
+    if pyproject.exists():
+        try:
+            with open(pyproject, "rb") as f:
+                data = tomllib.load(f)
+            for dep in data.get("project", {}).get("dependencies", []):
+                name = dep.split(">=")[0].split("<=")[0].split("==")[0].split("[")[0].strip()
+                deps.add(name.lower())
+        except Exception:
+            pass
+
+    for req_file in ("requirements.txt", "requirements.in"):
+        req_path = project_path / req_file
+        if req_path.exists():
+            try:
+                for line in req_path.read_text(encoding="utf-8").splitlines():
+                    line = line.strip()
+                    if not line or line.startswith("#") or line.startswith("-"):
+                        continue
+                    name = line.split(">=")[0].split("<=")[0].split("==")[0].split("[")[0].strip()
+                    deps.add(name.lower())
+            except Exception:
+                pass
+
+    return deps
+
+
+def _detect_dependency_signals(deps: set[str]) -> list[SchoolSignal]:
+    signals: list[SchoolSignal] = []
+    for dep_name, school_entries in _FRAMEWORK_SIGNALS.items():
+        if dep_name in deps:
+            for school, reason in school_entries:
+                signals.append(SchoolSignal(school=school, reason=reason, weight=2))
+    return signals
+
+
+def _detect_structure_signals(project_path: Path) -> list[SchoolSignal]:
+    """Detect philosophy signals from project structure."""
+    signals: list[SchoolSignal] = []
+
+    # Shell scripts suggest Unix philosophy
+    sh_files = list(project_path.rglob("*.sh"))
+    makefiles = list(project_path.glob("Makefile"))
+    if sh_files or makefiles:
+        signals.append(SchoolSignal(
+            school="unix",
+            reason=f"Found {len(sh_files)} shell script(s) and {len(makefiles)} Makefile(s)",
+        ))
+
+    # Protocol classes suggest classical OOP
+    py_files = list(project_path.rglob("*.py"))
+    protocol_count = 0
+    for py_file in py_files[:50]:  # cap file scanning
+        try:
+            content = py_file.read_text(encoding="utf-8", errors="replace")
+            if "Protocol" in content and "from typing" in content:
+                protocol_count += 1
+        except Exception:
+            pass
+    if protocol_count >= 2:
+        signals.append(SchoolSignal(
+            school="classical",
+            reason=f"Found {protocol_count} files using typing.Protocol (interface segregation)",
+        ))
+
+    # models.py + admin.py suggest Django/convention
+    if list(project_path.rglob("models.py")) and list(project_path.rglob("admin.py")):
+        signals.append(SchoolSignal(
+            school="convention",
+            reason="Found models.py + admin.py (Django app structure)",
+            weight=2,
+        ))
+
+    # migrations/ directory suggests convention
+    if list(project_path.rglob("migrations/")):
+        signals.append(SchoolSignal(
+            school="convention",
+            reason="Found migrations/ directory (framework-managed schema)",
+        ))
+
+    return signals
+
+
+def infer_philosophy(project_path: Path) -> InferenceResult:
+    """Analyze a project and return ranked philosophy school recommendations."""
+    result = InferenceResult()
+    deps = _read_dependencies(project_path)
+    result.signals.extend(_detect_dependency_signals(deps))
+    result.signals.extend(_detect_structure_signals(project_path))
+    return result

--- a/src/gaudi/philosophy.py
+++ b/src/gaudi/philosophy.py
@@ -137,10 +137,12 @@ def _detect_structure_signals(project_path: Path) -> list[SchoolSignal]:
     sh_files = list(project_path.rglob("*.sh"))
     makefiles = list(project_path.glob("Makefile"))
     if sh_files or makefiles:
-        signals.append(SchoolSignal(
-            school="unix",
-            reason=f"Found {len(sh_files)} shell script(s) and {len(makefiles)} Makefile(s)",
-        ))
+        signals.append(
+            SchoolSignal(
+                school="unix",
+                reason=f"Found {len(sh_files)} shell script(s) and {len(makefiles)} Makefile(s)",
+            )
+        )
 
     # Protocol classes suggest classical OOP
     py_files = list(project_path.rglob("*.py"))
@@ -153,25 +155,31 @@ def _detect_structure_signals(project_path: Path) -> list[SchoolSignal]:
         except Exception:
             pass
     if protocol_count >= 2:
-        signals.append(SchoolSignal(
-            school="classical",
-            reason=f"Found {protocol_count} files using typing.Protocol (interface segregation)",
-        ))
+        signals.append(
+            SchoolSignal(
+                school="classical",
+                reason=f"Found {protocol_count} files using typing.Protocol (interface segregation)",
+            )
+        )
 
     # models.py + admin.py suggest Django/convention
     if list(project_path.rglob("models.py")) and list(project_path.rglob("admin.py")):
-        signals.append(SchoolSignal(
-            school="convention",
-            reason="Found models.py + admin.py (Django app structure)",
-            weight=2,
-        ))
+        signals.append(
+            SchoolSignal(
+                school="convention",
+                reason="Found models.py + admin.py (Django app structure)",
+                weight=2,
+            )
+        )
 
     # migrations/ directory suggests convention
     if list(project_path.rglob("migrations/")):
-        signals.append(SchoolSignal(
-            school="convention",
-            reason="Found migrations/ directory (framework-managed schema)",
-        ))
+        signals.append(
+            SchoolSignal(
+                school="convention",
+                reason="Found migrations/ directory (framework-managed schema)",
+            )
+        )
 
     return signals
 

--- a/tests/test_philosophy_inference.py
+++ b/tests/test_philosophy_inference.py
@@ -1,0 +1,105 @@
+# ABOUTME: Tests for the philosophy inference engine that recommends a school
+# ABOUTME: based on project dependencies, structure, and code patterns.
+from __future__ import annotations
+
+from pathlib import Path
+
+from click.testing import CliRunner
+
+from gaudi.cli import main
+from gaudi.philosophy import SchoolSignal, InferenceResult, infer_philosophy
+
+
+class TestSchoolSignal:
+    def test_signal_default_weight(self) -> None:
+        s = SchoolSignal(school="classical", reason="test")
+        assert s.weight == 1
+
+
+class TestInferenceResult:
+    def test_empty_result(self) -> None:
+        r = InferenceResult()
+        assert r.scores == {}
+        assert r.recommended is None
+
+    def test_scores_sum_weights(self) -> None:
+        r = InferenceResult(signals=[
+            SchoolSignal("classical", "a", weight=2),
+            SchoolSignal("classical", "b", weight=1),
+            SchoolSignal("pragmatic", "c", weight=3),
+        ])
+        assert r.scores == {"pragmatic": 3, "classical": 3}
+
+    def test_recommended_is_highest_score(self) -> None:
+        r = InferenceResult(signals=[
+            SchoolSignal("convention", "django", weight=5),
+            SchoolSignal("classical", "sqlalchemy", weight=2),
+        ])
+        assert r.recommended == "convention"
+
+
+class TestDependencyDetection:
+    def test_django_signals_convention(self, tmp_path: Path) -> None:
+        (tmp_path / "requirements.txt").write_text("django>=4.0\n")
+        result = infer_philosophy(tmp_path)
+        schools = [s.school for s in result.signals]
+        assert "convention" in schools
+
+    def test_numpy_signals_data_oriented(self, tmp_path: Path) -> None:
+        (tmp_path / "requirements.txt").write_text("numpy>=1.26\n")
+        result = infer_philosophy(tmp_path)
+        schools = [s.school for s in result.signals]
+        assert "data-oriented" in schools
+
+    def test_tenacity_signals_resilient(self, tmp_path: Path) -> None:
+        (tmp_path / "pyproject.toml").write_text(
+            '[project]\nname = "x"\ndependencies = ["tenacity>=8.0"]\n'
+        )
+        result = infer_philosophy(tmp_path)
+        schools = [s.school for s in result.signals]
+        assert "resilient" in schools
+
+    def test_no_deps_no_signals(self, tmp_path: Path) -> None:
+        result = infer_philosophy(tmp_path)
+        assert result.signals == []
+
+
+class TestStructureDetection:
+    def test_models_and_admin_signal_convention(self, tmp_path: Path) -> None:
+        (tmp_path / "models.py").write_text("class M: pass\n")
+        (tmp_path / "admin.py").write_text("class A: pass\n")
+        result = infer_philosophy(tmp_path)
+        convention_signals = [s for s in result.signals if s.school == "convention"]
+        assert len(convention_signals) >= 1
+
+    def test_shell_scripts_signal_unix(self, tmp_path: Path) -> None:
+        (tmp_path / "deploy.sh").write_text("#!/bin/bash\n")
+        result = infer_philosophy(tmp_path)
+        unix_signals = [s for s in result.signals if s.school == "unix"]
+        assert len(unix_signals) >= 1
+
+
+class TestCliPhilosophyCommand:
+    def test_text_output(self, tmp_path: Path) -> None:
+        (tmp_path / "requirements.txt").write_text("django>=4.0\n")
+        runner = CliRunner()
+        result = runner.invoke(main, ["philosophy", str(tmp_path)])
+        assert result.exit_code == 0, result.output
+        assert "convention" in result.output
+        assert "Recommended" in result.output
+
+    def test_json_output(self, tmp_path: Path) -> None:
+        (tmp_path / "requirements.txt").write_text("django>=4.0\n")
+        runner = CliRunner()
+        result = runner.invoke(main, ["philosophy", str(tmp_path), "--format", "json"])
+        assert result.exit_code == 0, result.output
+        import json
+        data = json.loads(result.output)
+        assert data["recommended"] == "convention"
+        assert "convention" in data["scores"]
+
+    def test_empty_project(self, tmp_path: Path) -> None:
+        runner = CliRunner()
+        result = runner.invoke(main, ["philosophy", str(tmp_path)])
+        assert result.exit_code == 0, result.output
+        assert "No strong signals" in result.output

--- a/tests/test_philosophy_inference.py
+++ b/tests/test_philosophy_inference.py
@@ -23,18 +23,22 @@ class TestInferenceResult:
         assert r.recommended is None
 
     def test_scores_sum_weights(self) -> None:
-        r = InferenceResult(signals=[
-            SchoolSignal("classical", "a", weight=2),
-            SchoolSignal("classical", "b", weight=1),
-            SchoolSignal("pragmatic", "c", weight=3),
-        ])
+        r = InferenceResult(
+            signals=[
+                SchoolSignal("classical", "a", weight=2),
+                SchoolSignal("classical", "b", weight=1),
+                SchoolSignal("pragmatic", "c", weight=3),
+            ]
+        )
         assert r.scores == {"pragmatic": 3, "classical": 3}
 
     def test_recommended_is_highest_score(self) -> None:
-        r = InferenceResult(signals=[
-            SchoolSignal("convention", "django", weight=5),
-            SchoolSignal("classical", "sqlalchemy", weight=2),
-        ])
+        r = InferenceResult(
+            signals=[
+                SchoolSignal("convention", "django", weight=5),
+                SchoolSignal("classical", "sqlalchemy", weight=2),
+            ]
+        )
         assert r.recommended == "convention"
 
 
@@ -94,6 +98,7 @@ class TestCliPhilosophyCommand:
         result = runner.invoke(main, ["philosophy", str(tmp_path), "--format", "json"])
         assert result.exit_code == 0, result.output
         import json
+
         data = json.loads(result.output)
         assert data["recommended"] == "convention"
         assert "convention" in data["scores"]


### PR DESCRIPTION
## Summary

- New `gaudi philosophy` command that infers which architectural school best matches a project
- Analyzes dependencies (pyproject.toml, requirements.txt) and project structure (file patterns, code signals)
- Outputs ranked schools with evidence in text or JSON format
- Suggests a gaudi.toml snippet for the recommended school

Example:
```
$ gaudi philosophy .

Philosophy inference

  convention (score: 3)
    — Found models.py + admin.py (Django app structure)
    — Found migrations/ directory (framework-managed schema)

  unix (score: 1)
    — Found 2 shell script(s) and 0 Makefile(s)

Recommended: convention
```

## Test plan

- [x] 13 new tests covering signal detection, scoring, CLI text/JSON output, and empty projects
- [x] Full suite: 735 passed
- [x] Tested on Gaudi project itself

🤖 Generated with [Claude Code](https://claude.com/claude-code)