### PR TITLE
feat(sec): OWASP structural slice — subprocess shell injection

### DIFF
--- a/docs/gaudi-rules.md
+++ b/docs/gaudi-rules.md
@@ -24,6 +24,7 @@
 - **SEC-008 InsecureSSLVerification** — Leave verify at its default (True) or pass a CA bundle path. For ssl.SSLContext, use ssl.CERT_REQUIRED. Disabling verification makes the connection vulnerable to man-in-the-middle attacks.
 - **SEC-009 XXEVulnerable** — Use defusedxml (defusedxml.ElementTree.parse) for stdlib XML, or pass an lxml.etree.XMLParser(resolve_entities=False, no_network=True) via the parser= keyword. Default stdlib and lxml parsers resolve external entities and can leak files or cause billion-laughs DoS.
 - **SEC-010 InsecureTempFile** — Use tempfile.mkstemp() or tempfile.NamedTemporaryFile(). mktemp() returns a path without opening the file, so an attacker can create it as a symlink between the call and the subsequent open().
+- **SEC-011 SubprocessShellInjection** — Pass argv as a list (subprocess.run(['cmd', arg1, arg2])) and leave shell=False. If a shell is unavoidable, escape with shlex.quote. Never build a shell command by concatenating user input.
 - **SMELL-005 GlobalData** — Avoid mutable module-level variables. Use function-local state, dependency injection, or frozen data structures.
 - **SMELL-006 MutableData** — Avoid shared mutable state. Pass data as function parameters and return results.
 - **STAB-005 BlockingInAsync** — Use async equivalents (asyncio.sleep, httpx.AsyncClient) in async functions. Blocking calls freeze the event loop and starve all concurrent tasks.

--- a/docs/rule-sources.md
+++ b/docs/rule-sources.md
@@ -236,6 +236,7 @@ same naming as a memory leak.
 | SEC-008  | InsecureSSLVerification | `verify=False` on HTTP calls; `ssl.CERT_NONE`                | A02:2021 Cryptographic Failures (CWE-295) |
 | SEC-009  | XXEVulnerable           | `xml.etree.ElementTree.parse/fromstring` or `lxml.etree.parse/fromstring` without `parser=` hardened | A05:2021 (CWE-611) |
 | SEC-010  | InsecureTempFile        | `tempfile.mktemp()` — race between path selection and open  | A01:2021 (CWE-377)        |
+| SEC-011  | SubprocessShellInjection | `subprocess.*(..., shell=True)` with non-literal command; `os.system`/`os.popen` with non-literal | A03:2021 Injection (CWE-78) |
 
 **Overlap with `bandit`.** SEC-005/007/008 cover territory `bandit` also flags,
 but Gaudi's versions (a) carry principle citations so the reader knows *why*

--- a/src/gaudi/packs/python/rules/security.py
+++ b/src/gaudi/packs/python/rules/security.py
@@ -872,6 +872,95 @@ class InsecureTempFile(Rule):
 
 
 # ---------------------------------------------------------------
