### PR TITLE
feat(rules): SEC-006 SSRFVector — intra-procedural taint tracking

### DIFF
--- a/src/gaudi/packs/python/rules/security.py
+++ b/src/gaudi/packs/python/rules/security.py
@@ -485,9 +485,7 @@ class SSRFVector(Rule):
     code = "SEC-006"
     severity = Severity.WARN
     category = Category.SECURITY
-    message_template = (
-        "Tainted URL passed to '{sink}' at line {line} — SSRF risk"
-    )
+    message_template = "Tainted URL passed to '{sink}' at line {line} — SSRF risk"
     recommendation_template = (
         "Validate URLs against an allowlist before making HTTP requests. "
         "Use urlparse() to inspect scheme and hostname, and restrict to "

--- a/src/gaudi/packs/python/rules/security.py
+++ b/src/gaudi/packs/python/rules/security.py
@@ -1,9 +1,10 @@
 # ABOUTME: Security fundamental rules for Python (OWASP Top 10 overlap).
-# ABOUTME: Detects raw SQL injection, hardcoded credentials, eval/exec, unsafe deserialization.
+# ABOUTME: Detects raw SQL injection, hardcoded credentials, eval/exec, unsafe deserialization, SSRF.
 from __future__ import annotations
 
 import ast
 import re
+from typing import Iterator
 
 from gaudi.core import Rule, Finding, Severity, Category
 from gaudi.packs.python.context import PythonContext
@@ -324,6 +325,196 @@ class UnsafeDeserialization(Rule):
 
 
 # ---------------------------------------------------------------
+# SEC-006  SSRFVector
+# ---------------------------------------------------------------
+
+_HTTP_CALL_TARGETS: dict[str, frozenset[str]] = {
+    "requests": frozenset({"get", "post", "put", "delete", "head", "patch"}),
+    "httpx": frozenset({"get", "post", "put", "delete", "head", "patch"}),
+}
+
+_URLLIB_TARGETS = frozenset({"urlopen"})
+
+_SANITIZER_FUNCS = frozenset({"urlparse", "urlsplit"})
+
+_SANITIZER_METHODS = frozenset({"startswith", "endswith"})
+
+
+def _is_http_sink(node: ast.Call) -> str | None:
+    """Return 'module.method' if the call is a known HTTP sink, else None."""
+    func = node.func
+    if not isinstance(func, ast.Attribute):
+        return None
+    attr = func.attr
+    val = func.value
+    # requests.get(...), httpx.post(...)
+    if isinstance(val, ast.Name) and val.id in _HTTP_CALL_TARGETS:
+        if attr in _HTTP_CALL_TARGETS[val.id]:
+            return f"{val.id}.{attr}"
+    # urllib.request.urlopen(...)
+    if (
+        isinstance(val, ast.Attribute)
+        and isinstance(val.value, ast.Name)
+        and val.value.id == "urllib"
+        and val.attr == "request"
+        and attr in _URLLIB_TARGETS
+    ):
+        return "urllib.request.urlopen"
+    return None
+
+
+def _url_arg(call: ast.Call) -> ast.expr | None:
+    """Extract the URL argument from an HTTP call (first positional or 'url' keyword)."""
+    if call.args:
+        return call.args[0]
+    for kw in call.keywords:
+        if kw.arg == "url":
+            return kw.value
+    return None
+
+
+def _is_constant_expr(node: ast.expr) -> bool:
+    """Return True if the expression is a string constant or an f-string with a constant base."""
+    if isinstance(node, ast.Constant) and isinstance(node.value, str):
+        return True
+    if isinstance(node, ast.JoinedStr):
+        # f-string with constant base like f"https://api.example.com/{item_id}"
+        # is safe — the base URL is fixed, only path components vary.
+        if node.values and isinstance(node.values[0], ast.Constant):
+            prefix = node.values[0].value
+            if isinstance(prefix, str) and "://" in prefix:
+                return True
+    return False
+
+
+def _collect_tainted_names(func_def: ast.FunctionDef) -> set[str]:
+    """Walk a function body to find names that carry parameter taint.
+
+    Strategy:
+    1. All function parameters are initially tainted.
+    2. Simple assignments ``x = tainted`` propagate taint.
+    3. If a tainted name passes through a sanitizer (urlparse, startswith,
+       ``in`` membership check), clear it.
+    """
+    tainted: set[str] = set()
+    for arg in func_def.args.args:
+        tainted.add(arg.arg)
+
+    sanitized: set[str] = set()
+
+    for node in ast.walk(func_def):
+        # Detect sanitizers: urlparse(x), x.startswith(...), x in ALLOWED
+        if isinstance(node, ast.Call):
+            # urlparse(var) / urlsplit(var)
+            func = node.func
+            callee_name: str | None = None
+            if isinstance(func, ast.Name):
+                callee_name = func.id
+            elif isinstance(func, ast.Attribute):
+                callee_name = func.attr
+            if callee_name in _SANITIZER_FUNCS and node.args:
+                arg0 = node.args[0]
+                if isinstance(arg0, ast.Name):
+                    sanitized.add(arg0.id)
+
+            # var.startswith(...) / var.endswith(...)
+            if (
+                isinstance(func, ast.Attribute)
+                and func.attr in _SANITIZER_METHODS
+                and isinstance(func.value, ast.Name)
+            ):
+                sanitized.add(func.value.id)
+
+        # Detect ``var in ALLOWED_HOSTS`` or ``var not in ALLOWED``
+        if isinstance(node, ast.Compare):
+            if isinstance(node.left, ast.Name):
+                for op in node.ops:
+                    if isinstance(op, (ast.In, ast.NotIn)):
+                        sanitized.add(node.left.id)
+
+        # Propagate taint through simple assignment: x = tainted_var
+        if isinstance(node, ast.Assign) and len(node.targets) == 1:
+            target = node.targets[0]
+            value = node.value
+            if isinstance(target, ast.Name) and isinstance(value, ast.Name):
+                if value.id in tainted and value.id not in sanitized:
+                    tainted.add(target.id)
+                elif _is_constant_expr(value):
+                    pass  # constant assignment, not tainted
+            elif isinstance(target, ast.Name) and _is_constant_expr(value):
+                pass  # assigning a constant clears taint implicitly (name not added)
+
+    return tainted - sanitized
+
+
+def _check_function_ssrf(
+    func_def: ast.FunctionDef,
+    relative_path: str,
+) -> Iterator[tuple[int, str]]:
+    """Yield (line, sink_name) for HTTP calls with tainted URL args in a function."""
+    tainted = _collect_tainted_names(func_def)
+    if not tainted:
+        return
+
+    for node in ast.walk(func_def):
+        if not isinstance(node, ast.Call):
+            continue
+        sink = _is_http_sink(node)
+        if sink is None:
+            continue
+        url_node = _url_arg(node)
+        if url_node is None:
+            continue
+        if isinstance(url_node, ast.Name) and url_node.id in tainted:
+            yield (node.lineno, sink)
+        elif isinstance(url_node, ast.Constant):
+            pass  # constant URL literal, safe
+
+
+class SSRFVector(Rule):
+    """SEC-006: User input flowing into HTTP calls without validation.
+
+    Principles: #4 (Failure must be named).
+    Source: OWASP A10:2021 — Server-Side Request Forgery.
+
+    Uses intra-procedural taint tracking: function parameters are tainted,
+    taint propagates through simple assignments, and is cleared by
+    urlparse/startswith/membership checks.
+    """
+
+    code = "SEC-006"
+    severity = Severity.WARN
+    category = Category.SECURITY
+    message_template = (
+        "Tainted URL passed to '{sink}' at line {line} — SSRF risk"
+    )
+    recommendation_template = (
+        "Validate URLs against an allowlist before making HTTP requests. "
+        "Use urlparse() to inspect scheme and hostname, and restrict to "
+        "known-safe hosts."
+    )
+
+    def check(self, context: PythonContext) -> list[Finding]:
+        findings: list[Finding] = []
+        for f in context.files:
+            tree = f.ast_tree
+            if tree is None:
+                continue
+            for node in ast.walk(tree):
+                if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                    continue
+                for line, sink in _check_function_ssrf(node, f.relative_path):
+                    findings.append(
+                        self.finding(
+                            file=f.relative_path,
+                            line=line,
+                            sink=sink,
+                        )
+                    )
+        return findings
+
+
+# ---------------------------------------------------------------
 # Exported rule instances
 # ---------------------------------------------------------------
 
@@ -332,4 +523,5 @@ SECURITY_RULES = (
     HardcodedCredential(),
     EvalExecUsage(),
     UnsafeDeserialization(),
+    SSRFVector(),
 )

--- a/tests/fixtures/python/SEC-006/expected.json
+++ b/tests/fixtures/python/SEC-006/expected.json
@@ -6,17 +6,17 @@
       "expected_findings": [
         {
           "severity": "warn",
-          "line": 7,
+          "line": 8,
           "message_contains": "requests.get"
         },
         {
           "severity": "warn",
-          "line": 11,
+          "line": 12,
           "message_contains": "httpx.get"
         },
         {
           "severity": "warn",
-          "line": 15,
+          "line": 16,
           "message_contains": "requests.post"
         }
       ]
@@ -25,12 +25,12 @@
       "expected_findings": [
         {
           "severity": "warn",
-          "line": 8,
+          "line": 9,
           "message_contains": "requests.get"
         },
         {
           "severity": "warn",
-          "line": 13,
+          "line": 14,
           "message_contains": "urllib.request.urlopen"
         }
       ]

--- a/tests/fixtures/python/SEC-006/expected.json
+++ b/tests/fixtures/python/SEC-006/expected.json
@@ -1,0 +1,48 @@
+{
+  "rule_id": "SEC-006",
+  "description": "SSRFVector -- user input flowing into HTTP calls without validation",
+  "fixtures": {
+    "fail_tainted_url_direct.py": {
+      "expected_findings": [
+        {
+          "severity": "warn",
+          "line": 7,
+          "message_contains": "requests.get"
+        },
+        {
+          "severity": "warn",
+          "line": 11,
+          "message_contains": "httpx.get"
+        },
+        {
+          "severity": "warn",
+          "line": 15,
+          "message_contains": "requests.post"
+        }
+      ]
+    },
+    "fail_tainted_url_via_var.py": {
+      "expected_findings": [
+        {
+          "severity": "warn",
+          "line": 8,
+          "message_contains": "requests.get"
+        },
+        {
+          "severity": "warn",
+          "line": 13,
+          "message_contains": "urllib.request.urlopen"
+        }
+      ]
+    },
+    "pass_constant_url.py": {
+      "expected_findings": []
+    },
+    "pass_sanitized_url.py": {
+      "expected_findings": []
+    },
+    "pass_no_http_call.py": {
+      "expected_findings": []
+    }
+  }
+}

--- a/tests/fixtures/python/SEC-006/fail_tainted_url_direct.py
+++ b/tests/fixtures/python/SEC-006/fail_tainted_url_direct.py
@@ -1,0 +1,15 @@
+"""Fixture for SEC-006: user input flows directly into HTTP calls."""
+import requests
+import httpx
+
+
+def fetch_resource(url):
+    return requests.get(url)
+
+
+def fetch_with_httpx(endpoint):
+    return httpx.get(endpoint)
+
+
+def post_data(url, payload):
+    return requests.post(url, json=payload)

--- a/tests/fixtures/python/SEC-006/fail_tainted_url_direct.py
+++ b/tests/fixtures/python/SEC-006/fail_tainted_url_direct.py
@@ -1,4 +1,5 @@
 """Fixture for SEC-006: user input flows directly into HTTP calls."""
+
 import requests
 import httpx
 

--- a/tests/fixtures/python/SEC-006/fail_tainted_url_via_var.py
+++ b/tests/fixtures/python/SEC-006/fail_tainted_url_via_var.py
@@ -1,4 +1,5 @@
 """Fixture for SEC-006: tainted URL flows through local variable assignment."""
+
 import requests
 import urllib.request
 

--- a/tests/fixtures/python/SEC-006/fail_tainted_url_via_var.py
+++ b/tests/fixtures/python/SEC-006/fail_tainted_url_via_var.py
@@ -1,0 +1,13 @@
+"""Fixture for SEC-006: tainted URL flows through local variable assignment."""
+import requests
+import urllib.request
+
+
+def fetch_indirect(user_url):
+    target = user_url
+    return requests.get(target)
+
+
+def fetch_urllib(addr):
+    url = addr
+    return urllib.request.urlopen(url)

--- a/tests/fixtures/python/SEC-006/pass_constant_url.py
+++ b/tests/fixtures/python/SEC-006/pass_constant_url.py
@@ -1,4 +1,5 @@
 """Fixture for SEC-006: constant URLs are not tainted."""
+
 import requests
 import httpx
 

--- a/tests/fixtures/python/SEC-006/pass_constant_url.py
+++ b/tests/fixtures/python/SEC-006/pass_constant_url.py
@@ -1,0 +1,17 @@
+"""Fixture for SEC-006: constant URLs are not tainted."""
+import requests
+import httpx
+
+
+def fetch_api():
+    return requests.get("https://api.example.com/data")
+
+
+def fetch_httpx_constant():
+    url = "https://internal.example.com/health"
+    return httpx.get(url)
+
+
+def fetch_with_constant_base(item_id):
+    url = f"https://api.example.com/items/{item_id}"
+    return requests.get(url)

--- a/tests/fixtures/python/SEC-006/pass_no_http_call.py
+++ b/tests/fixtures/python/SEC-006/pass_no_http_call.py
@@ -1,0 +1,9 @@
+"""Fixture for SEC-006: functions that don't make HTTP calls."""
+
+
+def process_url(url):
+    return url.strip().lower()
+
+
+def build_url(base, path):
+    return f"{base}/{path}"

--- a/tests/fixtures/python/SEC-006/pass_sanitized_url.py
+++ b/tests/fixtures/python/SEC-006/pass_sanitized_url.py
@@ -1,0 +1,25 @@
+"""Fixture for SEC-006: sanitized URLs should not trigger."""
+import requests
+from urllib.parse import urlparse
+
+
+ALLOWED_HOSTS = {"api.example.com", "internal.example.com"}
+
+
+def fetch_after_urlparse(user_url):
+    parsed = urlparse(user_url)
+    if parsed.hostname not in ALLOWED_HOSTS:
+        raise ValueError("Host not allowed")
+    return requests.get(user_url)
+
+
+def fetch_after_startswith(url):
+    if not url.startswith("https://api.example.com"):
+        raise ValueError("Bad URL")
+    return requests.get(url)
+
+
+def fetch_after_in_check(url):
+    if url not in ALLOWED_HOSTS:
+        raise ValueError("Not allowed")
+    return requests.get(url)

--- a/tests/fixtures/python/SEC-006/pass_sanitized_url.py
+++ b/tests/fixtures/python/SEC-006/pass_sanitized_url.py
@@ -1,4 +1,5 @@
 """Fixture for SEC-006: sanitized URLs should not trigger."""
+
 import requests
 from urllib.parse import urlparse
 


### PR DESCRIPTION
## Summary
- Implements SEC-006 SSRFVector rule (closes #67) — detects user input (function parameters) flowing into HTTP calls (`requests`, `httpx`, `urllib.request`) without intervening validation
- Uses intra-procedural taint tracking: parameters are tainted at function entry, taint propagates through simple assignments, and is cleared by sanitizers (`urlparse`, `startswith`, membership checks)
- Severity: WARN (per issue spec)

## Test plan
- [x] Fixture `fail_tainted_url_direct.py` — parameter passed directly to `requests.get`, `httpx.get`, `requests.post` (3 findings)
- [x] Fixture `fail_tainted_url_via_var.py` — parameter flows through local var to `requests.get` and `urllib.request.urlopen` (2 findings)
- [x] Fixture `pass_constant_url.py` — string literals and f-strings with constant base (0 findings)
- [x] Fixture `pass_sanitized_url.py` — URLs validated via `urlparse`, `startswith`, or `in` membership (0 findings)
- [x] Fixture `pass_no_http_call.py` — functions with no HTTP calls (0 findings)
- [x] Full test suite: 1012 passed
- [x] `gaudi check .` clean (no new findings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)