### PR TITLE
feat(sec): OWASP structural slice — deserialization, weak crypto, SSL verify

### DIFF
--- a/docs/gaudi-rules.md
+++ b/docs/gaudi-rules.md
@@ -19,7 +19,9 @@
 - **SEC-002 RawSQLInjection** — Use parameterized queries: pass values as a separate tuple/dict argument to execute() instead of formatting them into the SQL string.
 - **SEC-003 HardcodedCredential** — Read secrets from environment variables (os.getenv) or a secrets manager. Hardcoded credentials leak through git history.
 - **SEC-004 EvalExecUsage** — eval() and exec() execute arbitrary code. Use ast.literal_eval for safe expression parsing, or refactor to avoid dynamic execution.
-- **SEC-005 UnsafeDeserialization** — pickle and yaml.load can execute arbitrary code on untrusted input. Use json, or yaml.safe_load / Loader=SafeLoader.
+- **SEC-005 UnsafeDeserialization** — pickle, marshal, and yaml.load execute arbitrary code on untrusted input. Use json, or yaml.safe_load / Loader=SafeLoader.
+- **SEC-007 WeakCryptography** — Use hashlib.sha256 or hashlib.scrypt for password/message hashing, and the 'secrets' module (token_hex, token_urlsafe, token_bytes) for tokens, keys, salts, and session identifiers.
+- **SEC-008 InsecureSSLVerification** — Leave verify at its default (True) or pass a CA bundle path. For ssl.SSLContext, use ssl.CERT_REQUIRED. Disabling verification makes the connection vulnerable to man-in-the-middle attacks.
 - **SMELL-005 GlobalData** — Avoid mutable module-level variables. Use function-local state, dependency injection, or frozen data structures.
 - **SMELL-006 MutableData** — Avoid shared mutable state. Pass data as function parameters and return results.
 - **STAB-005 BlockingInAsync** — Use async equivalents (asyncio.sleep, httpx.AsyncClient) in async functions. Blocking calls freeze the event loop and starve all concurrent tasks.
@@ -154,3 +156,4 @@
 - **TEST-SCALE-001 PytestFixtureScope** [pytest] — Add scope='session' or scope='module' to fixtures that create expensive resources (database connections, API clients) to avoid recreating them per test.
 - **TEST-STRUCT-001 PytestAssertMessage** [pytest] — Add a failure message to complex assertions: assert condition, 'description'. Messages make test failures easier to diagnose.
 - **TEST-STRUCT-002 PytestFixtureDependencyDepth** [pytest] — Flatten the fixture graph: inline trivial dependencies, or compose explicit setup objects in a single fixture. Deep fixture chains make failure diagnosis painful.
+

--- a/docs/gaudi-rules.md
+++ b/docs/gaudi-rules.md
@@ -156,4 +156,3 @@
 - **TEST-SCALE-001 PytestFixtureScope** [pytest] — Add scope='session' or scope='module' to fixtures that create expensive resources (database connections, API clients) to avoid recreating them per test.
 - **TEST-STRUCT-001 PytestAssertMessage** [pytest] — Add a failure message to complex assertions: assert condition, 'description'. Messages make test failures easier to diagnose.
 - **TEST-STRUCT-002 PytestFixtureDependencyDepth** [pytest] — Flatten the fixture graph: inline trivial dependencies, or compose explicit setup objects in a single fixture. Deep fixture chains make failure diagnosis painful.
-

--- a/docs/rule-sources.md
+++ b/docs/rule-sources.md
@@ -217,6 +217,32 @@ leakage, and undocumented error responses.
 | API-003  | LeakingInternalID       | URL pattern exposes `<int:pk>` / int PK             | OWASP API (BOLA)      |
 | API-004  | NoErrorResponseSchema   | FastAPI `response_model=` with no `responses=`      | OpenAPI specification |
 
