### PR TITLE
fix(ci): upgrade runner pip past PYSEC-2026-196 before pip-audit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,6 +67,12 @@ jobs:
       - name: Security scan (bandit)
         run: bandit -r src/ -c pyproject.toml
 
+      - name: Upgrade runner pip past PYSEC-2026-196
+        # The ubuntu runner image ships pip 26.1.1, which pip-audit flags
+        # (fixed in 26.1.2). Nothing in the job uses pip, but pip-audit
+        # audits the whole environment.
+        run: uv pip install --system --upgrade "pip>=26.1.2"
+
       - name: Dependency audit
         run: pip-audit --skip-editable
 

--- a/documentation/trajectories/2026-06-11-PR235.md
+++ b/documentation/trajectories/2026-06-11-PR235.md
@@ -1,0 +1,27 @@
+---
+date: 2026-06-11
+repo: gaudi
+pr: gaudi#235
+branch: session/ci-pip-heal
+issues: []
+session_kind: in-session-pickup
+duration: ~5min
+---
+
+# Trajectory — CI heal: runner pip vs PYSEC-2026-196
+
+## Context
+
+PYSEC-2026-196 (published 2026-06-11) flags pip 26.1.1, which the ubuntu runner image ships. `pip-audit` audits the whole environment, so every gaudi PR's security job fails — first observed on #234, whose content (governance files) was unrelated.
+
+## Trajectory
+
+One step before the audit: `uv pip install --system --upgrade "pip>=26.1.2"`. Considered pinning pip-audit's view instead (`--ignore-vuln`); upgrading is the honest fix.
+
+## What was learned
+
+- pip-audit failures on PRs deserve a published-date check before blaming the diff: advisory-feed updates break green branches with zero code change. (Same-day evidence: #233 passed this job four hours earlier.)
+
+## Open threads
+
+- None. #234 re-runs green once this merges (pull_request merge-ref picks the fix up from main).


### PR DESCRIPTION
PYSEC-2026-196 (published today) flags the ubuntu runner image's pip 26.1.1; `pip-audit` audits the whole environment, so every PR's security job fails until pip ≥ 26.1.2. One upgrade step before the audit — first observed breaking #234 (governance PR, unrelated content).

This PR's own security job is the proof.

🤖 Generated with [Claude Code](https://claude.com/claude-code)