### PR TITLE
feat(sec): OWASP structural slice — path traversal

### DIFF
--- a/docs/gaudi-rules.md
+++ b/docs/gaudi-rules.md
@@ -25,6 +25,7 @@
 - **SEC-009 XXEVulnerable** — Use defusedxml (defusedxml.ElementTree.parse) for stdlib XML, or pass an lxml.etree.XMLParser(resolve_entities=False, no_network=True) via the parser= keyword. Default stdlib and lxml parsers resolve external entities and can leak files or cause billion-laughs DoS.
 - **SEC-010 InsecureTempFile** — Use tempfile.mkstemp() or tempfile.NamedTemporaryFile(). mktemp() returns a path without opening the file, so an attacker can create it as a symlink between the call and the subsequent open().
 - **SEC-011 SubprocessShellInjection** — Pass argv as a list (subprocess.run(['cmd', arg1, arg2])) and leave shell=False. If a shell is unavoidable, escape with shlex.quote. Never build a shell command by concatenating user input.
+- **SEC-012 PathTraversal** — Validate the path against an allowlist or a fixed base directory. Resolve with Path(user_input).resolve() and check path.is_relative_to(BASE) before opening.
 - **SMELL-005 GlobalData** — Avoid mutable module-level variables. Use function-local state, dependency injection, or frozen data structures.
 - **SMELL-006 MutableData** — Avoid shared mutable state. Pass data as function parameters and return results.
 - **STAB-005 BlockingInAsync** — Use async equivalents (asyncio.sleep, httpx.AsyncClient) in async functions. Blocking calls freeze the event loop and starve all concurrent tasks.

--- a/docs/rule-sources.md
+++ b/docs/rule-sources.md
@@ -237,6 +237,7 @@ same naming as a memory leak.
 | SEC-009  | XXEVulnerable           | `xml.etree.ElementTree.parse/fromstring` or `lxml.etree.parse/fromstring` without `parser=` hardened | A05:2021 (CWE-611) |
 | SEC-010  | InsecureTempFile        | `tempfile.mktemp()` — race between path selection and open  | A01:2021 (CWE-377)        |
 | SEC-011  | SubprocessShellInjection | `subprocess.*(..., shell=True)` with non-literal command; `os.system`/`os.popen` with non-literal | A03:2021 Injection (CWE-78) |
+| SEC-012  | PathTraversal           | Function parameter flows into `open()` or `Path()` with no startswith/membership/resolve guard | A01:2021 Broken Access Control (CWE-22) |
 
 **Overlap with `bandit`.** SEC-005/007/008 cover territory `bandit` also flags,
 but Gaudi's versions (a) carry principle citations so the reader knows *why*

