### PR TITLE
fix(rules): LOG-002 tighten sensitive-name matching

### DIFF
--- a/src/gaudi/packs/python/rules/logging_rules.py
+++ b/src/gaudi/packs/python/rules/logging_rules.py
@@ -115,11 +115,20 @@ _SENSITIVE_EXACT: frozenset[str] = frozenset({"token", "pwd"})
 
 def _is_sensitive_name(name: str) -> bool:
     lower = name.lower()
+    parts = lower.split("_")
     if lower in _SENSITIVE_EXACT:
         return True
-    if any(part in _SENSITIVE_EXACT for part in lower.split("_")):
+    if any(part in _SENSITIVE_EXACT for part in parts):
         return True
-    return any(pat in lower for pat in _SENSITIVE_NAME_PATTERNS)
+    # Match sensitive patterns as complete underscore-delimited segments.
+    # "password" matches "user_password" but not "passwordless".
+    # "api_key" matches "my_api_key" but not "api_server_key".
+    for pat in _SENSITIVE_NAME_PATTERNS:
+        pat_parts = pat.split("_")
+        for i in range(len(parts) - len(pat_parts) + 1):
+            if parts[i : i + len(pat_parts)] == pat_parts:
+                return True
+    return False
 
 
 def _references_sensitive(node: ast.AST) -> bool:


### PR DESCRIPTION
## Summary

- **#129** LOG-002: switch from substring matching to underscore-delimited segment matching for sensitive name detection
- `"password"` matches `"user_password"` but not `"passwordless"`
- `"api_key"` matches `"my_api_key"` but not `"api_server_key"`

Fixes #129.

## Test plan

- [x] 763 passed, ruff clean
- [x] Existing LOG-002 fixtures still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)