### PR TITLE
feat(sec): OWASP structural slice — XXE and insecure tempfiles

### DIFF
--- a/docs/gaudi-rules.md
+++ b/docs/gaudi-rules.md
@@ -22,6 +22,8 @@
 - **SEC-005 UnsafeDeserialization** — pickle, marshal, and yaml.load execute arbitrary code on untrusted input. Use json, or yaml.safe_load / Loader=SafeLoader.
 - **SEC-007 WeakCryptography** — Use hashlib.sha256 or hashlib.scrypt for password/message hashing, and the 'secrets' module (token_hex, token_urlsafe, token_bytes) for tokens, keys, salts, and session identifiers.
 - **SEC-008 InsecureSSLVerification** — Leave verify at its default (True) or pass a CA bundle path. For ssl.SSLContext, use ssl.CERT_REQUIRED. Disabling verification makes the connection vulnerable to man-in-the-middle attacks.
+- **SEC-009 XXEVulnerable** — Use defusedxml (defusedxml.ElementTree.parse) for stdlib XML, or pass an lxml.etree.XMLParser(resolve_entities=False, no_network=True) via the parser= keyword. Default stdlib and lxml parsers resolve external entities and can leak files or cause billion-laughs DoS.
+- **SEC-010 InsecureTempFile** — Use tempfile.mkstemp() or tempfile.NamedTemporaryFile(). mktemp() returns a path without opening the file, so an attacker can create it as a symlink between the call and the subsequent open().
 - **SMELL-005 GlobalData** — Avoid mutable module-level variables. Use function-local state, dependency injection, or frozen data structures.
 - **SMELL-006 MutableData** — Avoid shared mutable state. Pass data as function parameters and return results.
 - **STAB-005 BlockingInAsync** — Use async equivalents (asyncio.sleep, httpx.AsyncClient) in async functions. Blocking calls freeze the event loop and starve all concurrent tasks.

--- a/docs/rule-sources.md
+++ b/docs/rule-sources.md
@@ -234,6 +234,8 @@ same naming as a memory leak.
 | SEC-006  | SSRFVector              | Function parameter flows into `requests`/`httpx`/`urlopen` URL unsanitized | A10:2021 SSRF          |
 | SEC-007  | WeakCryptography        | `hashlib.md5/sha1`; `random` module inside token/key/secret functions | A02:2021 Cryptographic Failures (CWE-327/338) |
 | SEC-008  | InsecureSSLVerification | `verify=False` on HTTP calls; `ssl.CERT_NONE`                | A02:2021 Cryptographic Failures (CWE-295) |
+| SEC-009  | XXEVulnerable           | `xml.etree.ElementTree.parse/fromstring` or `lxml.etree.parse/fromstring` without `parser=` hardened | A05:2021 (CWE-611) |
+| SEC-010  | InsecureTempFile        | `tempfile.mktemp()` — race between path selection and open  | A01:2021 (CWE-377)        |
 
 **Overlap with `bandit`.** SEC-005/007/008 cover territory `bandit` also flags,
 but Gaudi's versions (a) carry principle citations so the reader knows *why*

--- a/src/gaudi/packs/python/rules/security.py
+++ b/src/gaudi/packs/python/rules/security.py
@@ -690,6 +690,188 @@ class InsecureSSLVerification(Rule):
 
 
 # ---------------------------------------------------------------
