### PR TITLE
review(gaudi#202): self-dogfood + overlap-with-tool convention for new rules

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -117,6 +117,22 @@ a numeric threshold.
 CI runs `gaudi-fixture-coverage --strict`. Any rule without a complete
 fixture directory fails CI — there is no warn-mode escape hatch.
 
+**Before opening the PR, two more checks the fixture suite does not cover:**
+
+1. **Self-dogfood.** Run `gaudi check .` against Gaudi's own tree. The new
+   rule must either come up clean or have every hit acknowledged (a
+   `# noqa: <CODE>` on the line, with the reason obvious from context). A
+   rule that fires noisily on its own author's codebase is either wrong or
+   needs a narrower heuristic — fix it before merge, not after.
+2. **Overlap-with-existing-tool.** If the rule covers territory another
+   widely-used static analyzer already flags (e.g. `bandit`, `ruff`,
+   `mypy`), state in the PR body why Gaudi's version adds detection power:
+   narrower heuristic, principle citation, one-sentence fix, same-pass
+   reporting, or a combination. This is question #3 of the Rule Acceptance
+   Test (Subsumption, [docs/principles.md](docs/principles.md#L341))
+   applied externally rather than internally. If the only answer is "we
+   already have this pack" — drop the rule.
+
 ## Shared AST helpers (rule authors)
 
 Before writing AST-walking boilerplate inside a rule file, check


### PR DESCRIPTION
Auto-generated by the review-dispatch skill (Fiscus #28, Knob-1 re-run per Fiscus#49).

## Decision
patched

## Source
- Reviewed PR: gaudi#202
- Trajectory note: (absent — weaker-signal mode)

## Files touched
- CLAUDE.md

## Rationale
PR #202 was the first in a four-PR OWASP slice (#202/#203/#204/#205). Two
conventions were established silently in #202's PR body and reused without
articulation by every follow-up: (a) every PR ran `gaudi check .` against
Gaudi itself and either came up clean or carried `# noqa: <CODE>` for
acknowledged sites (see #205 `cli.py` SEC-012 suppressions), and (b) every
PR contained an "Overlap with bandit" section naming Gaudi's added detection
power. Neither is captured in CLAUDE.md or `docs/principles.md`. The
"Shared AST helpers" and "Fixture-First TDD" sections cover adjacent
discipline but not these two. Codifying them under the existing
Fixture-First section makes the convention load-bearing for the next rule
pack (the issue spec for #142 is open-ended; more SEC rules are planned).

## Confidence
medium — the pattern is durable across four PRs but the convention is
"editorial discipline" not "bug class." If Nathan judges this too soft for
CLAUDE.md, the right home would be a short addendum in `docs/principles.md`
under the Rule Acceptance Test. Either location keeps the convention from
relying on PR-body archaeology.

## Adjacent issues filed
- (none)

---

🤖 Auto-generated by Fiscus review-dispatch (#28). Human reviews before merge.