+# SEC-011  SubprocessShellInjection
+# ---------------------------------------------------------------
+
+_SUBPROCESS_CALLABLES = frozenset(
+    {"run", "call", "check_call", "check_output", "Popen"}
+)
+
+
+def _is_literal_command(node: ast.expr) -> bool:
+    """Return True if a command argument is a safe literal (str/bytes constant)."""
+    return isinstance(node, ast.Constant) and isinstance(node.value, (str, bytes))
+
+
+def _has_shell_true(call: ast.Call) -> bool:
+    for kw in call.keywords:
+        if (
+            kw.arg == "shell"
+            and isinstance(kw.value, ast.Constant)
+            and kw.value.value is True
+        ):
+            return True
+    return False
+
+
+class SubprocessShellInjection(Rule):
+    """SEC-011: subprocess with shell=True on a non-literal, or os.system/popen with a non-literal.
+
+    Principles: #4 (Failure must be named).
+    Source: OWASP A03:2021 — Injection; CWE-78 OS Command Injection.
+    """
+
+    code = "SEC-011"
+    severity = Severity.ERROR
+    category = Category.SECURITY
+    message_template = "{detail} at line {line} — command injection risk"
+    recommendation_template = (
+        "Pass argv as a list (subprocess.run(['cmd', arg1, arg2])) and leave "
+        "shell=False. If a shell is unavoidable, escape with shlex.quote. "
+        "Never build a shell command by concatenating user input."
+    )
+
+    def check(self, context: PythonContext) -> list[Finding]:
+        findings: list[Finding] = []
+        for f in context.files:
+            if _is_test_file(f.relative_path):
+                continue
+            tree = f.ast_tree
+            if tree is None:
+                continue
+            module_aliases, direct_names = _build_name_to_module(tree)
+            for node in ast.walk(tree):
+                if not isinstance(node, ast.Call):
+                    continue
+                target = _resolve_call_target(node, module_aliases, direct_names)
+                if target is None:
+                    continue
+                module, func_name = target
+                # subprocess.<callable> with shell=True and a non-literal command
+                if module == "subprocess" and func_name in _SUBPROCESS_CALLABLES:
+                    if not _has_shell_true(node):
+                        continue
+                    if not node.args:
+                        continue
+                    if _is_literal_command(node.args[0]):
+                        continue
+                    findings.append(
+                        self.finding(
+                            file=f.relative_path,
+                            line=node.lineno,
+                            detail=f"subprocess.{func_name}(shell=True, ...)",
+                        )
+                    )
+                # os.system / os.popen with a non-literal command
+                elif module == "os" and func_name in ("system", "popen"):
+                    if not node.args:
+                        continue
+                    if _is_literal_command(node.args[0]):
+                        continue
+                    findings.append(
+                        self.finding(
+                            file=f.relative_path,
+                            line=node.lineno,
+                            detail=f"os.{func_name}",
+                        )
+                    )
+        return findings
+
+
+# ---------------------------------------------------------------
 # Exported rule instances
 # ---------------------------------------------------------------
 
@@ -885,4 +974,5 @@ SECURITY_RULES = (
     InsecureSSLVerification(),
     XXEVulnerable(),
     InsecureTempFile(),
+    SubprocessShellInjection(),
 )

--- a/src/gaudi/packs/python/rules/security.py
+++ b/src/gaudi/packs/python/rules/security.py
@@ -875,9 +875,7 @@ class InsecureTempFile(Rule):
 # SEC-011  SubprocessShellInjection
 # ---------------------------------------------------------------
 
-_SUBPROCESS_CALLABLES = frozenset(
-    {"run", "call", "check_call", "check_output", "Popen"}
-)
+_SUBPROCESS_CALLABLES = frozenset({"run", "call", "check_call", "check_output", "Popen"})
 
 
 def _is_literal_command(node: ast.expr) -> bool:
@@ -887,11 +885,7 @@ def _is_literal_command(node: ast.expr) -> bool:
 
 def _has_shell_true(call: ast.Call) -> bool:
     for kw in call.keywords:
-        if (
-            kw.arg == "shell"
-            and isinstance(kw.value, ast.Constant)
-            and kw.value.value is True
-        ):
+        if kw.arg == "shell" and isinstance(kw.value, ast.Constant) and kw.value.value is True:
             return True
     return False
 