+# Import resolution helper (shared by SEC-009, SEC-010)
+# ---------------------------------------------------------------
+
+
+def _build_name_to_module(tree: ast.AST) -> tuple[dict[str, str], dict[str, str]]:
+    """Scan imports; return (module_aliases, direct_names).
+
+    - ``module_aliases`` maps a local name back to its dotted source module
+      (``import xml.etree.ElementTree as ET`` → ``{"ET": "xml.etree.ElementTree"}``).
+    - ``direct_names`` maps a directly imported symbol to its source module
+      (``from tempfile import mktemp`` → ``{"mktemp": "tempfile"}``).
+    """
+    module_aliases: dict[str, str] = {}
+    direct_names: dict[str, str] = {}
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                local = alias.asname or alias.name.split(".")[0]
+                module_aliases[local] = alias.name
+        elif isinstance(node, ast.ImportFrom):
+            if not node.module:
+                continue
+            for alias in node.names:
+                direct_names[alias.asname or alias.name] = node.module
+    return module_aliases, direct_names
+
+
+def _resolve_call_target(
+    call: ast.Call,
+    module_aliases: dict[str, str],
+    direct_names: dict[str, str],
+) -> tuple[str, str] | None:
+    """Resolve a Call to (module, function).
+
+    Returns None if the call target cannot be resolved to an imported symbol.
+    Handles three shapes:
+      1. ``alias.func(...)``         → (module_aliases[alias], func)
+      2. ``a.b.func(...)``           → ("a.b", func) if a.b is an import path
+      3. ``func(...)``               → (direct_names[func], func)
+    """
+    func = call.func
+    if isinstance(func, ast.Attribute):
+        value = func.value
+        if isinstance(value, ast.Name):
+            module = module_aliases.get(value.id)
+            if module:
+                return (module, func.attr)
+        # a.b.func — walk the dotted chain
+        parts: list[str] = [func.attr]
+        cursor: ast.expr = value
+        while isinstance(cursor, ast.Attribute):
+            parts.append(cursor.attr)
+            cursor = cursor.value
+        if isinstance(cursor, ast.Name):
+            parts.append(cursor.id)
+            parts.reverse()
+            # Did the user `import a.b`? Then module_aliases[a] == "a.b".
+            root = parts[0]
+            root_module = module_aliases.get(root)
+            if root_module:
+                # Reconstruct: if `import lxml.etree`, parts=["lxml","etree","parse"]
+                # Module = "lxml.etree", function = "parse"
+                prefix = ".".join(parts[:-1])
+                if prefix == root_module or prefix.startswith(root_module + "."):
+                    return (prefix, parts[-1])
+    elif isinstance(func, ast.Name):
+        module = direct_names.get(func.id)
+        if module:
+            return (module, func.id)
+    return None
+
+
+# ---------------------------------------------------------------
+# SEC-009  XXEVulnerable
+# ---------------------------------------------------------------
+
+_XXE_UNSAFE_MODULES = frozenset({"xml.etree.ElementTree", "lxml.etree"})
+_XXE_UNSAFE_FUNCS = frozenset({"parse", "fromstring", "iterparse"})
+
+
+class XXEVulnerable(Rule):
+    """SEC-009: XML parsing without disabling external entities.
+
+    Principles: #4 (Failure must be named).
+    Source: OWASP A05:2021 — Security Misconfiguration; CWE-611 XXE.
+    """
+
+    code = "SEC-009"
+    severity = Severity.ERROR
+    category = Category.SECURITY
+    message_template = "'{call}' at line {line} — XXE risk (external entities enabled by default)"
+    recommendation_template = (
+        "Use defusedxml (defusedxml.ElementTree.parse) for stdlib XML, "
+        "or pass an lxml.etree.XMLParser(resolve_entities=False, no_network=True) "
+        "via the parser= keyword. Default stdlib and lxml parsers resolve "
+        "external entities and can leak files or cause billion-laughs DoS."
+    )
+
+    def check(self, context: PythonContext) -> list[Finding]:
+        findings: list[Finding] = []
+        for f in context.files:
+            if _is_test_file(f.relative_path):
+                continue
+            tree = f.ast_tree
+            if tree is None:
+                continue
+            module_aliases, direct_names = _build_name_to_module(tree)
+            for node in ast.walk(tree):
+                if not isinstance(node, ast.Call):
+                    continue
+                target = _resolve_call_target(node, module_aliases, direct_names)
+                if target is None:
+                    continue
+                module, func_name = target
+                if module not in _XXE_UNSAFE_MODULES:
+                    continue
+                if func_name not in _XXE_UNSAFE_FUNCS:
+                    continue
+                # A hardened parser passed via keyword clears the finding.
+                if any(kw.arg == "parser" for kw in node.keywords):
+                    continue
+                call_repr = f"{module}.{func_name}"
+                findings.append(
+                    self.finding(
+                        file=f.relative_path,
+                        line=node.lineno,
+                        call=call_repr,
+                    )
+                )
+        return findings
+
+
+# ---------------------------------------------------------------
+# SEC-010  InsecureTempFile
+# ---------------------------------------------------------------
+
+
+class InsecureTempFile(Rule):
+    """SEC-010: tempfile.mktemp() race between path selection and open.
+
+    Principles: #4 (Failure must be named).
+    Source: OWASP A01:2021 — Broken Access Control; CWE-377 Insecure Temporary File.
+    """
+
+    code = "SEC-010"
+    severity = Severity.ERROR
+    category = Category.SECURITY
+    message_template = "'{call}' at line {line} — race-prone temporary file"
+    recommendation_template = (
+        "Use tempfile.mkstemp() or tempfile.NamedTemporaryFile(). mktemp() "
+        "returns a path without opening the file, so an attacker can create "
+        "it as a symlink between the call and the subsequent open()."
+    )
+
+    def check(self, context: PythonContext) -> list[Finding]:
+        findings: list[Finding] = []
+        for f in context.files:
+            if _is_test_file(f.relative_path):
+                continue
+            tree = f.ast_tree
+            if tree is None:
+                continue
+            module_aliases, direct_names = _build_name_to_module(tree)
+            for node in ast.walk(tree):
+                if not isinstance(node, ast.Call):
+                    continue
+                target = _resolve_call_target(node, module_aliases, direct_names)
+                if target is None:
+                    continue
+                module, func_name = target
+                if module == "tempfile" and func_name == "mktemp":
+                    findings.append(
+                        self.finding(
+                            file=f.relative_path,
+                            line=node.lineno,
+                            call=f"tempfile.{func_name}",
+                        )
+                    )
+        return findings
+
+
+# ---------------------------------------------------------------
 # Exported rule instances
 # ---------------------------------------------------------------
 