--- a/src/gaudi/cli.py
+++ b/src/gaudi/cli.py
@@ -222,7 +222,7 @@ def report(
     markdown = format_markdown_report(findings, project_path, snippet_context=snippet_context)
 
     if output:
-        Path(output).write_text(markdown, encoding="utf-8")
+        Path(output).write_text(markdown, encoding="utf-8")  # noqa: SEC-012
         console.print(f"[green]Wrote report to {output}[/green]")
     else:
         click.echo(markdown)
@@ -379,7 +379,7 @@ def cheat_sheet(output: str | None, check: bool):
         sys.exit(1)
 
     if output:
-        Path(output).write_text(rendered, encoding="utf-8")
+        Path(output).write_text(rendered, encoding="utf-8")  # noqa: SEC-012
         console.print(f"[green]Wrote cheat-sheet to {output}[/green]")
     else:
         click.echo(rendered)

--- a/src/gaudi/packs/python/rules/security.py
+++ b/src/gaudi/packs/python/rules/security.py
@@ -955,6 +955,123 @@ class SubprocessShellInjection(Rule):
 
 
 # ---------------------------------------------------------------
+# SEC-012  PathTraversal
+# ---------------------------------------------------------------
+
+
+_PATH_IO_METHODS = frozenset(
+    {
+        "read_text",
+        "read_bytes",
+        "write_text",
+        "write_bytes",
+        "open",
+        "unlink",
+        "touch",
+        "mkdir",
+        "rmdir",
+        "rename",
+        "replace",
+    }
+)
+
+
+def _is_path_constructor(call: ast.Call) -> bool:
+    """True for Path(...) or pathlib.Path(...)."""
+    func = call.func
+    if isinstance(func, ast.Name) and func.id == "Path":
+        return True
+    if (
+        isinstance(func, ast.Attribute)
+        and func.attr == "Path"
+        and isinstance(func.value, ast.Name)
+        and func.value.id == "pathlib"
+    ):
+        return True
+    return False
+
+
+def _check_function_path_traversal(
+    func_def: ast.FunctionDef | ast.AsyncFunctionDef,
+) -> Iterator[tuple[int, str]]:
+    """Yield (line, sink_name) for I/O calls with tainted first args.
+
+    Sinks:
+      - open(tainted, ...)
+      - Path(tainted).<io_method>(...)  — I/O must be chained on the Path
+    """
+    tainted = _collect_tainted_names(func_def)
+    if not tainted:
+        return
+
+    for node in ast.walk(func_def):
+        if not isinstance(node, ast.Call):
+            continue
+        func = node.func
+
+        # open(tainted, ...)
+        if isinstance(func, ast.Name) and func.id == "open":
+            if node.args and isinstance(node.args[0], ast.Name) and node.args[0].id in tainted:
+                yield (node.lineno, "open")
+                continue
+
+        # <Path(tainted)>.<io_method>(...)
+        if isinstance(func, ast.Attribute) and func.attr in _PATH_IO_METHODS:
+            inner = func.value
+            if (
+                isinstance(inner, ast.Call)
+                and _is_path_constructor(inner)
+                and inner.args
+                and isinstance(inner.args[0], ast.Name)
+                and inner.args[0].id in tainted
+            ):
+                yield (node.lineno, f"Path(...).{func.attr}")
+
+
+class PathTraversal(Rule):
+    """SEC-012: Function parameter flows into open() or Path() unsanitized.
+
+    Principles: #4 (Failure must be named).
+    Source: OWASP A01:2021 — Broken Access Control; CWE-22 Path Traversal.
+
+    Uses intra-procedural taint (same model as SEC-006): parameters are
+    tainted, simple renames propagate, startswith/endswith/membership/
+    urlparse-style checks clear the taint.
+    """
+
+    code = "SEC-012"
+    severity = Severity.ERROR
+    category = Category.SECURITY
+    message_template = "Tainted path passed to '{sink}' at line {line} — path traversal risk"
+    recommendation_template = (
+        "Validate the path against an allowlist or a fixed base directory. "
+        "Resolve with Path(user_input).resolve() and check "
+        "path.is_relative_to(BASE) before opening."
+    )
+
+    def check(self, context: PythonContext) -> list[Finding]:
+        findings: list[Finding] = []
+        for f in context.files:
+            if _is_test_file(f.relative_path):
+                continue
+            tree = f.ast_tree
+            if tree is None:
+                continue
+            for node in ast.walk(tree):
+                if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                    continue
+                for line, sink in _check_function_path_traversal(node):
+                    findings.append(
+                        self.finding(
+                            file=f.relative_path,
+                            line=line,
+                            sink=sink,
+                        )
+                    )
+        return findings
+
+
+# ---------------------------------------------------------------
 # Exported rule instances
 # ---------------------------------------------------------------
 
@@ -969,4 +1086,5 @@ SECURITY_RULES = (
     XXEVulnerable(),
     InsecureTempFile(),
     SubprocessShellInjection(),
+    PathTraversal(),
 )

--- a/tests/fixtures/python/SEC-012/expected.json
+++ b/tests/fixtures/python/SEC-012/expected.json
@@ -1,0 +1,33 @@
+{
+  "rule_id": "SEC-012",
+  "description": "PathTraversal -- tainted parameter flows into open() or pathlib.Path() without a containment check",
+  "fixtures": {
+    "fail_path_traversal.py": {
+      "expected_findings": [
+        {
+          "severity": "error",
+          "line": 12,
+          "message_contains": "open"
+        },
+        {
+          "severity": "error",
+          "line": 18,
+          "message_contains": "open"
+        },
+        {
+          "severity": "error",
+          "line": 22,
+          "message_contains": "Path"
+        },
+        {
+          "severity": "error",
+          "line": 26,
+          "message_contains": "open"
+        }
+      ]
+    },
+    "pass_path_guarded.py": {
+      "expected_findings": []
+    }
+  }
+}

--- a/tests/fixtures/python/SEC-012/fail_path_traversal.py
+++ b/tests/fixtures/python/SEC-012/fail_path_traversal.py
@@ -1,0 +1,27 @@
+"""Fixture for SEC-012: tainted path flowing into open() or Path().
+
+The rule uses the same intra-procedural taint model as SEC-006:
+function parameters are tainted; simple renames propagate;
+startswith/endswith/membership/urlparse-style checks sanitize.
+"""
+
+from pathlib import Path
+
+
+def read_user_file(filename):
+    with open(filename) as f:
+        return f.read()
+
+
+def fetch_report(report_id):
+    path = report_id
+    return open(path).read()
+
+
+def read_pathlib(user_path):
+    return Path(user_path).read_text()
+
+
+def open_for_write(target):
+    with open(target, "w") as f:
+        f.write("x")

--- a/tests/fixtures/python/SEC-012/pass_path_guarded.py
+++ b/tests/fixtures/python/SEC-012/pass_path_guarded.py
@@ -1,0 +1,32 @@
+"""Passing fixture for SEC-012: sanitized or constant paths."""
+
+from pathlib import Path
+
+ALLOWED_REPORTS = {"alpha", "beta", "gamma"}
+
+
+def read_allowed(user_path):
+    if user_path in ALLOWED_REPORTS:
+        return open(user_path).read()
+    return ""
+
+
+def read_prefixed(user_path):
+    if user_path.startswith("/var/reports/"):
+        return open(user_path).read()
+    return ""
+
+
+def read_suffixed(user_path):
+    if user_path.endswith(".txt"):
+        return Path(user_path).read_text()
+    return ""
+
+
+def read_constant():
+    return open("/etc/config.ini").read()
+
+
+def read_local_constant():
+    path = "/etc/hosts"
+    return open(path).read()


### PR DESCRIPTION
## Summary

Fourth and final slice of #142.

**SEC-012 PathTraversal** — function parameter flows into I/O without a containment check. Uses the same intra-procedural taint model as SEC-006 (SSRFVector): parameters are tainted; simple renames propagate; `startswith`/`endswith`/membership/`urlparse`-style checks clear the taint. OWASP A01:2021 / CWE-22.

**Sinks:**
- `open(tainted, ...)`
- `Path(tainted).<io_method>(...)` — only when chained with I/O (`read_text`, `write_text`, `open`, `unlink`, `touch`, `mkdir`, etc.)

The `Path` constructor alone is **not** flagged — constructing a path is not I/O. This keeps CLI tools that accept `--output path` arguments clean unless the path is actually opened. Two legitimate write sites in [src/gaudi/cli.py](src/gaudi/cli.py) carry `# noqa: SEC-012` to acknowledge the CLI contract: the user explicitly chose to write to that path.

## Overlap vs. `bandit`

Bandit has no equivalent general path-traversal check. Its rules (B108 hardcoded tmp path, etc.) target specific sub-cases. SEC-012 fills the general pattern with a taint-aware model that matches SEC-006's design.

## Rule Acceptance Test

| # | Question | SEC-012 |
|---|----------|---------|
| 1 | Published + citable? | ✅ OWASP A01, CWE-22 |
| 2 | Failing fixture? | ✅ (4 cases: direct param, rename, pathlib chain, write) |
| 3 | General rule covers? | ❌ |
| 4 | Needs runtime/graph? | ❌ — intra-procedural taint |
| 5 | One-sentence fix? | ✅ allowlist or `Path(x).resolve().is_relative_to(BASE)` |

## Test plan
- [x] Fixture corpus red before implementation
- [x] Narrowed rule after dogfooding: `Path(x)` bare construction no longer flagged; only chained I/O
- [x] Fixture corpus green after implementation
- [x] Full `pytest` suite — 1048 passed
- [x] `gaudi check .` — 2 legitimate CLI sites suppressed with `# noqa: SEC-012`; otherwise clean
- [x] `docs/rule-sources.md` updated
- [x] `docs/gaudi-rules.md` regenerated
- [x] `ruff format --check` clean

Closes the structural slice of #142: **8 security rules accepted across 4 PRs** (SEC-005 extension + SEC-007 through SEC-012), all sharing a principle citation, an OWASP source, and the Rule Acceptance Test.

Refs #142

🤖 Generated with [Claude Code](https://claude.com/claude-code)