--- a/tests/fixtures/python/SEC-011/expected.json
+++ b/tests/fixtures/python/SEC-011/expected.json
@@ -1,0 +1,38 @@
+{
+  "rule_id": "SEC-011",
+  "description": "SubprocessShellInjection -- shell=True with non-literal command, or os.system/os.popen with non-literal argument",
+  "fixtures": {
+    "fail_shell_injection.py": {
+      "expected_findings": [
+        {
+          "severity": "error",
+          "line": 8,
+          "message_contains": "shell=True"
+        },
+        {
+          "severity": "error",
+          "line": 12,
+          "message_contains": "shell=True"
+        },
+        {
+          "severity": "error",
+          "line": 16,
+          "message_contains": "shell=True"
+        },
+        {
+          "severity": "error",
+          "line": 20,
+          "message_contains": "os.system"
+        },
+        {
+          "severity": "error",
+          "line": 24,
+          "message_contains": "os.popen"
+        }
+      ]
+    },
+    "pass_safe_subprocess.py": {
+      "expected_findings": []
+    }
+  }
+}

--- a/tests/fixtures/python/SEC-011/fail_shell_injection.py
+++ b/tests/fixtures/python/SEC-011/fail_shell_injection.py
@@ -1,0 +1,24 @@
+"""Fixture for SEC-011: subprocess and os.system with untrusted command strings."""
+
+import os
+import subprocess
+
+
+def run_ls(target: str):
+    return subprocess.run(f"ls {target}", shell=True)
+
+
+def popen_grep(pattern: str, path: str):
+    return subprocess.Popen("grep " + pattern + " " + path, shell=True)
+
+
+def check_output_cat(path: str):
+    return subprocess.check_output("cat %s" % path, shell=True)
+
+
+def call_system(user_cmd: str):
+    return os.system(user_cmd)
+
+
+def popen_system(user_cmd: str):
+    return os.popen(user_cmd)

--- a/tests/fixtures/python/SEC-011/pass_safe_subprocess.py
+++ b/tests/fixtures/python/SEC-011/pass_safe_subprocess.py
@@ -1,0 +1,20 @@
+"""Passing fixture for SEC-011: argv-list form and literal commands."""
+
+import os
+import subprocess
+
+
+def list_files(target: str):
+    return subprocess.run(["ls", target], check=True)
+
+
+def grep_pattern(pattern: str, path: str):
+    return subprocess.Popen(["grep", pattern, path])
+
+
+def run_literal_command():
+    return subprocess.run("date", shell=True, check=True)
+
+
+def os_system_literal():
+    return os.system("sync")


### PR DESCRIPTION
## Summary

Third slice of #142.

**SEC-011 SubprocessShellInjection** flags:
- `subprocess.run/call/check_call/check_output/Popen` with `shell=True` and a non-literal first argument (f-string, concat, `%`-format, `Name`, etc.)
- `os.system(x)` / `os.popen(x)` with a non-literal argument

The argv-list form (`subprocess.run(['cmd', arg])`) is always safe and passes clean. Literal commands with `shell=True` also pass — the injection risk is user input flowing into a shell-interpreted string. OWASP A03:2021 / CWE-78.

Reuses the import-resolution helper from SEC-009/SEC-010.

## Overlap vs. `bandit`

Bandit B602/B603/B605 overlap. Gaudi's version is tighter: bandit flags `shell=True` even on string literals (B602), producing false positives for `subprocess.run("date", shell=True)`. SEC-011 requires both `shell=True` **and** a non-literal first argument, matching the real injection surface.

## Rule Acceptance Test

| # | Question | SEC-011 |
|---|----------|---------|
| 1 | Published + citable? | ✅ OWASP A03, CWE-78 |
| 2 | Failing fixture? | ✅ (5 cases) |
| 3 | General rule covers? | ❌ |
| 4 | Needs runtime/graph? | ❌ — intra-call AST |
| 5 | One-sentence fix? | ✅ argv list + `shlex.quote` if shell is unavoidable |

## Test plan
- [x] Fixture corpus red before implementation
- [x] Fixture corpus green after implementation
- [x] Full `pytest` suite — 1045 passed
- [x] `gaudi check .` — no self-hits
- [x] `docs/rule-sources.md` updated
- [x] `docs/gaudi-rules.md` regenerated

Refs #142. Remaining candidate: path traversal (intra-procedural taint).

🤖 Generated with [Claude Code](https://claude.com/claude-code)