### PR TITLE
fix: issue batch — #68, #79, #84, #110, #122

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,6 +33,15 @@ We take supply chain security seriously. All contributions are reviewed with thi
 
 We recommend (but don't yet require) [signed commits](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits). This may become mandatory as the project matures.
 
+## Editorial Doctrine
+
+Every rule design question in Gaudi must appeal to a principle. The fourteen
+numbered principles in three pillars (Truthfulness, Economy, Cost-honesty)
+govern which rules enter the catalog, how thresholds and severities are
+assigned, and when a rule should be cut. Read
+[docs/principles.md](docs/principles.md) before proposing a new rule or
+changing a threshold.
+
 ## High-Impact Contributions
 
 These are the areas where contributions will have the most impact right now:

--- a/src/gaudi/packs/python/parser.py
+++ b/src/gaudi/packs/python/parser.py
@@ -105,13 +105,7 @@ SQLALCHEMY_IMPORTS = frozenset({"sqlalchemy", "sqlalchemy.orm"})
 
 # Built-in glob patterns excluded from analysis on every Python project.
 # Layered on top of the universal CORE_EXCLUDE_GLOBS from gaudi.excludes.
-# ``migrations`` is here because Django auto-generates that directory and
-# it never reflects intentional architecture; removing it is tracked as
-# a follow-up.
-DEFAULT_EXCLUDE_GLOBS: tuple[str, ...] = (
-    *CORE_EXCLUDE_GLOBS,
-    "**/migrations/**",
-)
+DEFAULT_EXCLUDE_GLOBS: tuple[str, ...] = (*CORE_EXCLUDE_GLOBS,)
 
 
 def parse_project(path: Path, extra_excludes: list[str] | None = None) -> PythonContext:

--- a/src/gaudi/packs/python/rules/bloaters.py
+++ b/src/gaudi/packs/python/rules/bloaters.py
@@ -42,7 +42,7 @@ class LongFunction(Rule):
                 if node.end_lineno is None:
                     continue
                 lines = node.end_lineno - node.lineno + 1
-                if lines > 25:
+                if lines > 30:
                     findings.append(
                         self.finding(
                             file=f.relative_path,

--- a/src/gaudi/packs/python/rules/py314.py
+++ b/src/gaudi/packs/python/rules/py314.py
@@ -456,27 +456,72 @@ class TarfileNoFilter(Rule):
             except SyntaxError:
                 continue
 
+            # Collect names that are tarfile objects (assigned from tarfile.open)
+            tarfile_names = self._find_tarfile_names(tree)
             for node in ast.walk(tree):
                 if isinstance(node, ast.Call):
-                    func_name = self._get_call_name(node)
-                    if func_name and func_name.endswith((".extract", ".extractall")):
-                        # Check if 'filter' is in keyword arguments
-                        has_filter = any(kw.arg == "filter" for kw in node.keywords)
-                        if not has_filter:
-                            findings.append(
-                                self.finding(
-                                    file=file_info.relative_path,
-                                    line=node.lineno,
-                                )
+                    if not self._is_tarfile_extract(node, tarfile_names):
+                        continue
+                    has_filter = any(kw.arg == "filter" for kw in node.keywords)
+                    if not has_filter:
+                        findings.append(
+                            self.finding(
+                                file=file_info.relative_path,
+                                line=node.lineno,
                             )
+                        )
         return findings
 
-    def _get_call_name(self, node: ast.Call) -> str | None:
-        if isinstance(node.func, ast.Attribute):
-            return f".{node.func.attr}"
-        if isinstance(node.func, ast.Name):
-            return node.func.id
-        return None
+    @staticmethod
+    def _find_tarfile_names(tree: ast.Module) -> set[str]:
+        """Collect variable names assigned from tarfile.open() or TarFile()."""
+        names: set[str] = set()
+        for node in ast.walk(tree):
+            # Regular assignment: tf = tarfile.open(...)
+            if isinstance(node, ast.Assign):
+                val = node.value
+                if not isinstance(val, ast.Call):
+                    continue
+                func = val.func
+                if isinstance(func, ast.Attribute) and isinstance(func.value, ast.Name):
+                    if func.value.id == "tarfile" and func.attr in ("open", "TarFile"):
+                        for t in node.targets:
+                            if isinstance(t, ast.Name):
+                                names.add(t.id)
+            # Context manager: with tarfile.open(...) as tf:
+            if isinstance(node, ast.With):
+                for item in node.items:
+                    ctx = item.context_expr
+                    if not isinstance(ctx, ast.Call):
+                        continue
+                    func = ctx.func
+                    if (
+                        isinstance(func, ast.Attribute)
+                        and isinstance(func.value, ast.Name)
+                        and func.value.id == "tarfile"
+                        and func.attr in ("open", "TarFile")
+                        and isinstance(item.optional_vars, ast.Name)
+                    ):
+                        names.add(item.optional_vars.id)
+        return names
+
+    @staticmethod
+    def _is_tarfile_extract(node: ast.Call, tarfile_names: set[str]) -> bool:
+        """Check if this call is .extract/.extractall on a tarfile object."""
+        func = node.func
+        if not isinstance(func, ast.Attribute):
+            return False
+        if func.attr not in ("extract", "extractall"):
+            return False
+        # Direct tarfile.open().extract() chain
+        if isinstance(func.value, ast.Call) and isinstance(func.value.func, ast.Attribute):
+            inner = func.value.func
+            if isinstance(inner.value, ast.Name) and inner.value.id == "tarfile":
+                return True
+        # Named variable: tf.extract() where tf was assigned from tarfile.open()
+        if isinstance(func.value, ast.Name) and func.value.id in tarfile_names:
+            return True
+        return False
 
 
 # ---------------------------------------------------------------------------

--- a/tests/fixtures/python/SMELL-003/expected.json
+++ b/tests/fixtures/python/SMELL-003/expected.json
@@ -1,6 +1,6 @@
 {
   "rule_id": "SMELL-003",
-  "description": "LongFunction -- functions exceeding 25 lines",
+  "description": "LongFunction -- functions exceeding 30 lines",
   "fixtures": {
     "fail_long_function.py": {
       "expected_findings": [
@@ -14,7 +14,7 @@
     "pass_short_function.py": {
       "expected_findings": []
     },
-    "pass_boundary_25_lines.py": {
+    "pass_boundary_30_lines.py": {
       "expected_findings": []
     }
   }

--- a/tests/fixtures/python/SMELL-003/fail_long_function.py
+++ b/tests/fixtures/python/SMELL-003/fail_long_function.py
@@ -1,4 +1,4 @@
-"""Fixture for SMELL-003: a 26-line function trips the > 25 threshold."""
+"""Fixture for SMELL-003: a 31-line function trips the > 30 threshold."""
 
 
 def process_order(order):
@@ -25,6 +25,10 @@ def process_order(order):
     order.audit_trail.append("done")
     order.audit_trail.append("emailed")
     order.audit_trail.append("queued")
+    order.audit_trail.append("archived")
+    order.audit_trail.append("confirmed")
+    order.audit_trail.append("finalized")
     order.notify()
     order.flush()
+    order.save()
     return total

--- a/tests/fixtures/python/SMELL-003/pass_boundary_30_lines.py
+++ b/tests/fixtures/python/SMELL-003/pass_boundary_30_lines.py
@@ -1,4 +1,4 @@
-"""Fixture for SMELL-003: a function exactly 25 lines long is at the boundary."""
+"""Fixture for SMELL-003: a function exactly 30 lines long is at the boundary."""
 
 
 def boundary(order):
@@ -22,5 +22,11 @@ def boundary(order):
     order.audit_trail.append("checked")
     order.audit_trail.append("logged")
     order.audit_trail.append("notified")
+    order.audit_trail.append("done")
+    order.audit_trail.append("emailed")
+    order.audit_trail.append("queued")
+    order.audit_trail.append("archived")
+    order.audit_trail.append("confirmed")
     order.notify()
+    order.flush()
     return total

--- a/tests/test_fixture_corpus_loader.py
+++ b/tests/test_fixture_corpus_loader.py
@@ -121,10 +121,7 @@ class TestMultiFileFixtures:
         rule_dir = _write_rule_dir(
             tmp_path,
             "DEMO-005",
-            {
-                "rule_id": "DEMO-005",
-                "fixtures": {"fail_branched": {"expected_findings": []}},
-            },
+            {"rule_id": "DEMO-005", "fixtures": {"fail_branched": {"expected_findings": []}}},
             {
                 "fail_branched/alembic/versions/a.py": "revision = 'a'\n",
                 "fail_branched/alembic/versions/b.py": "revision = 'b'\n",
@@ -132,25 +129,16 @@ class TestMultiFileFixtures:
         )
         case = _cases_for_rule_dir(rule_dir)[0]
 
-        with fixture_as_project(case) as project_root:
-            assert (project_root / "alembic" / "versions" / "a.py").read_text(
+        with fixture_as_project(case) as root:
+            assert (root / "alembic" / "versions" / "a.py").read_text(
                 encoding="utf-8"
             ) == "revision = 'a'\n"
-            assert (project_root / "alembic" / "versions" / "b.py").read_text(
+            assert (root / "alembic" / "versions" / "b.py").read_text(
                 encoding="utf-8"
             ) == "revision = 'b'\n"
-            # The fail_ prefix is NOT preserved at the project root.
-            assert not (project_root / "fail_branched").exists(), (
-                "directory fixture wrapper should not appear in temp project"
-            )
-            # Directory fixtures own their project shape -- the runner does NOT
-            # synthesize a stub pyproject.toml for them. Single-file fixtures
-            # still get one (covered by test_fixture_as_project_single_file).
-            assert not (project_root / "pyproject.toml").exists(), (
-                "directory fixtures must own their project shape; runner must "
-                "not inject stub files (this is what makes STRUCT-011/013 fail "
-                "fixtures expressible)"
-            )
+            assert not (root / "fail_branched").exists()
+            # Directory fixtures own their project shape — no stub files injected
+            assert not (root / "pyproject.toml").exists()
 
     def test_mixed_single_and_multi_in_one_rule(self, tmp_path: Path) -> None:
         rule_dir = _write_rule_dir(


### PR DESCRIPTION
## Summary

Five issues from the backlog resolved in one batch:

- **#68** SMELL-003 threshold raised from 25 → 30 lines
- **#79** Remove `migrations/` from DEFAULT_EXCLUDE_GLOBS
- **#84** Add editorial doctrine section to CONTRIBUTING.md referencing docs/principles.md
- **#110** PY314-006 tightened to verify tarfile object, not any .extractall()
- **#122** Refactor long test from 35 → 22 lines

Fixes #68, fixes #79, fixes #84, fixes #110, fixes #122.

## Test plan

- [x] Updated SMELL-003 fixtures for new 30-line threshold
- [x] PY314-006 fail fixture still fires correctly with context manager detection
- [x] Full suite: 760 passed, ruff clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)