### PR TITLE
docs: rescope rule-registry.md to rule-sources.md (#138)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,7 +50,7 @@ Gaudi rule decision.
 - **src/gaudi/cli.py** — Click-based CLI (`gaudi check`)
 - **src/gaudi/packs/python/** — Python language pack (79 rules: 64 general + 15 library-specific)
 - **tests/** — pytest suite with fixtures
-- **docs/rule-registry.md** — Maps every rule to its canonical source text
+- **docs/rule-sources.md** — Curated source texts, ARCH-90 curriculum, philosophy scope audit, mining queues (not exhaustive; see docs/gaudi-rules.md for every rule)
 
 ## Key Files
 
@@ -58,7 +58,7 @@ Gaudi rule decision.
 - **CONTRIBUTING.md** — Contributor guide
 - **pyproject.toml** — Package metadata, dependencies, entry points, ruff config
 - **gaudi.toml** — Runtime configuration (severity overrides, exclusions)
-- **docs/rule-registry.md** — Rule provenance and mining queues
+- **docs/rule-sources.md** — Rule provenance and mining queues
 
 ## PR Workflow
 

--- a/docs/philosophy/README.md
+++ b/docs/philosophy/README.md
@@ -31,7 +31,7 @@ a faithful fixture of that school.
 
 These sheets are the scaffolding for three downstream pieces of work:
 
-1. **The rule audit** — every rule in [docs/rule-registry.md](../rule-registry.md)
+1. **The rule audit** — every rule in [docs/rule-sources.md](../rule-sources.md)
    gets tagged with a philosophy scope (`universal` or a specific school),
    appealing to the axiom sheet that makes the tag defensible.
 2. **The canonical task** — a single domain problem (order processing
@@ -147,7 +147,7 @@ The relationship is Thomistic by design:
   and cannot be defended against the axioms of another.
 
 When Phase 0b (the rule audit) lands, every rule in
-[docs/rule-registry.md](../rule-registry.md) will be tagged with its
+[docs/rule-sources.md](../rule-sources.md) will be tagged with its
 philosophy scope. Most rules will come back `universal` — they descend
 from the pillars and hold in every school. A smaller number will come
 back tagged with one or more specific schools, because they depend on
@@ -158,7 +158,7 @@ axioms that not every school accepts.
 ## What Is Not Here Yet
 
 - **The rule audit column** — Phase 0b. Every rule gets tagged; the
-  column lives in [docs/rule-registry.md](../rule-registry.md).
+  column lives in [docs/rule-sources.md](../rule-sources.md).
 - **The canonical task statement** — Phase 0c. The order-processing
   problem, acceptance criteria, and interface for the eight
   implementations.
@@ -174,7 +174,7 @@ axioms that not every school accepts.
 
 - [docs/principles.md](../principles.md) — The editorial constitution
   and universal core.
-- [docs/rule-registry.md](../rule-registry.md) — The rule catalog,
+- [docs/rule-sources.md](../rule-sources.md) — The rule catalog,
   which will gain a philosophy-scope column during Phase 0b.
 - [docs/testing-fixtures.md](../testing-fixtures.md) — The fixture-first
   TDD rubric; the philosophy exemplars extend this discipline to the

--- a/docs/philosophy/classical.md
+++ b/docs/philosophy/classical.md
@@ -198,7 +198,7 @@ fewer is pastiche and should be rewritten, not patched.
   Classical axiom is the school closest to these principles, but not identical
   to them; the principles are the universal core, Classical is one material
   expression of the core.
-- [docs/rule-registry.md](../rule-registry.md) — The rule catalog and its
+- [docs/rule-sources.md](../rule-sources.md) — The rule catalog and its
   provenance column (to be extended with a `philosophy_scope` column during
   Phase 0b).
 - `docs/philosophy/README.md` — Index of all eight axiom sheets (to be written

--- a/docs/philosophy/pragmatic.md
+++ b/docs/philosophy/pragmatic.md
@@ -203,5 +203,5 @@ Pragmatic badge.
 - [docs/principles.md](../principles.md) — Principles #6 (best line is the
   one not written), #8 (smallest reasonable change), and #12 (tests are the
   specification) are Pragmatic's direct contributions to the universal core.
-- [docs/rule-registry.md](../rule-registry.md) — `SMELL-014`, `SMELL-015`,
+- [docs/rule-sources.md](../rule-sources.md) — `SMELL-014`, `SMELL-015`,
   and `SMELL-018` are the catalog's current expressions of Pragmatic scope.

--- a/docs/principles.md
+++ b/docs/principles.md
@@ -496,6 +496,6 @@ doctrine exists to make it derivable from first principles in any project.
 ## See Also
 
 - [README.md](../README.md) — User-facing introduction.
-- [docs/rule-registry.md](rule-registry.md) — Source provenance for every rule.
+- [docs/rule-sources.md](rule-sources.md) — Source provenance for every rule.
 - [docs/testing-fixtures.md](testing-fixtures.md) — The fixture-first TDD rubric.
 - [CONTRIBUTING.md](../CONTRIBUTING.md) — Contributor workflow.

--- a/docs/rule-sources.md
+++ b/docs/rule-sources.md
@@ -1,15 +1,20 @@
-# Gaudi Rule Source Registry
+# Gaudi Rule Sources
 
-Every rule in Gaudi traces back to a canonical source: a published text,
-a named pattern, or (where original) the project's own design principles.
-This registry provides citable provenance for each rule code and serves as
-a mining queue for planned rules.
+This file is a **curated, hand-edited** record of the canonical source texts
+Gaudi's rules draw from, the Architecture-90 curriculum that seeded the early
+catalog, the philosophy scope audit, and mining queues for planned rules.
+
+**This is not an exhaustive rule index.** The complete list of implemented
+rules lives in [gaudi-rules.md](gaudi-rules.md), which is generated from the
+live registry by `gaudi cheat-sheet` and cannot drift. Use that file when you
+need "every rule." Use this one when you need the *why* — the source text,
+the curriculum position, or the philosophy scope — for the rules it covers.
 
 The **editorial doctrine** that governs which rules enter the catalog, how
 their severity and thresholds are assigned, and when they are subsumed or cut
-lives in [principles.md](principles.md). Footnotes in this registry that
-explain rule removals (e.g. "detection too weak", "subsumed by STAB-006")
-are applications of those principles.
+lives in [principles.md](principles.md). Footnotes in this file that explain
+rule removals (e.g. "detection too weak", "subsumed by STAB-006") are
+applications of those principles.
 
 ---
 

--- a/src/gaudi/core.py
+++ b/src/gaudi/core.py
@@ -175,7 +175,7 @@ class Rule:
     means the rule descends from the three pillars and holds in every school;
     a rule that depends on school-specific axioms should list the schools
     explicitly (e.g. ``{"pragmatic", "functional"}``). See
-    ``docs/philosophy/`` for the axiom sheets and ``docs/rule-registry.md``
+    ``docs/philosophy/`` for the axiom sheets and ``docs/rule-sources.md``
     for the scope audit.
 
     Example:

--- a/tests/philosophy/classical/canonical/README.md
+++ b/tests/philosophy/classical/canonical/README.md
@@ -86,7 +86,7 @@ without a line changing.
 Running `gaudi check` against this exemplar at the project level produces
 twelve findings, which fall into three categories. The categorization
 itself is the forcing-function evidence for the Phase 1 engine change
-that [docs/rule-registry.md](../../../../docs/rule-registry.md)
+that [docs/rule-sources.md](../../../../docs/rule-sources.md)
 (Philosophy Scope Audit section) exists to justify.
 
 ### Category A — audit-validating false positives (SMELL-014, ×6)
@@ -98,7 +98,7 @@ behavior. The rule says "consider inlining"; the Classical discipline
 says "no — these classes exist to implement the Repository Protocol,
 and inlining them would destroy the abstraction boundary."
 
-The audit in [docs/rule-registry.md](../../../../docs/rule-registry.md)
+The audit in [docs/rule-sources.md](../../../../docs/rule-sources.md)
 already tags `SMELL-014` as scoped to `{pragmatic, unix, functional,
 data-oriented}` — explicitly **not** Classical. **These six findings
 are exactly what the audit predicted would be false positives when the
@@ -185,5 +185,5 @@ become visible.
 
 - [docs/philosophy/classical.md](../../../../docs/philosophy/classical.md) — The axiom sheet.
 - [docs/philosophy/canonical-task.md](../../../../docs/philosophy/canonical-task.md) — The canonical task specification.
-- [docs/rule-registry.md](../../../../docs/rule-registry.md) — The rule audit, including the scope tag for SMELL-014.
+- [docs/rule-sources.md](../../../../docs/rule-sources.md) — The rule audit, including the scope tag for SMELL-014.
 - [docs/principles.md](../../../../docs/principles.md) — The universal core this exemplar satisfies.

--- a/tests/philosophy/convention/canonical/README.md
+++ b/tests/philosophy/convention/canonical/README.md
@@ -252,7 +252,7 @@ implementation, where the previous four yielded four total.
 
 - [docs/philosophy/convention.md](../../../../docs/philosophy/convention.md) — The axiom sheet.
 - [docs/philosophy/canonical-task.md](../../../../docs/philosophy/canonical-task.md) — The canonical task specification.
-- [docs/rule-registry.md](../../../../docs/rule-registry.md) — The rule audit.
+- [docs/rule-sources.md](../../../../docs/rule-sources.md) — The rule audit.
 - [tests/philosophy/classical/canonical/README.md](../../classical/canonical/README.md) — Classical (OOP tree).
 - [tests/philosophy/pragmatic/canonical/README.md](../../pragmatic/canonical/README.md) — Pragmatic (one function).
 - [tests/philosophy/functional/canonical/README.md](../../functional/canonical/README.md) — Functional (pure composition).

--- a/tests/philosophy/functional/canonical/README.md
+++ b/tests/philosophy/functional/canonical/README.md
@@ -179,6 +179,6 @@ Three observations from the triangle:
 
 - [docs/philosophy/functional.md](../../../../docs/philosophy/functional.md) — The axiom sheet.
 - [docs/philosophy/canonical-task.md](../../../../docs/philosophy/canonical-task.md) — The canonical task specification.
-- [docs/rule-registry.md](../../../../docs/rule-registry.md) — The rule audit, including the scope tags the matrix test verifies.
+- [docs/rule-sources.md](../../../../docs/rule-sources.md) — The rule audit, including the scope tags the matrix test verifies.
 - [tests/philosophy/classical/canonical/README.md](../../classical/canonical/README.md) — The Classical reference exemplar.
 - [tests/philosophy/pragmatic/canonical/README.md](../../pragmatic/canonical/README.md) — The Pragmatic reference exemplar.

--- a/tests/philosophy/pragmatic/canonical/README.md
+++ b/tests/philosophy/pragmatic/canonical/README.md
@@ -99,7 +99,7 @@ merged produces three kinds of findings, each meaningful:
 
 `process_order` is ~80 lines. The rule says functions should be
 shorter. This is a **universal** rule (`SMELL-003` was classified as
-universal in the [rule audit](../../../../docs/rule-registry.md)),
+universal in the [rule audit](../../../../docs/rule-sources.md)),
 and it fires correctly: a Pragmatic one-big-function is genuinely a
 long function, and the rule is accurately reporting a real cost to
 readability that the Pragmatic discipline accepts as a trade-off.
@@ -158,7 +158,7 @@ pressure forces a split.
 
 Neither is wrong. They are the two faithful expressions of two
 genuinely different axioms about when abstraction pays for itself.
-Gaudí's [philosophy scope audit](../../../../docs/rule-registry.md)
+Gaudí's [philosophy scope audit](../../../../docs/rule-sources.md)
 is the editorial constitution that lets both exemplars score 10/10
 against their own rubrics — the scoping system is what makes this
 pluralism defensible instead of confused.
@@ -188,5 +188,5 @@ six can be reviewed.
 
 - [docs/philosophy/pragmatic.md](../../../../docs/philosophy/pragmatic.md) — The axiom sheet.
 - [docs/philosophy/canonical-task.md](../../../../docs/philosophy/canonical-task.md) — The canonical task specification.
-- [docs/rule-registry.md](../../../../docs/rule-registry.md) — The rule audit, including the scope tags that make the Classical and Pragmatic findings diverge as they should.
+- [docs/rule-sources.md](../../../../docs/rule-sources.md) — The rule audit, including the scope tags that make the Classical and Pragmatic findings diverge as they should.
 - [tests/philosophy/classical/canonical/README.md](../../classical/canonical/README.md) — The Classical reference exemplar; read this one's Category A findings alongside that one's to see what the scope system is doing.

--- a/tests/philosophy/resilient/canonical/README.md
+++ b/tests/philosophy/resilient/canonical/README.md
@@ -213,7 +213,7 @@ Added to `test_philosophy_matrix.py`:
 
 - [docs/philosophy/resilient.md](../../../../docs/philosophy/resilient.md) — The axiom sheet.
 - [docs/philosophy/canonical-task.md](../../../../docs/philosophy/canonical-task.md) — The canonical task specification.
-- [docs/rule-registry.md](../../../../docs/rule-registry.md) — The rule audit, unchanged by this PR.
+- [docs/rule-sources.md](../../../../docs/rule-sources.md) — The rule audit, unchanged by this PR.
 - [tests/philosophy/classical/canonical/README.md](../../classical/canonical/README.md) — Classical exemplar (layered OOP).
 - [tests/philosophy/pragmatic/canonical/README.md](../../pragmatic/canonical/README.md) — Pragmatic exemplar (one function).
 - [tests/philosophy/functional/canonical/README.md](../../functional/canonical/README.md) — Functional exemplar (pure records).

--- a/tests/philosophy/unix/canonical/README.md
+++ b/tests/philosophy/unix/canonical/README.md
@@ -135,7 +135,7 @@ purpose is to read stdin, loop over records, and write stdout.
 ### The audit revision this PR makes
 
 This PR amends the [philosophy scope audit in
-docs/rule-registry.md](../../../../docs/rule-registry.md) to move
+docs/rule-sources.md](../../../../docs/rule-sources.md) to move
 ``ARCH-013 FatScript`` from the universal list to the scoped list,
 excluding it from ``unix``. The scope is tagged on the rule class in
 ``src/gaudi/packs/python/rules/layers.py`` with an inline comment
@@ -157,7 +157,7 @@ After this PR:
 
 - `ARCH-013` is scoped to everything *except* `unix`, fires on seven
   of eight schools on the Unix exemplar, **23 scoped rules total**.
-  The audit summary in [docs/rule-registry.md](../../../../docs/rule-registry.md)
+  The audit summary in [docs/rule-sources.md](../../../../docs/rule-sources.md)
   is updated from "22 (18%)" to "23 (19%)".
 
 ### Remaining findings (all universal, all correct)
@@ -213,7 +213,7 @@ proves universal rules are scope-invariant.
 
 - [docs/philosophy/unix.md](../../../../docs/philosophy/unix.md) — The axiom sheet.
 - [docs/philosophy/canonical-task.md](../../../../docs/philosophy/canonical-task.md) — The canonical task specification.
-- [docs/rule-registry.md](../../../../docs/rule-registry.md) — The rule audit, including the new ARCH-013 row.
+- [docs/rule-sources.md](../../../../docs/rule-sources.md) — The rule audit, including the new ARCH-013 row.
 - [tests/philosophy/classical/canonical/README.md](../../classical/canonical/README.md) — Classical exemplar (OOP tree).
 - [tests/philosophy/pragmatic/canonical/README.md](../../pragmatic/canonical/README.md) — Pragmatic exemplar (one big function).
 - [tests/philosophy/functional/canonical/README.md](../../functional/canonical/README.md) — Functional exemplar (pure composition).


### PR DESCRIPTION
## Summary

Resolves #138 via Option 2 (rename and rescope). The file claimed to map "every rule" to its canonical source but had drifted — ~50 rules were missing and no generator or CI guard kept it honest. Rather than build a competing generator alongside `gaudi cheat-sheet` (which already produces the complete machine-readable listing at `docs/gaudi-rules.md` with a drift guard), this PR admits what the file actually is: a curated editorial artifact — source-text tables, ARCH-90 curriculum, philosophy scope audit, mining queues — not an exhaustive index.

- Rename `docs/rule-registry.md` → `docs/rule-sources.md`
- Rewrite preamble to drop the "every rule" claim and point readers to `docs/gaudi-rules.md` for the complete listing
- Update all 11 inbound references across `CLAUDE.md`, `docs/`, and `tests/philosophy/`

## Test plan

- [x] 1028 tests pass
- [x] `ruff format --check .` and `ruff check .` clean
- [x] `grep -r "rule-registry" .` returns no matches
- [x] All cross-references still resolve (checked git mv preserves rename-detection)

🤖 Generated with [Claude Code](https://claude.com/claude-code)