### PR TITLE
fix: issue batch — #140, #148, #150

### DIFF
--- a/src/gaudi/packs/ops/parser.py
+++ b/src/gaudi/packs/ops/parser.py
@@ -24,16 +24,20 @@ from gaudi.excludes import (
 from gaudi.packs.ops.context import DockerfileInfo, DockerfileLine, OpsContext
 
 
-# Only the canonical filename ``Dockerfile`` is accepted today. Stage variants
-# (``Dockerfile.prod``, ``app.Dockerfile``) are a real Docker convention but
-# distinguishing them from source files in disguise (``dockerfile.py``,
-# ``Dockerfile.tar.gz``) requires either a denylist or a config-driven
-# allowlist. Both are speculative until a user asks. The earlier
-# ``startswith("dockerfile.")`` check matched ``dockerfile.py`` during dogfood
-# and there is no clean structural rule that distinguishes "stage" from
-# "extension". Stage-variant support is tracked as a follow-up.
+# Matches canonical ``Dockerfile`` plus stage variants like
+# ``Dockerfile.prod`` and ``app.Dockerfile``. Excludes non-Docker files
+# by rejecting extensions that are clearly source code or archives.
+_NON_DOCKER_SUFFIXES = frozenset({".py", ".sh", ".yml", ".yaml", ".json", ".toml", ".gz", ".zip"})
+
+
 def _is_dockerfile(path: Path) -> bool:
-    return path.name == "Dockerfile"
+    name = path.name
+    if name == "Dockerfile":
+        return True
+    lower = name.lower()
+    if lower.startswith("dockerfile.") or lower.endswith(".dockerfile"):
+        return path.suffix.lower() not in _NON_DOCKER_SUFFIXES
+    return False
 
 
 def _stitch_instructions(source: str) -> list[DockerfileLine]:

--- a/src/gaudi/packs/python/rules/architecture.py
+++ b/src/gaudi/packs/python/rules/architecture.py
@@ -29,14 +29,15 @@ class NoTenantIsolation(Rule):
     """
 
     code = "ARCH-001"
-    severity = Severity.WARN
+    severity = Severity.INFO
     category = Category.ARCHITECTURE
     message_template = (
         "Project has {model_count} related models but no tenant isolation column detected"
     )
     recommendation_template = (
         "Consider adding a tenant_id, organization_id, or account_id ForeignKey "
-        "to models that store user data. Enforce filtering in all queries."
+        "to models that store user data. Enforce filtering in all queries. "
+        'Promote to warn with [gaudi.rules] "ARCH-001" = "warn" if multi-tenancy applies.'
     )
 
     def check(self, context: PythonContext) -> list[Finding]:

--- a/src/gaudi/packs/python/rules/pydantic.py
+++ b/src/gaudi/packs/python/rules/pydantic.py
@@ -8,6 +8,7 @@ from gaudi.core import Rule, Finding, Severity, Category
 from gaudi.packs.python.context import PythonContext
 
 _PYDANTIC_BASES = frozenset({"BaseModel", "BaseSettings"})
+_PYDANTIC_CLASS_VARS = frozenset({"model_config", "model_fields", "model_validators"})
 
 
 def _is_pydantic_class(cls: ast.ClassDef) -> bool:
@@ -52,8 +53,20 @@ class PydanticMutableDefault(Rule):
                 for item in node.body:
                     if not isinstance(item, (ast.Assign, ast.AnnAssign)):
                         continue
+                    # Skip Pydantic class variables (model_config, etc.)
+                    if isinstance(item, ast.Assign) and any(
+                        isinstance(t, ast.Name) and t.id in _PYDANTIC_CLASS_VARS
+                        for t in item.targets
+                    ):
+                        continue
                     value = item.value if isinstance(item, ast.AnnAssign) else item.value
                     if value is None:
+                        continue
+                    # Skip Field() wrappers — Pydantic handles these safely
+                    if isinstance(value, ast.Call) and (
+                        (isinstance(value.func, ast.Name) and value.func.id == "Field")
+                        or (isinstance(value.func, ast.Attribute) and value.func.attr == "Field")
+                    ):
                         continue
                     if isinstance(value, (ast.List, ast.Dict, ast.Set)):
                         findings.append(self.finding(file=f.relative_path, line=item.lineno))

--- a/tests/fixtures/python/ARCH-001/expected.json
+++ b/tests/fixtures/python/ARCH-001/expected.json
@@ -5,7 +5,7 @@
     "fail_no_tenant/": {
       "expected_findings": [
         {
-          "severity": "warn",
+          "severity": "info",
           "message_contains": "tenant isolation"
         }
       ]

--- a/tests/fixtures/python/PYD-ARCH-001/expected.json
+++ b/tests/fixtures/python/PYD-ARCH-001/expected.json
@@ -21,6 +21,9 @@
     },
     "pass_non_pydantic_class.py": {
       "expected_findings": []
+    },
+    "pass_model_config.py": {
+      "expected_findings": []
     }
   }
 }

--- a/tests/fixtures/python/PYD-ARCH-001/pass_model_config.py
+++ b/tests/fixtures/python/PYD-ARCH-001/pass_model_config.py
@@ -1,0 +1,9 @@
+"""Fixture for PYD-ARCH-001: model_config is a Pydantic class variable, not a field."""
+
+from pydantic import BaseModel
+
+
+class User(BaseModel):
+    model_config = {"strict": True, "frozen": True}
+    name: str
+    age: int

--- a/tests/test_ops_pack.py
+++ b/tests/test_ops_pack.py
@@ -63,12 +63,15 @@ class TestIsDockerfile:
         # ambiguous with source filenames; require the canonical form.
         assert not _is_dockerfile(Path("dockerfile"))
 
-    def test_rejects_stage_variants_for_now(self) -> None:
-        # Documented gap: stage variants are not supported yet. When a user
-        # asks for them, add a config-driven allowlist or a denylist of source
-        # extensions; do NOT silently widen the regex.
-        assert not _is_dockerfile(Path("Dockerfile.prod"))
-        assert not _is_dockerfile(Path("app.Dockerfile"))
+    def test_accepts_stage_variants(self) -> None:
+        assert _is_dockerfile(Path("Dockerfile.prod"))
+        assert _is_dockerfile(Path("Dockerfile.staging"))
+        assert _is_dockerfile(Path("app.Dockerfile"))
+
+    def test_rejects_non_docker_extensions(self) -> None:
+        assert not _is_dockerfile(Path("Dockerfile.py"))
+        assert not _is_dockerfile(Path("Dockerfile.yml"))
+        assert not _is_dockerfile(Path("Dockerfile.tar.gz"))
 
 
 class TestOpsPackDiscovery:


### PR DESCRIPTION
## Summary

- **#140** Dockerfile variants: accept `Dockerfile.prod`, `app.Dockerfile`, reject `.py`/`.yml`/`.tar.gz`
- **#148** PYD-ARCH-001: skip `model_config` and `Field()` wrappers in Pydantic models
- **#150** ARCH-001: downgrade from WARN to INFO; multi-tenant isolation is opt-in

Fixes #140, fixes #148, fixes #150.

## Test plan

- [x] Updated Dockerfile tests: accepts stage variants, rejects non-Docker extensions
- [x] New fixture: PYD-ARCH-001/pass_model_config.py
- [x] Updated ARCH-001 fixture severity expectation
- [x] 765 passed, ruff clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)