+### Security Rules (SEC) -- Source: OWASP Top 10
+
+General Python security rules mined from the **structural slice** of the OWASP
+Top 10 (issue #142) — patterns detectable from a single file's AST without
+runtime data, taint analysis, or a whole-project graph. Principle 4 (Failure
+must be named) explicitly calls for this slice: hostile input deserves the
+same naming as a memory leak.
+
+| Code     | Class Name              | Pattern / Anti-Pattern                                       | OWASP Source                    |
+|----------|-------------------------|--------------------------------------------------------------|---------------------------------|
+| SEC-002  | RawSQLInjection         | f-string / % / concat / .format passed to execute(), raw()   | A03:2021 Injection              |
+| SEC-003  | HardcodedCredential     | Credential-named variable assigned to a string literal       | A07:2021 Identification Failures|
+| SEC-004  | EvalExecUsage           | Built-in `eval()` or `exec()` invoked                        | A03:2021 Injection              |
+| SEC-005  | UnsafeDeserialization   | `pickle.load(s)`, `marshal.load(s)`, `yaml.load` w/o SafeLoader | A08:2021 Software & Data Integrity |
+| SEC-006  | SSRFVector              | Function parameter flows into `requests`/`httpx`/`urlopen` URL unsanitized | A10:2021 SSRF          |
+| SEC-007  | WeakCryptography        | `hashlib.md5/sha1`; `random` module inside token/key/secret functions | A02:2021 Cryptographic Failures (CWE-327/338) |
+| SEC-008  | InsecureSSLVerification | `verify=False` on HTTP calls; `ssl.CERT_NONE`                | A02:2021 Cryptographic Failures (CWE-295) |
+
+**Overlap with `bandit`.** SEC-005/007/008 cover territory `bandit` also flags,
+but Gaudi's versions (a) carry principle citations so the reader knows *why*
+it matters, (b) ship a one-sentence actionable fix, and (c) are checked in the
+same pass as the architectural rules — one tool, one report. SEC-007's
+`random`-inside-security-function heuristic is narrower than bandit's
+`B311` (which flags every `random` call), reducing false positives for
+simulations, games, and sampling code.
+
 ### Dependency Graph Rules (DEP) -- Source: MARTIN
 
 Rules mined from *Clean Architecture*. Module-level coupling metrics that

--- a/src/gaudi/packs/python/rules/security.py
+++ b/src/gaudi/packs/python/rules/security.py
@@ -281,7 +281,7 @@ class UnsafeDeserialization(Rule):
     category = Category.SECURITY
     message_template = "Unsafe deserialization '{call}' at line {line}"
     recommendation_template = (
-        "pickle and yaml.load can execute arbitrary code on untrusted "
+        "pickle, marshal, and yaml.load execute arbitrary code on untrusted "
         "input. Use json, or yaml.safe_load / Loader=SafeLoader."
     )
 
@@ -308,6 +308,16 @@ class UnsafeDeserialization(Rule):
                             file=f.relative_path,
                             line=node.lineno,
                             call=f"pickle.{attr}",
+                        )
+                    )
+                    continue
+                # marshal.load / marshal.loads
+                if module == "marshal" and attr in ("load", "loads"):
+                    findings.append(
+                        self.finding(
+                            file=f.relative_path,
+                            line=node.lineno,
+                            call=f"marshal.{attr}",
                         )
                     )
                     continue
@@ -513,6 +523,173 @@ class SSRFVector(Rule):
 
 
 # ---------------------------------------------------------------