@@ -701,4 +883,6 @@ SECURITY_RULES = (
     SSRFVector(),
     WeakCryptography(),
     InsecureSSLVerification(),
+    XXEVulnerable(),
+    InsecureTempFile(),
 )

--- a/tests/fixtures/python/SEC-009/expected.json
+++ b/tests/fixtures/python/SEC-009/expected.json
@@ -1,0 +1,43 @@
+{
+  "rule_id": "SEC-009",
+  "description": "XXEVulnerable -- XML parsing without disabling external entities / DTDs",
+  "fixtures": {
+    "fail_xxe.py": {
+      "expected_findings": [
+        {
+          "severity": "error",
+          "line": 9,
+          "message_contains": "ElementTree.parse"
+        },
+        {
+          "severity": "error",
+          "line": 13,
+          "message_contains": "ElementTree.fromstring"
+        },
+        {
+          "severity": "error",
+          "line": 17,
+          "message_contains": "ElementTree.parse"
+        },
+        {
+          "severity": "error",
+          "line": 21,
+          "message_contains": "ElementTree.fromstring"
+        },
+        {
+          "severity": "error",
+          "line": 25,
+          "message_contains": "lxml.etree.parse"
+        },
+        {
+          "severity": "error",
+          "line": 29,
+          "message_contains": "lxml.etree.fromstring"
+        }
+      ]
+    },
+    "pass_safe_xml.py": {
+      "expected_findings": []
+    }
+  }
+}

--- a/tests/fixtures/python/SEC-009/fail_xxe.py
+++ b/tests/fixtures/python/SEC-009/fail_xxe.py
@@ -1,0 +1,29 @@
+"""Fixture for SEC-009: XML parsing without disabling external entities."""
+
+import xml.etree.ElementTree as ET
+from xml.etree.ElementTree import parse, fromstring
+import lxml.etree
+
+
+def parse_user_xml(path: str):
+    return ET.parse(path)
+
+
+def parse_xml_bytes(data: bytes):
+    return ET.fromstring(data)
+
+
+def parse_via_alias(path: str):
+    return parse(path)
+
+
+def parse_string_via_alias(data: str):
+    return fromstring(data)
+
+
+def parse_with_lxml(path: str):
+    return lxml.etree.parse(path)
+
+
+def parse_lxml_string(data: bytes):
+    return lxml.etree.fromstring(data)

--- a/tests/fixtures/python/SEC-009/pass_safe_xml.py
+++ b/tests/fixtures/python/SEC-009/pass_safe_xml.py
@@ -1,0 +1,22 @@
+"""Passing fixture for SEC-009: defusedxml and hardened lxml parsers."""
+
+import defusedxml.ElementTree as DET
+import lxml.etree
+
+
+def parse_with_defusedxml(path: str):
+    return DET.parse(path)
+
+
+def parse_string_with_defusedxml(data: bytes):
+    return DET.fromstring(data)
+
+
+def parse_lxml_hardened(path: str):
+    parser = lxml.etree.XMLParser(resolve_entities=False, no_network=True)
+    return lxml.etree.parse(path, parser=parser)
+
+
+def parse_lxml_string_hardened(data: bytes):
+    parser = lxml.etree.XMLParser(resolve_entities=False, no_network=True)
+    return lxml.etree.fromstring(data, parser=parser)

