### PR TITLE
chore(governance): worktree-discipline kit + [oversteward:managed] markers

### DIFF
--- a/.claude/hooks/guard_main_worktree.py
+++ b/.claude/hooks/guard_main_worktree.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+# ABOUTME: PreToolUse(Bash) guard — refuse branch checkout/switch in the primary worktree.
+# ABOUTME: Canonical in OverSteward shared/scripts/dev/; deployed to <repo>/.claude/hooks/.
+"""Block branch-mutating git in the primary worktree.
+
+Parallel Claude sessions that share one working tree collide: a
+``git checkout -b`` / ``git checkout <branch>`` in the shared main checkout
+yanks another session's branch out from under it and strands its uncommitted
+work. This hook refuses those commands when the session is anchored in the
+*primary* worktree and points at ``scripts/dev/new-session.sh`` instead. Linked
+worktrees (``.git/worktrees/<name>``) are exempt — that is where work belongs.
+
+Allowed even in the main tree: file restores (``git checkout -- <path>`` /
+``git restore``), ``git worktree add``, and anything prefixed with
+``CLAUDE_ALLOW_MAIN_GIT=1`` — the conscious-override escape hatch (promotes,
+one-off rebases). ``GS_ALLOW_MAIN_GIT=1`` is also honored as a back-compat
+alias for grantspider, which shipped this guard first.
+
+Decision logic is split into pure functions so it is unit-tested without git.
+"""
+
+import json
+import os
+import re
+import subprocess  # list-form argv, no shell; cwd is the only input
+import sys
+
+# Env vars that wave the guard through. CLAUDE_ALLOW_MAIN_GIT is the standard;
+# GS_ALLOW_MAIN_GIT is grantspider's original name, kept as an alias.
+_OVERRIDE_VARS = ("CLAUDE_ALLOW_MAIN_GIT", "GS_ALLOW_MAIN_GIT")
+
+# ``git`` only at a command position — start of line, or after a shell
+# separator (``; & | && ||``). This skips string mentions (echo / printf /
+# test data) that merely contain "git checkout", which would otherwise
+# false-positive constantly. It can miss git buried behind an unusual prefix
+# (e.g. ``VAR=x git checkout``), but the launcher + discipline are the primary
+# mechanism; this hook is the backstop.
+_AT_CMD = r"(?:^|[\n;&|])\s*"
+_BRANCH_OP = re.compile(_AT_CMD + r"git\s+(?:checkout|switch)\b")
+_FILE_RESTORE = re.compile(_AT_CMD + r"git\s+checkout\b[^\n|;&]*\s--(\s|$)")
+_RESTORE = re.compile(_AT_CMD + r"git\s+restore\b")
+
+_MESSAGE = (
+    "BLOCKED — branch checkout/switch in the shared main worktree.\n\n"
+    "Parallel agent sessions share this working tree; switching or creating a\n"
+    "branch here strands another session's uncommitted work.\n\n"
+    "Start an isolated session worktree instead:\n"
+    "    scripts/dev/new-session.sh <name>\n\n"
+    "Deliberate one-off (promote, rebase, etc.): prefix the command with\n"
+    "    CLAUDE_ALLOW_MAIN_GIT=1 <your git command>\n"
+)
+
+
+def is_branch_switch(command: str) -> bool:
+    """True if ``command`` switches or creates a branch (not a file restore)."""
+    if not _BRANCH_OP.search(command):
+        return False
+    return not (_FILE_RESTORE.search(command) or _RESTORE.search(command))
+
+
+def in_main_worktree(git_dir: str) -> bool:
+    """True if ``git_dir`` belongs to the primary worktree.
+
+    Linked worktrees report a git-dir nested under ``.../worktrees/<name>``;
+    the primary worktree's is the plain repository ``.git``.
+    """
+    return bool(git_dir) and "worktrees/" not in git_dir.replace(os.sep, "/")
+
+
+def has_override(command: str) -> bool:
+    """True if an override env var is set in the environment or inline."""
+    return any(os.environ.get(var) == "1" or f"{var}=1" in command for var in _OVERRIDE_VARS)
+
+
+def _git_dir(cwd: str) -> str:
+    try:
+        result = subprocess.run(  # list-form argv, no shell
+            ["git", "-C", cwd, "rev-parse", "--git-dir"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+            check=False,
+        )
+    except Exception:  # any failure → do not block
+        return ""
+    return result.stdout.strip()
+
+
+def main() -> int:
+    try:
+        event = json.load(sys.stdin)
+    except Exception:  # unparseable input → don't block
+        return 0
+    if event.get("tool_name") != "Bash":
+        return 0
+    command = (event.get("tool_input") or {}).get("command", "") or ""
+    if not is_branch_switch(command):
+        return 0
+    if has_override(command):
+        return 0
+    cwd = event.get("cwd") or os.getcwd()
+    if not in_main_worktree(_git_dir(cwd)):
+        return 0
+    sys.stderr.write(_MESSAGE)
+    return 2
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,12 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          { "type": "command", "command": "python3 \"$CLAUDE_PROJECT_DIR/.claude/hooks/guard_main_worktree.py\"" }
+        ]
+      }
+    ]
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -18,5 +18,10 @@ env/
 htmlcov/
 .mypy_cache/
 .tox/