+# SEC-007  WeakCryptography
+# ---------------------------------------------------------------
+
+_WEAK_HASHES = frozenset({"md5", "sha1"})
+
+_SECURITY_TOKEN_NAME_RE = re.compile(
+    r"(?:^|_)(token|key|secret|password|nonce|salt|session|otp|signature|csrf)(?:$|_)",
+    re.IGNORECASE,
+)
+
+_RANDOM_CALLABLES = frozenset(
+    {
+        "random",
+        "randint",
+        "randrange",
+        "choice",
+        "choices",
+        "sample",
+        "randbytes",
+        "getrandbits",
+        "uniform",
+    }
+)
+
+
+def _has_security_context(name: str | None) -> bool:
+    """Return True if an identifier name signals security-sensitive use."""
+    if not name:
+        return False
+    return bool(_SECURITY_TOKEN_NAME_RE.search(name))
+
+
+class WeakCryptography(Rule):
+    """SEC-007: hashlib.md5/sha1 used for security, or random module used for tokens.
+
+    Principles: #4 (Failure must be named).
+    Source: OWASP A02 — Cryptographic Failures; CWE-327 / CWE-338.
+    """
+
+    code = "SEC-007"
+    severity = Severity.ERROR
+    category = Category.SECURITY
+    message_template = "Weak cryptography '{call}' at line {line}"
+    recommendation_template = (
+        "Use hashlib.sha256 or hashlib.scrypt for password/message hashing, "
+        "and the 'secrets' module (token_hex, token_urlsafe, token_bytes) "
+        "for tokens, keys, salts, and session identifiers."
+    )
+
+    def check(self, context: PythonContext) -> list[Finding]:
+        findings: list[Finding] = []
+        for f in context.files:
+            if _is_test_file(f.relative_path):
+                continue
+            tree = f.ast_tree
+            if tree is None:
+                continue
+            # Pass 1: hashlib.md5 / hashlib.sha1 — flag unconditionally.
+            for node in ast.walk(tree):
+                if not isinstance(node, ast.Call):
+                    continue
+                func = node.func
+                if (
+                    isinstance(func, ast.Attribute)
+                    and isinstance(func.value, ast.Name)
+                    and func.value.id == "hashlib"
+                    and func.attr in _WEAK_HASHES
+                ):
+                    findings.append(
+                        self.finding(
+                            file=f.relative_path,
+                            line=node.lineno,
+                            call=f"hashlib.{func.attr}",
+                        )
+                    )
+            # Pass 2: random.<callable>() inside a function whose name signals
+            # security context (generate_token, api_key, make_session, etc.).
+            for fn in ast.walk(tree):
+                if not isinstance(fn, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                    continue
+                if not _has_security_context(fn.name):
+                    continue
+                for node in ast.walk(fn):
+                    if not isinstance(node, ast.Call):
+                        continue
+                    func = node.func
+                    if (
+                        isinstance(func, ast.Attribute)
+                        and isinstance(func.value, ast.Name)
+                        and func.value.id == "random"
+                        and func.attr in _RANDOM_CALLABLES
+                    ):
+                        findings.append(
+                            self.finding(
+                                file=f.relative_path,
+                                line=node.lineno,
+                                call=f"random.{func.attr}",
+                            )
+                        )
+        return findings
+
+
+# ---------------------------------------------------------------
+# SEC-008  InsecureSSLVerification
+# ---------------------------------------------------------------
+
+
+class InsecureSSLVerification(Rule):
+    """SEC-008: TLS certificate verification disabled via verify=False or ssl.CERT_NONE.
+
+    Principles: #4 (Failure must be named).
+    Source: OWASP A02 — Cryptographic Failures; CWE-295 Improper Certificate Validation.
+    """
+
+    code = "SEC-008"
+    severity = Severity.ERROR
+    category = Category.SECURITY
+    message_template = "{detail} at line {line} — TLS verification disabled"
+    recommendation_template = (
+        "Leave verify at its default (True) or pass a CA bundle path. "
+        "For ssl.SSLContext, use ssl.CERT_REQUIRED. Disabling verification "
+        "makes the connection vulnerable to man-in-the-middle attacks."
+    )
+
+    def check(self, context: PythonContext) -> list[Finding]:
+        findings: list[Finding] = []
+        for f in context.files:
+            if _is_test_file(f.relative_path):
+                continue
+            tree = f.ast_tree
+            if tree is None:
+                continue
+            for node in ast.walk(tree):
+                # verify=False on any call
+                if isinstance(node, ast.Call):
+                    for kw in node.keywords:
+                        if (
+                            kw.arg == "verify"
+                            and isinstance(kw.value, ast.Constant)
+                            and kw.value.value is False
+                        ):
+                            findings.append(
+                                self.finding(
+                                    file=f.relative_path,
+                                    line=node.lineno,
+                                    detail="verify=False",
+                                )
+                            )
+                            break
+                # ssl.CERT_NONE reference
+                if (
+                    isinstance(node, ast.Attribute)
+                    and isinstance(node.value, ast.Name)
+                    and node.value.id == "ssl"
+                    and node.attr == "CERT_NONE"
+                ):
+                    findings.append(
+                        self.finding(
+                            file=f.relative_path,
+                            line=node.lineno,
+                            detail="ssl.CERT_NONE",
+                        )
+                    )
+        return findings
+
+
+# ---------------------------------------------------------------
 # Exported rule instances
 # ---------------------------------------------------------------
 
@@ -522,4 +699,6 @@ SECURITY_RULES = (
     EvalExecUsage(),
     UnsafeDeserialization(),
     SSRFVector(),
+    WeakCryptography(),
+    InsecureSSLVerification(),
 )

--- a/tests/fixtures/python/SEC-005/expected.json
+++ b/tests/fixtures/python/SEC-005/expected.json
@@ -1,23 +1,33 @@
 {
   "rule_id": "SEC-005",
-  "description": "UnsafeDeserialization -- pickle.load/loads and yaml.load execute arbitrary code on hostile input",
+  "description": "UnsafeDeserialization -- pickle.load/loads, yaml.load without SafeLoader, and marshal.load/loads execute arbitrary code on hostile input",
   "fixtures": {
     "fail_unsafe_deserialization.py": {
       "expected_findings": [
         {
           "severity": "error",
-          "line": 9,
+          "line": 10,
           "message_contains": "pickle.load"
         },
         {
           "severity": "error",
-          "line": 13,
+          "line": 14,
           "message_contains": "pickle.loads"
         },
         {
           "severity": "error",
-          "line": 17,
+          "line": 18,
           "message_contains": "yaml.load"
+        },
+        {
+          "severity": "error",
+          "line": 23,
+          "message_contains": "marshal.load"
+        },
+        {
+          "severity": "error",
+          "line": 27,
+          "message_contains": "marshal.loads"
         }
       ]
     },

--- a/tests/fixtures/python/SEC-005/fail_unsafe_deserialization.py
+++ b/tests/fixtures/python/SEC-005/fail_unsafe_deserialization.py
@@ -1,7 +1,8 @@
-"""Fixture for SEC-005: pickle.load/loads and yaml.load without a safe loader."""
+"""Fixture for SEC-005: pickle.load/loads, yaml.load without SafeLoader, and marshal.load/loads."""
 
 import pickle
 import yaml
+import marshal
 
 
 def load_pickle_file(path):
@@ -15,3 +16,12 @@ def load_pickle_bytes(data):
 
 def load_yaml(text):
     return yaml.load(text)
+
+
+def load_marshal_file(path):
+    with open(path, "rb") as f:
+        return marshal.load(f)
+
+
+def load_marshal_bytes(data):
+    return marshal.loads(data)

--- a/tests/fixtures/python/SEC-007/expected.json
+++ b/tests/fixtures/python/SEC-007/expected.json
@@ -1,0 +1,36 @@
+{
+  "rule_id": "SEC-007",
+  "description": "WeakCryptography -- hashlib.md5/sha1 for security, and random module for tokens/keys",
+  "fixtures": {
+    "fail_weak_crypto.py": {
+      "expected_findings": [
+        {
+          "severity": "error",
+          "line": 8,
+          "message_contains": "hashlib.md5"
+        },
+        {
+          "severity": "error",
+          "line": 12,
+          "message_contains": "hashlib.sha1"
+        },
+        {
+          "severity": "error",
+          "line": 16,
+          "message_contains": "random"
+        },
+        {
+          "severity": "error",
+          "line": 20,
+          "message_contains": "random"
+        }
+      ]
+    },
+    "pass_secure_crypto.py": {
+      "expected_findings": []
+    },
+    "pass_non_security_use.py": {
+      "expected_findings": []
+    }
+  }
+}

--- a/tests/fixtures/python/SEC-007/fail_weak_crypto.py
+++ b/tests/fixtures/python/SEC-007/fail_weak_crypto.py
@@ -1,0 +1,20 @@
+"""Fixture for SEC-007: hashlib.md5/sha1 and random for security tokens."""
+
+import hashlib
+import random
+
+
+def hash_password_md5(password: str) -> str:
+    return hashlib.md5(password.encode()).hexdigest()
+
+
+def hash_password_sha1(password: str) -> str:
+    return hashlib.sha1(password.encode()).hexdigest()
+
+
+def generate_session_token() -> str:
+    return "".join(str(random.randint(0, 9)) for _ in range(16))
+
+
+def generate_api_key() -> float:
+    return random.random()

--- a/tests/fixtures/python/SEC-007/pass_non_security_use.py
+++ b/tests/fixtures/python/SEC-007/pass_non_security_use.py
@@ -1,0 +1,20 @@
+"""Passing fixture for SEC-007: random used for non-security purposes (simulation, tests)."""
+
+import random
+
+
+def roll_dice() -> int:
+    return random.randint(1, 6)
+
+
+def shuffle_deck(cards: list) -> list:
+    random.shuffle(cards)
+    return cards
+
+
+def sample_rows(rows: list, k: int) -> list:
+    return random.sample(rows, k)
+
+
+def uniform_jitter() -> float:
+    return random.uniform(0.0, 1.0)

--- a/tests/fixtures/python/SEC-007/pass_secure_crypto.py
+++ b/tests/fixtures/python/SEC-007/pass_secure_crypto.py
@@ -1,0 +1,20 @@
+"""Passing fixture for SEC-007: strong hashes and secrets module for tokens."""
+
+import hashlib
+import secrets
+
+
+def hash_password(password: str, salt: bytes) -> bytes:
+    return hashlib.sha256(password.encode() + salt).digest()
+
+
+def hash_password_scrypt(password: str, salt: bytes) -> bytes:
+    return hashlib.scrypt(password.encode(), salt=salt, n=16384, r=8, p=1)
+
+
+def generate_session_token() -> str:
+    return secrets.token_hex(16)
+
+
+def generate_api_key() -> str:
+    return secrets.token_urlsafe(32)

--- a/tests/fixtures/python/SEC-008/expected.json
+++ b/tests/fixtures/python/SEC-008/expected.json
@@ -1,0 +1,33 @@
+{
+  "rule_id": "SEC-008",
+  "description": "InsecureSSLVerification -- verify=False on HTTP libraries and ssl.CERT_NONE disable certificate checks",
+  "fixtures": {
+    "fail_ssl_disabled.py": {
+      "expected_findings": [
+        {
+          "severity": "error",
+          "line": 9,
+          "message_contains": "verify=False"
+        },
+        {
+          "severity": "error",
+          "line": 13,
+          "message_contains": "verify=False"
+        },
+        {
+          "severity": "error",
+          "line": 17,
+          "message_contains": "verify=False"
+        },
+        {
+          "severity": "error",
+          "line": 23,
+          "message_contains": "CERT_NONE"
+        }
+      ]
+    },
+    "pass_ssl_enabled.py": {
+      "expected_findings": []
+    }
+  }
+}

--- a/tests/fixtures/python/SEC-008/fail_ssl_disabled.py
+++ b/tests/fixtures/python/SEC-008/fail_ssl_disabled.py
@@ -1,0 +1,24 @@
+"""Fixture for SEC-008: SSL verification disabled via verify=False and ssl.CERT_NONE."""
+
+import ssl
+import requests
+import httpx
+
+
+def fetch_without_verify(url: str) -> str:
+    return requests.get(url, verify=False).text
+
+
+def post_without_verify(url: str, payload: dict) -> str:
+    return requests.post(url, json=payload, verify=False).text
+
+
+def httpx_without_verify(url: str) -> str:
+    return httpx.get(url, verify=False).text
+
+
+def build_insecure_context() -> ssl.SSLContext:
+    ctx = ssl.create_default_context()
+    ctx.check_hostname = False
+    ctx.verify_mode = ssl.CERT_NONE
+    return ctx

--- a/tests/fixtures/python/SEC-008/pass_ssl_enabled.py
+++ b/tests/fixtures/python/SEC-008/pass_ssl_enabled.py
@@ -1,0 +1,22 @@
+"""Passing fixture for SEC-008: default verification and explicit CA bundles."""
+
+import ssl
+import requests
+
+
+def fetch(url: str) -> str:
+    return requests.get(url).text
+
+
+def fetch_with_ca_bundle(url: str, ca_path: str) -> str:
+    return requests.get(url, verify=ca_path).text
+
+
+def fetch_with_verify_true(url: str) -> str:
+    return requests.get(url, verify=True).text
+
+
+def build_secure_context() -> ssl.SSLContext:
+    ctx = ssl.create_default_context()
+    ctx.verify_mode = ssl.CERT_REQUIRED
+    return ctx


### PR DESCRIPTION
## Summary

First slice of #142 — mining the structural half of the OWASP Top 10 under the Rule Acceptance Test ([principles.md:329-352](docs/principles.md#L329-L352)).

- **SEC-007 WeakCryptography** — flags `hashlib.md5/sha1` unconditionally and `random.<method>` only inside functions whose names signal security context (`token`, `key`, `secret`, `password`, `nonce`, `salt`, `session`, `otp`, `signature`, `csrf`). OWASP A02:2021 / CWE-327 / CWE-338.
- **SEC-008 InsecureSSLVerification** — flags `verify=False` literals on any HTTP call and any reference to `ssl.CERT_NONE`. OWASP A02:2021 / CWE-295.
- **SEC-005 UnsafeDeserialization** — extended to cover `marshal.load` / `marshal.loads` alongside the existing `pickle` and `yaml.load` cases. OWASP A08:2021.

## Overlap vs. `bandit`

All three overlap with `bandit` to some degree, but each adds detection power:

- **SEC-007** narrows `random`-is-weak (bandit B311) by requiring a security-named enclosing function. Dice rolls, shuffling, and sampling pass clean — only `generate_session_token()` and `make_api_key()` fire. Fewer false positives.
- **SEC-008** matches bandit B501/B502 but ships a one-sentence recommendation and a principle citation, and is reported in the same pass as the architectural rules.
- **SEC-005** extends the existing Gaudi rule with `marshal`, which bandit covers (B302) but the previous SEC-005 did not.

Every rule cites Principle 4 (Failure must be named) and a published OWASP source.

## Rule Acceptance Test — all pass

| # | Question | SEC-005 (ext.) | SEC-007 | SEC-008 |
|---|----------|---|---|---|
| 1 | Published + citable source? | ✅ OWASP A08 | ✅ OWASP A02, CWE-327/338 | ✅ OWASP A02, CWE-295 |
| 2 | Failing fixture? | ✅ | ✅ | ✅ |
| 3 | General rule already covers? | ❌ — extension | ❌ | ❌ |
| 4 | Needs runtime/graph data? | ❌ — pure AST | ❌ — pure AST | ❌ — pure AST |
| 5 | One-sentence fix? | ✅ `json` / `yaml.safe_load` | ✅ `hashlib.sha256` / `secrets.token_hex` | ✅ default `verify=True` / `ssl.CERT_REQUIRED` |

## Test plan
- [x] Fixture corpus red before implementation (3 new failure cases)
- [x] Fixture corpus green after implementation
- [x] Full `pytest` suite — 1036 passed
- [x] `gaudi check .` self-run — no SEC-007/008 hits on Gaudi's own codebase
- [x] `docs/rule-sources.md` updated with a new Security Rules section
- [x] `docs/gaudi-rules.md` regenerated via `gaudi cheat-sheet`

## Scope

This is **one** of the 3-5 PRs planned for #142. Candidates for the next slice: path traversal, XXE (XML external entity), insecure tempfiles, subprocess shell injection with non-literal command. Each will follow the same fixture-first discipline.

Refs #142

🤖 Generated with [Claude Code](https://claude.com/claude-code)