--- a/tests/fixtures/python/SEC-010/expected.json
+++ b/tests/fixtures/python/SEC-010/expected.json
@@ -1,0 +1,23 @@
+{
+  "rule_id": "SEC-010",
+  "description": "InsecureTempFile -- tempfile.mktemp creates a race condition between path selection and file open",
+  "fixtures": {
+    "fail_insecure_tempfile.py": {
+      "expected_findings": [
+        {
+          "severity": "error",
+          "line": 8,
+          "message_contains": "tempfile.mktemp"
+        },
+        {
+          "severity": "error",
+          "line": 15,
+          "message_contains": "mktemp"
+        }
+      ]
+    },
+    "pass_safe_tempfile.py": {
+      "expected_findings": []
+    }
+  }
+}

--- a/tests/fixtures/python/SEC-010/fail_insecure_tempfile.py
+++ b/tests/fixtures/python/SEC-010/fail_insecure_tempfile.py
@@ -1,0 +1,18 @@
+"""Fixture for SEC-010: tempfile.mktemp is race-condition prone."""
+
+import tempfile
+from tempfile import mktemp
+
+
+def write_report(data: str) -> str:
+    path = tempfile.mktemp(suffix=".txt")
+    with open(path, "w") as f:
+        f.write(data)
+    return path
+
+
+def another_temp(data: str) -> str:
+    path = mktemp()
+    with open(path, "w") as f:
+        f.write(data)
+    return path

--- a/tests/fixtures/python/SEC-010/pass_safe_tempfile.py
+++ b/tests/fixtures/python/SEC-010/pass_safe_tempfile.py
@@ -1,0 +1,17 @@
+"""Passing fixture for SEC-010: mkstemp and NamedTemporaryFile."""
+
+import os
+import tempfile
+
+
+def write_report(data: str) -> str:
+    fd, path = tempfile.mkstemp(suffix=".txt")
+    with os.fdopen(fd, "w") as f:
+        f.write(data)
+    return path
+
+
+def write_report_named(data: str) -> str:
+    with tempfile.NamedTemporaryFile("w", delete=False, suffix=".txt") as f:
+        f.write(data)
+        return f.name


### PR DESCRIPTION
## Summary

Second slice of #142.

- **SEC-009 XXEVulnerable** — flags `xml.etree.ElementTree.parse/fromstring/iterparse` and `lxml.etree.parse/fromstring/iterparse` invocations that do not pass a hardened `parser=`. OWASP A05:2021 / CWE-611.
- **SEC-010 InsecureTempFile** — flags `tempfile.mktemp()` (whether via `tempfile.mktemp` or `from tempfile import mktemp`). OWASP A01:2021 / CWE-377.

Both rules share a new import-resolution helper (`_build_name_to_module` + `_resolve_call_target`) that handles three call shapes: `alias.func(...)`, `a.b.func(...)` (dotted chain), and `func(...)` (direct import). This will be reused by the remaining slices.

## Overlap vs. `bandit`

- **SEC-009** matches bandit B313–B320 but is narrower: it clears calls that pass `parser=`, matching real-world lxml hardening. Bandit's detection doesn't check for a hardened parser override.
- **SEC-010** matches bandit B306 but adds principle citation + one-sentence fix.

## Rule Acceptance Test

| # | Question | SEC-009 | SEC-010 |
|---|----------|---|---|
| 1 | Published + citable? | ✅ OWASP A05, CWE-611 | ✅ OWASP A01, CWE-377 |
| 2 | Failing fixture? | ✅ (6 cases) | ✅ (2 cases) |
| 3 | General rule covers? | ❌ | ❌ |
| 4 | Needs runtime/graph? | ❌ | ❌ |
| 5 | One-sentence fix? | ✅ defusedxml / parser=XMLParser(resolve_entities=False) | ✅ mkstemp / NamedTemporaryFile |

## Test plan
- [x] Fixture corpus red before implementation
- [x] Fixture corpus green after implementation
- [x] Full `pytest` suite — 1042 passed
- [x] `gaudi check .` — no self-hits
- [x] `docs/rule-sources.md` Security table extended
- [x] `docs/gaudi-rules.md` regenerated

Refs #142. Remaining candidates: subprocess shell injection, path traversal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)