### PR TITLE
fix: SVC-004 app detection + ARCH-011 guard patterns

### DIFF
--- a/src/gaudi/packs/python/rules/layers.py
+++ b/src/gaudi/packs/python/rules/layers.py
@@ -72,6 +72,33 @@ class ImportDirectionViolation(Rule):
 _DATA_LAYER_KEYWORDS = ("connector", "store", "repository", "db")
 
 
+def _is_guard_pattern(node: ast.If) -> bool:
+    """Return True if the if-statement is a defensive guard, not business logic.
+
+    Guards are: ``if x is None``, ``if not x``, ``if isinstance(x, ...)``,
+    ``if x is not None``. These are normal defensive checks in data-layer
+    code (cache misses, null results, type narrowing).
+    """
+    test = node.test
+    # if x is None / if x is not None
+    if isinstance(test, ast.Compare) and len(test.ops) == 1:
+        op = test.ops[0]
+        if isinstance(op, (ast.Is, ast.IsNot)):
+            if isinstance(test.comparators[0], ast.Constant) and test.comparators[0].value is None:
+                return True
+    # if not x
+    if isinstance(test, ast.UnaryOp) and isinstance(test.op, ast.Not):
+        return True
+    # if isinstance(x, ...)
+    if (
+        isinstance(test, ast.Call)
+        and isinstance(test.func, ast.Name)
+        and test.func.id == "isinstance"
+    ):
+        return True
+    return False
+
+
 class ConnectorLogicLeak(Rule):
     """Detect data-layer files containing business logic (connector logic leak).
 
@@ -103,6 +130,8 @@ class ConnectorLogicLeak(Rule):
                     continue
                 for child in ast.walk(node):
                     if isinstance(child, ast.If) and child.orelse:
+                        if _is_guard_pattern(child):
+                            continue
                         findings.append(
                             self.finding(
                                 file=fi.relative_path,

--- a/src/gaudi/packs/python/rules/services.py
+++ b/src/gaudi/packs/python/rules/services.py
@@ -192,17 +192,20 @@ class NoAPIVersioning(Rule):
 # ---------------------------------------------------------------
 
 
-def _importer_app(relative_path: str) -> str | None:
+def _importer_app(relative_path: str, has_apps_dir: bool = False) -> str | None:
     """Return the Django app name an importing file lives in.
 
-    Recognises ``apps/<name>/...`` layouts and falls back to the first path
-    segment for top-level app directories like ``users/views.py``.
+    Recognises ``apps/<name>/...`` layouts. When the project uses an ``apps/``
+    directory, top-level directories (``config/``, ``scripts/``) are not
+    treated as apps — they are project-level infrastructure.
     """
     parts = relative_path.replace("\\", "/").split("/")
     if len(parts) < 2:
         return None
     if parts[0] == "apps" and len(parts) >= 3:
         return parts[1]
+    if has_apps_dir:
+        return None
     return parts[0]
 
 
@@ -241,13 +244,16 @@ class SharedDatabasePattern(Rule):
     )
 
     def check(self, context: PythonContext) -> list[Finding]:
+        has_apps_dir = any(
+            fi.relative_path.replace("\\", "/").startswith("apps/") for fi in context.files
+        )
         # (owner_app, model_name) -> list[(file, line, importer_app)]
         usages: dict[tuple[str, str], list[tuple[str, int, str]]] = {}
         for fi in context.files:
             tree = fi.ast_tree
             if tree is None:
                 continue
-            importer_app = _importer_app(fi.relative_path)
+            importer_app = _importer_app(fi.relative_path, has_apps_dir)
             if importer_app is None:
                 continue
             for node in ast.walk(tree):


### PR DESCRIPTION
## Summary

- **#149** SVC-004: detect `apps/` layout; top-level dirs like `config/` are project infrastructure, not separate Django apps
- **#154** ARCH-011: skip guard patterns (None checks, `not x`, `isinstance`) in data-layer files

Fixes #149, fixes #154.

## Test plan

- [x] 763 passed, ruff clean
- [x] Existing ARCH-011 fail fixture still triggers (business logic, not guard)

🤖 Generated with [Claude Code](https://claude.com/claude-code)