### PR TITLE
ci: install dependencies with uv instead of pip

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,8 +20,19 @@ jobs:
         with:
           python-version: "3.12"
 
+      - name: Set up uv
+        # uv does the install; enable-cache persists its wheel cache between
+        # runs, keyed on pyproject.toml. --system below targets the
+        # setup-python interpreter on PATH so ruff / pytest / bandit / the
+        # gaudi console scripts keep resolving as bare commands.
+        # (Transfer of grantspider PR #1276.)
+        uses: astral-sh/setup-uv@v8.2.0
+        with:
+          enable-cache: true
+          cache-dependency-glob: pyproject.toml
+
       - name: Install dependencies
-        run: pip install -e ".[dev]"
+        run: uv pip install --system -e ".[dev]"
 
       - name: Check formatting
         run: ruff format --check .
@@ -39,8 +50,19 @@ jobs:
         with:
           python-version: "3.12"
 
+      - name: Set up uv
+        # uv does the install; enable-cache persists its wheel cache between
+        # runs, keyed on pyproject.toml. --system below targets the
+        # setup-python interpreter on PATH so ruff / pytest / bandit / the
+        # gaudi console scripts keep resolving as bare commands.
+        # (Transfer of grantspider PR #1276.)
+        uses: astral-sh/setup-uv@v8.2.0
+        with:
+          enable-cache: true
+          cache-dependency-glob: pyproject.toml
+
       - name: Install dependencies
-        run: pip install -e ".[dev]"
+        run: uv pip install --system -e ".[dev]"
 
       - name: Security scan (bandit)
         run: bandit -r src/ -c pyproject.toml
@@ -63,8 +85,19 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
+      - name: Set up uv
+        # uv does the install; enable-cache persists its wheel cache between
+        # runs, keyed on pyproject.toml. --system below targets the
+        # setup-python interpreter on PATH so ruff / pytest / bandit / the
+        # gaudi console scripts keep resolving as bare commands.
+        # (Transfer of grantspider PR #1276.)
+        uses: astral-sh/setup-uv@v8.2.0
+        with:
+          enable-cache: true
+          cache-dependency-glob: pyproject.toml
+
       - name: Install dependencies
-        run: pip install -e ".[dev]"
+        run: uv pip install --system -e ".[dev]"
 
       - name: Test with coverage
         run: pytest --tb=short --cov=gaudi --cov-report=term-missing --cov-fail-under=60

--- a/documentation/trajectories/2026-06-11-PR233.md
+++ b/documentation/trajectories/2026-06-11-PR233.md
@@ -1,0 +1,37 @@
+---
+date: 2026-06-11
+repo: gaudi
+pr: gaudi#233
+branch: session/ci-uv
+issues: []
+session_kind: in-session-pickup
+duration: ~10min
+---
+
+# Trajectory — CI installs via uv (transfer of grantspider PR #1276)
+
+## Context
+
+Nathan sped up grantspider's per-PR CI by swapping pip for uv in runner install steps (GS PR #1276). OverSteward transfer sweep 2026-06-11 propagates the pattern estate-wide. gaudi's CI pays the install 7× per PR (lint + security + a 5-version test matrix) — the biggest multiplier in the estate.
+
+## Trajectory
+
+Mechanical transfer: all three install sites gain `setup-uv@v8.2.0` (`enable-cache` keyed on `pyproject.toml`), installs swapped to `uv pip install --system -e ".[dev]"`. The matrix jobs share the wheel cache; uv keys built wheels per interpreter version internally. `publish.yml` untouched (release-time, one package).
+
+## What worked
+
+- The GS pattern needed zero adaptation; the gaudi console scripts (`gaudi`, `gaudi-fixture-coverage`) resolve as bare commands under `--system` exactly like ruff/pytest.
+
+## What didn't
+
+- Nothing notable.
+
+## What was learned
+
+- Matrix workflows multiply the install win: 5-version matrices make the
+  uv swap worth proportionally more than single-job pipelines.
+
+## Open threads
+
+- This PR's own CI run (7 jobs) is the end-to-end proof.
+- First trajectory note in gaudi — `documentation/trajectories/` created by this PR per estate PR-workflow doctrine.


### PR DESCRIPTION
## Summary

Transfer of grantspider PR #1276 (estate CI-speed sweep, 2026-06-11):

- All three install sites (`lint`, `security`, and the 5-version `test` matrix — 7 jobs per PR, the estate's biggest install multiplier): `astral-sh/setup-uv@v8.2.0` with `enable-cache: true` keyed on `pyproject.toml`; installs swapped to `uv pip install --system -e ".[dev]"`.
- `--system` targets the setup-python interpreter on PATH, so `ruff` / `pytest` / `bandit` / `pip-audit` and the `gaudi` console scripts keep resolving as bare commands.
- `publish.yml` untouched (release-time, one package).

This PR's own CI run executes the changed workflow across all 7 jobs — green checks are the end-to-end proof.

Trajectory note: `documentation/trajectories/2026-06-11-PR233.md` (first in this repo; directory created per estate PR-workflow doctrine).

🤖 Generated with [Claude Code](https://claude.com/claude-code)