-.claude/
+# Claude Code — track team-shared config (settings.json, hooks), ignore
+# operator-local artifacts only. (GS .gitignore pattern.)
+.claude/projects/
+.claude/scheduled_tasks.lock
+.claude/worktrees/
+.claude/settings.local.json
 CLAUDE.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,8 @@
+<!-- [oversteward:managed | synced: 2026-06-11] -->
 @~/.claude/shared/souls/chestertron.md
 
 At session start, check `~/.claude/shared/inbox.md` for updates. If entries exist, review them and apply any relevant changes, then clear the file.
+<!-- [oversteward:managed:end] -->
 ---
 
 # Working Guidelines

--- a/documentation/trajectories/2026-06-11-PR234.md
+++ b/documentation/trajectories/2026-06-11-PR234.md
@@ -1,0 +1,27 @@
+---
+date: 2026-06-11
+repo: gaudi
+pr: gaudi#234
+branch: session/governance-sync
+issues: []
+session_kind: in-session-pickup
+duration: ~10min
+---
+
+# Trajectory — governance sync: worktree-discipline kit + managed block
+
+## Context
+
+OverSteward's first `/sync-status` run (its PR #62; report `reports/2026-06-11.md`) found gaudi missing the estate's session-per-worktree kit (guard hook + `new-session.sh`, canonical in OverSteward `shared/scripts/dev/`, deployed byte-identical) and the `[oversteward:managed]` CLAUDE.md markers. This PR delivers both, plus the tracked `.claude/settings.json` that registers the hook (Fiscus pattern — gaudi had no settings.json at all, so no merge-conflict risk).
+
+## Trajectory
+
+Byte-copies from canonical (diff-verified identical), settings.json with exactly the Fiscus hook block, managed-block markers wrapped around the existing head lines per the wphelper pattern.
+
+## What worked / What was learned
+
+- Mechanical; the only judgment call was settings: tracked file is safe here precisely because none existed (contrast AG, where Nathan's untracked local settings.json blocks this — flagged in the OverSteward report).
+
+## Open threads
+
+- None for gaudi.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -93,5 +93,7 @@ testpaths = ["tests"]
 norecursedirs = ["fixtures"]
 
 [tool.bandit]
-exclude_dirs = ["tests"]
+# .claude/hooks holds the OverSteward-canonical worktree guard (dev tooling,
+# byte-identical across the estate — not shipped package code).
+exclude_dirs = ["tests", ".claude"]
 skips = ["B101", "B110", "B112"]

--- a/scripts/dev/new-session.sh
+++ b/scripts/dev/new-session.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+# ABOUTME: Create an isolated session worktree so parallel agents never share the main tree.
+# ABOUTME: Canonical (OverSteward shared/scripts/dev/); self-adapting — deployed byte-identical to every repo.
+set -euo pipefail
+
+name="${1:-}"
+if [ -z "$name" ]; then
+    echo "usage: scripts/dev/new-session.sh <name> [base-ref]" >&2
+    echo "  creates .claude/worktrees/<name> on branch session/<name>" >&2
+    echo "  base-ref defaults to origin/staging if it exists, else the default branch" >&2
+    exit 2
+fi
+
+# Must run from the PRIMARY worktree (linked worktrees nest under .git/worktrees/).
+git_dir="$(git rev-parse --git-dir 2>/dev/null || true)"
+case "$git_dir" in
+    "") echo "Not inside a git repository." >&2; exit 1 ;;
+    *worktrees/*) echo "Run this from the main worktree, not a linked one." >&2; exit 1 ;;
+esac
+
+root="$(git rev-parse --show-toplevel)"
+git -C "$root" fetch origin --quiet
+
+# Base ref: explicit arg wins; else origin/staging if it exists (GS/AG model);
+# else the remote's default branch (main/master for trunk-only repos).
+base="${2:-}"
+if [ -z "$base" ]; then
+    if git -C "$root" rev-parse --verify --quiet origin/staging >/dev/null; then
+        base="origin/staging"
+    else
+        default="$(git -C "$root" symbolic-ref --quiet refs/remotes/origin/HEAD 2>/dev/null | sed 's@^refs/remotes/@@')"
+        base="${default:-origin/main}"
+    fi
+fi
+
+wt="$root/.claude/worktrees/$name"
+branch="session/$name"
+if [ -e "$wt" ]; then
+    echo "Worktree already exists: $wt" >&2
+    exit 1
+fi
+
+# git worktree add is not a branch checkout/switch, so the guard hook allows it;
+# the override prefix is belt-and-braces.
+CLAUDE_ALLOW_MAIN_GIT=1 git -C "$root" worktree add "$wt" -b "$branch" "$base"
+
+# Share the single venv (deps live there). PYTHONPATH makes the project import
+# resolve to THIS worktree's source, overriding the editable install's .pth that
+# points at the main tree — verified: editable installs are path-based here
+# (pip and uv alike), so PYTHONPATH wins. src/ layout → src; flat/Django → root.
+if [ -d "$root/.venv" ]; then
+    ln -sfn "$root/.venv" "$wt/.venv"
+fi
+if [ -d "$wt/src" ]; then
+    pp='$PWD/src'
+else
+    pp='$PWD'
+fi
+printf 'export PYTHONPATH="%s"\n' "$pp" >"$wt/.envrc"
+
+cat <<EOF
+
+  Worktree:  $wt
+  Branch:    $branch  (from $base)
+
+  Start Claude Code IN that directory, with the shared venv + isolated source:
+
+      cd "$wt"
+      export PYTHONPATH="$(eval echo "$pp")"
+      # launch Claude Code here
+
+  (direnv users: a .envrc was written — run 'direnv allow'.)
+  (uv repos: run tools as .venv/bin/<tool> in the worktree — not 'uv run',
+   which may re-sync the shared venv.)
+
+  When done: open a PR from '$branch', then  git worktree remove "$wt"
+EOF


### PR DESCRIPTION
OverSteward sync sweep 2026-06-11 (see OverSteward `reports/2026-06-11.md`):

- `.claude/hooks/guard_main_worktree.py` + `scripts/dev/new-session.sh` — byte-copies of the canonical kit (`shared/scripts/dev/`), diff-verified identical.
- `.claude/settings.json` (tracked) — registers the PreToolUse hook, Fiscus pattern. Safe to track: gaudi had no settings.json, so no local-file collision.
- `.gitignore` — `.claude/` blanket narrowed to operator-local artifacts (GS pattern) so shared config can be tracked.
- `pyproject.toml` — bandit `exclude_dirs` gains `.claude` (the canonical hook is dev tooling, byte-identical across the estate; per-repo nosec edits would break the byte-copy invariant).
- CLAUDE.md head wrapped in `[oversteward:managed | synced: 2026-06-11]` markers (no content changes).

Config-and-docs only; no package code touched.

Trajectory note: `documentation/trajectories/2026-06-11-PR234.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)