### PR TITLE
fix(rules): Django false positives — urlpatterns, local settings, filter chains

### DIFF
--- a/src/gaudi/packs/python/rules/django.py
+++ b/src/gaudi/packs/python/rules/django.py
@@ -9,6 +9,7 @@ from gaudi.packs.python.context import PythonContext
 
 _TEST_PLACEHOLDER_PREFIXES = ("test-", "test_", "test.", "dummy-", "dummy_", "fake-", "fake_")
 _TEST_PLACEHOLDER_SUBSTRINGS = ("example", "placeholder", "not-used", "not_used")
+_DEV_SETTINGS_MARKERS = ("local", "dev", "development", "testing")
 
 
 def _is_test_placeholder(value: str) -> bool:
@@ -74,10 +75,18 @@ class DjangoDebugTrue(Rule):
         "Set DEBUG = False in production. Use environment variables to control debug mode."
     )
 
+    @staticmethod
+    def _is_dev_settings(path: str) -> bool:
+        """Settings files for local/dev/testing are expected to have DEBUG=True."""
+        lowered = path.replace("\\", "/").lower()
+        return any(marker in lowered for marker in _DEV_SETTINGS_MARKERS)
+
     def check(self, context: PythonContext) -> list[Finding]:
         findings = []
         for f in context.files:
             if "settings" not in f.relative_path.lower():
+                continue
+            if self._is_dev_settings(f.relative_path):
                 continue
             tree = f.ast_tree
             if tree is None:

--- a/src/gaudi/packs/python/rules/smells.py
+++ b/src/gaudi/packs/python/rules/smells.py
@@ -229,6 +229,9 @@ class GlobalData(Rule):
                 # ALL_CAPS non-empty dict/list = reference data table
                 if is_allcaps and _is_reference_data(value):
                     continue
+                # Django urlpatterns is a module-level list by design
+                if any(isinstance(t, ast.Name) and t.id == "urlpatterns" for t in node.targets):
+                    continue
                 # Flag mutable containers
                 is_mutable = isinstance(value, (ast.Dict, ast.List, ast.Set)) or _is_mutable_call(
                     value

--- a/src/gaudi/packs/python/rules/stability.py
+++ b/src/gaudi/packs/python/rules/stability.py
@@ -20,7 +20,7 @@ def _parse_safe(source: str) -> ast.Module | None:
 # Nygard Ch. 4: "Unbounded Result Sets" anti-pattern
 # ---------------------------------------------------------------
 
-_ORM_ALL_ATTRS = frozenset({"all", "filter", "exclude", "select_related", "prefetch_related"})
+_ORM_ALL_ATTRS = frozenset({"all"})
 _BOUNDING_TERMINALS = frozenset({"first", "last", "get", "count", "exists", "aggregate"})
 
 

--- a/tests/fixtures/python/DJ-SEC-002/expected.json
+++ b/tests/fixtures/python/DJ-SEC-002/expected.json
@@ -16,6 +16,9 @@
     },
     "pass_settings_debug_from_env.py": {
       "expected_findings": []
+    },
+    "pass_local_settings.py": {
+      "expected_findings": []
     }
   }
 }

--- a/tests/fixtures/python/DJ-SEC-002/pass_local_settings.py
+++ b/tests/fixtures/python/DJ-SEC-002/pass_local_settings.py
@@ -1,0 +1,3 @@
+"""Fixture for DJ-SEC-002: DEBUG=True in local/dev settings is expected."""
+
+DEBUG = True

--- a/tests/fixtures/python/SMELL-005/expected.json
+++ b/tests/fixtures/python/SMELL-005/expected.json
@@ -18,6 +18,9 @@
     },
     "pass_constants_only.py": {
       "expected_findings": []
+    },
+    "pass_django_urlpatterns.py": {
+      "expected_findings": []
     }
   }
 }

--- a/tests/fixtures/python/SMELL-005/pass_django_urlpatterns.py
+++ b/tests/fixtures/python/SMELL-005/pass_django_urlpatterns.py
@@ -1,0 +1,8 @@
+"""Fixture for SMELL-005: Django urlpatterns is a module-level list by design."""
+
+from django.urls import path
+
+urlpatterns = [
+    path("home/", lambda r: None, name="home"),
+    path("about/", lambda r: None, name="about"),
+]

--- a/tests/fixtures/python/STAB-001/expected.json
+++ b/tests/fixtures/python/STAB-001/expected.json
@@ -8,11 +8,6 @@
           "severity": "warn",
           "line": 5,
           "message_contains": "all"
-        },
-        {
-          "severity": "warn",
-          "line": 9,
-          "message_contains": "filter"
         }
       ]
     },
@@ -23,6 +18,9 @@
       "expected_findings": []
     },
     "pass_filter_chain_bounded.py": {
+      "expected_findings": []
+    },
+    "pass_filter_only.py": {
       "expected_findings": []
     }
   }

--- a/tests/fixtures/python/STAB-001/pass_filter_only.py
+++ b/tests/fixtures/python/STAB-001/pass_filter_only.py
@@ -1,0 +1,13 @@
+"""Fixture for STAB-001: .filter() and .select_related() are query-building, not materializing."""
+
+
+class Manager:
+    objects = None
+
+
+def get_filtered():
+    return Manager.objects.filter(active=True).select_related("profile")
+
+
+def get_excluded():
+    return Manager.objects.exclude(deleted=True).prefetch_related("items")


### PR DESCRIPTION
## Summary

Three Django-specific false positive fixes surfaced by the AIgranthelper audit:

- **SMELL-005**: Exempt `urlpatterns` by name (9 false positives on AIgranthelper)
- **DJ-SEC-002**: Skip settings files with "local"/"dev"/"testing" in the path
- **STAB-001**: Only flag `.all()` — remove `.filter()`, `.exclude()`, `.select_related()`, `.prefetch_related()` from triggering set (55→~5 findings on AIgranthelper)

Fixes #152.

## Test plan

- [x] New fixtures for all three rules
- [x] 763 passed, ruff clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)