### PR TITLE
docs: update README for v0.1.2 + add CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,59 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+## [0.1.2] — 2026-04-13
+
+### Added
+- **Philosophy attribution** in all output formats — scoped rules show
+  which schools they apply to (e.g., `DOM-001 [WARN] (classical, convention)`)
+- **`gaudi philosophy` command** — infers which architectural school best
+  matches a project from its dependencies and structure
+- **Severity overrides** from `[gaudi.rules]` in gaudi.toml — map rule
+  codes to severity levels or `"off"` to suppress entirely
+- **Inline `# noqa` suppression** — `# noqa: RULE-ID` suppresses specific
+  findings per line; bare `# noqa` suppresses all findings on a line
+- **Editorial doctrine section** in CONTRIBUTING.md referencing docs/principles.md
+
+### Fixed
+- **DOM-001** false positives on Django models with generic Manager types
+  (`Manager["Model"]`)
+- **DJ-SEC-001** false positives on test-placeholder SECRET_KEY values
+- **DJ-SEC-002** false positives on local/dev settings files (`DEBUG = True`)
+- **SEC-003** false positives on test-prefixed credential values
+- **SMELL-005** false positives on Django `urlpatterns` (module-level list by design)
+- **SMELL-007** false positives on coordinator/service classes with injected
+  dependencies
+- **SMELL-023** false positives on Protocol classes (stub methods are interface
+  declarations, not refused bequests)
+- **SCHEMA-001** false positives on reference/lookup models (no ForeignKey,
+  no mutable-state fields)
+- **SEC-001** noise on ordinary Django models — now only fires on
+  security-sensitive model names/paths
+- **STAB-001** noise from `.filter()`, `.select_related()`, `.exclude()`,
+  `.prefetch_related()` — only `.all()` triggers unbounded result set warnings
+- **PY314-006** false positives on non-tarfile `.extractall()` calls
+- **SMELL-003** threshold raised from 25 to 30 lines to reduce noise on
+  normal-complexity methods
+
+### Changed
+- **Migrations no longer excluded by default** — Django migration files can
+  contain architecture issues and should be linted. Add `"**/migrations/**"`
+  to `[gaudi].exclude` in gaudi.toml if you want to restore the old behavior.
+- School configuration passed from CLI through engine to packs, so
+  `[philosophy].school` in gaudi.toml is respected in all invocations
+
+### Removed
+- RFC file moved from repo root to `docs/gaudi-architectural-philosophies.md`
+
+## [0.1.1] — 2026-04-08
+
+### Added
+- Philosophy scoping system (Rule.philosophy_scope, [philosophy].school in gaudi.toml)
+- 8 reference exemplars (Classical, Pragmatic, Functional, Unix, Convention,
+  Resilient, Data-Oriented, Event-Sourced)
+- Philosophy matrix acceptance tests (206 tests)
+
+## [0.1.0] — 2026-04-07
+
+Initial alpha release. Python-only architecture linter with ~124 rules.

--- a/README.md
+++ b/README.md
@@ -179,17 +179,39 @@ severity = "warn"          # minimum severity to report
 exclude = ["migrations/"]  # paths to skip
 
 [gaudi.rules]
-"ARCH-001" = "error"       # override severity (planned, see Known Limitations)
-"IDX-003" = "off"          # disable specific rule (planned, see Known Limitations)
+"ARCH-001" = "error"       # override severity
+"IDX-003" = "off"          # disable a rule entirely
+
+[philosophy]
+school = "convention"      # infer with: gaudi philosophy .
 ```
 
-## Known Limitations (v0.1.0 alpha)
+### Inline suppression
 
-- **Per-rule severity overrides and disabling are not wired yet.** The `[gaudi.rules]` section in `gaudi.toml` is parsed but not enforced. Path exclusions via `[gaudi].exclude` work as documented.
+Suppress findings on a single line with `# noqa`:
+
+```python
+SECRET_KEY = "test-only"  # noqa: DJ-SEC-001
+urlpatterns = [...]       # noqa
+```
+
+`# noqa` (bare) suppresses all findings on that line. `# noqa: CODE1, CODE2` suppresses only the listed rules.
+
+### Philosophy inference
+
+Gaudi can recommend which architectural school best matches your project:
+
+```bash
+gaudi philosophy .
+```
+
+This analyzes your dependencies and project structure to suggest a school (e.g., `convention` for Django projects, `data-oriented` for NumPy pipelines).
+
+## Known Limitations (v0.1 alpha)
+
 - Some library-specific rules use regex on raw text instead of full AST analysis, which can produce false positives.
-- Severity assignments across the catalog have not yet been audited against the doctrine in [docs/principles.md](https://github.com/NathanKrupa/gaudi/blob/main/docs/principles.md). They are not wrong; they are unaudited.
 
-These limitations are tracked in the [issue tracker](https://github.com/NathanKrupa/gaudi/issues) and will be addressed in v0.2.
+These are tracked in the [issue tracker](https://github.com/NathanKrupa/gaudi/issues).
 
 ## Philosophy
 


### PR DESCRIPTION
## Summary

- Remove stale Known Limitations about severity overrides (now implemented)
- Document `# noqa` suppression syntax, `gaudi philosophy` command, and `[philosophy].school` config
- Add CHANGELOG.md covering v0.1.0 through v0.1.2

## Test plan

- [x] No code changes, documentation only

🤖 Generated with [Claude Code](https://claude.com/claude-code)