### PR TITLE
refactor: extract collect_receiver_names helper (#199)

### DIFF
--- a/src/gaudi/packs/python/ast_helpers.py
+++ b/src/gaudi/packs/python/ast_helpers.py
@@ -42,9 +42,7 @@ def collect_receiver_names(
     return names
 
 
-def _matches_module_ctor(
-    func: ast.expr, module: str, constructors: frozenset[str]
-) -> bool:
+def _matches_module_ctor(func: ast.expr, module: str, constructors: frozenset[str]) -> bool:
     return (
         isinstance(func, ast.Attribute)
         and func.attr in constructors

--- a/src/gaudi/packs/python/ast_helpers.py
+++ b/src/gaudi/packs/python/ast_helpers.py
@@ -1,0 +1,53 @@
+# ABOUTME: Shared AST helpers for Python pack rules.
+# ABOUTME: Generalizes patterns like receiver-variable tracking across rules.
+from __future__ import annotations
+
+import ast
+from collections.abc import Sequence
+
+
+def collect_receiver_names(
+    tree: ast.Module,
+    module: str,
+    constructors: Sequence[str],
+) -> set[str]:
+    """Collect variable names bound to ``module.<constructor>(...)`` calls.
+
+    Walks both ``x = module.ctor(...)`` assignments and
+    ``with module.ctor(...) as x:`` context managers, returning the set of
+    variable names that hold the resulting receiver. Only direct attribute
+    access on a bare ``ast.Name`` matching ``module`` is matched; aliased
+    imports and indirect assignments are intentionally out of scope.
+    """
+    ctor_set = frozenset(constructors)
+    names: set[str] = set()
+
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Assign):
+            call = node.value
+            if isinstance(call, ast.Call) and _matches_module_ctor(call.func, module, ctor_set):
+                for target in node.targets:
+                    if isinstance(target, ast.Name):
+                        names.add(target.id)
+        elif isinstance(node, ast.With):
+            for item in node.items:
+                ctx = item.context_expr
+                if (
+                    isinstance(ctx, ast.Call)
+                    and _matches_module_ctor(ctx.func, module, ctor_set)
+                    and isinstance(item.optional_vars, ast.Name)
+                ):
+                    names.add(item.optional_vars.id)
+
+    return names
+
+
+def _matches_module_ctor(
+    func: ast.expr, module: str, constructors: frozenset[str]
+) -> bool:
+    return (
+        isinstance(func, ast.Attribute)
+        and func.attr in constructors
+        and isinstance(func.value, ast.Name)
+        and func.value.id == module
+    )

--- a/src/gaudi/packs/python/rules/boto3.py
+++ b/src/gaudi/packs/python/rules/boto3.py
@@ -5,9 +5,11 @@ from __future__ import annotations
 import ast
 
 from gaudi.core import Category, Finding, Rule, Severity
+from gaudi.packs.python.ast_helpers import collect_receiver_names
 from gaudi.packs.python.context import PythonContext
 
 _BOTO3_CONSTRUCTORS = frozenset({"client", "resource", "Session"})
+_BOTO3_CLIENT_CONSTRUCTORS = ("client", "resource")
 
 _PAGINATED_PREFIXES = ("list_", "describe_", "get_log_events", "scan")
 
@@ -25,20 +27,7 @@ def _is_boto3_call(node: ast.Call) -> bool:
 
 def _find_boto3_client_names(tree: ast.Module) -> set[str]:
     """Find variable names assigned from boto3.client() or boto3.resource()."""
-    names: set[str] = set()
-    for node in ast.walk(tree):
-        if not isinstance(node, ast.Assign):
-            continue
-        if not isinstance(node.value, ast.Call):
-            continue
-        if not _is_boto3_call(node.value):
-            continue
-        func = node.value.func
-        if isinstance(func, ast.Attribute) and func.attr in ("client", "resource"):
-            for target in node.targets:
-                if isinstance(target, ast.Name):
-                    names.add(target.id)
-    return names
+    return collect_receiver_names(tree, "boto3", _BOTO3_CLIENT_CONSTRUCTORS)
 
 
 def _is_inside_try(node: ast.AST, parent_map: dict[ast.AST, ast.AST]) -> bool:

--- a/src/gaudi/packs/python/rules/py314.py
+++ b/src/gaudi/packs/python/rules/py314.py
@@ -12,7 +12,10 @@ from __future__ import annotations
 import ast
 
 from gaudi.core import Rule, Finding, Severity, Category
+from gaudi.packs.python.ast_helpers import collect_receiver_names
 from gaudi.packs.python.context import PythonContext
+
+_TARFILE_CONSTRUCTORS = ("open", "TarFile")
 
 
 # ---------------------------------------------------------------------------
@@ -475,35 +478,7 @@ class TarfileNoFilter(Rule):
     @staticmethod
     def _find_tarfile_names(tree: ast.Module) -> set[str]:
         """Collect variable names assigned from tarfile.open() or TarFile()."""
-        names: set[str] = set()
-        for node in ast.walk(tree):
-            # Regular assignment: tf = tarfile.open(...)
-            if isinstance(node, ast.Assign):
-                val = node.value
-                if not isinstance(val, ast.Call):
-                    continue
-                func = val.func
-                if isinstance(func, ast.Attribute) and isinstance(func.value, ast.Name):
-                    if func.value.id == "tarfile" and func.attr in ("open", "TarFile"):
-                        for t in node.targets:
-                            if isinstance(t, ast.Name):
-                                names.add(t.id)
-            # Context manager: with tarfile.open(...) as tf:
-            if isinstance(node, ast.With):
-                for item in node.items:
-                    ctx = item.context_expr
-                    if not isinstance(ctx, ast.Call):
-                        continue
-                    func = ctx.func
-                    if (
-                        isinstance(func, ast.Attribute)
-                        and isinstance(func.value, ast.Name)
-                        and func.value.id == "tarfile"
-                        and func.attr in ("open", "TarFile")
-                        and isinstance(item.optional_vars, ast.Name)
-                    ):
-                        names.add(item.optional_vars.id)
-        return names
+        return collect_receiver_names(tree, "tarfile", _TARFILE_CONSTRUCTORS)
 
     @staticmethod
     def _is_tarfile_extract(node: ast.Call, tarfile_names: set[str]) -> bool:


### PR DESCRIPTION
## Summary
- Extract `collect_receiver_names(tree, module, constructors)` to `src/gaudi/packs/python/ast_helpers.py`.
- Port `boto3.py` (`AWS-ERR-001`, `AWS-SCALE-001`) and `PY314-006` to the helper instead of inline implementations.
- Behavior unchanged for tarfile (Assign + With both handled). Boto3 gains With-context tracking — additive, no test churn.

Closes #199.

## Test plan
- [x] `pytest tests/ -q` — 1048 passed
- [x] `gaudi check .` — no new findings on touched files