### PR TITLE
fix(#239): rule-precision pass on the false-positive cluster (8 rules)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,36 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.2.2] — 2026-06-19
+
+### Fixed
+Rule-precision pass on the false-positive cluster (#239) — each rule keeps
+catching genuine violations but stops firing on a by-design pattern, so repos
+can drop the corresponding `# noqa` accretions:
+
+- **DOM-001** — exempt intentional telemetry/event/value tables (names ending
+  in event, impression, log, audit, metric, snapshot, feedback, ...). Their
+  behavior belongs to the aggregator that reads them.
+- **ARCH-003** — require the true join-table shape (only ForeignKeys, no other
+  fields). A first-class entity with two optional FKs plus real fields no
+  longer fires.
+- **IDX-001** — don't fire on a lookup column already served by a covering
+  composite index (leading column of `Meta.indexes` / `index_together` /
+  `unique_together`).
+- **ARCH-011** — exempt connector parse-layer dispatch (branching on an XML
+  element tag, an XPath hit, or a parser method result is format translation,
+  not a business decision).
+- **SMELL-025** — exempt a constant whose version-suffix name pins its string
+  value (`SCHEMA_V1 = "v1"`): a persisted/DB-pinned literal, not change history.
+- **SEC-003** — distinguish an env-var NAME constant (`API_KEY_ENV =
+  "MYAPP_API_KEY"`, or any UPPER_SNAKE env-var-name value) from a literal
+  secret.
+- **PYD-ARCH-001** — don't fire on `ClassVar`-annotated attributes; these are
+  class attributes, not per-instance defaults.
+- **STRUCT-010** — exempt executable entrypoints (files under scripts/bin/tools,
+  manage.py / conftest.py, or files with an `if __name__ == "__main__":` guard)
+  that bootstrap `sys.path` to locate siblings before install.
+
 ## [0.2.1] — 2026-06-19
 
 ### Fixed

--- a/docs/gaudi-rules.md
+++ b/docs/gaudi-rules.md
@@ -119,7 +119,7 @@
 - **API-003 LeakingInternalID** — Replace <int:pk> with <uuid:pk> or a slug. Sequential integer IDs leak row counts and enable BOLA-style enumeration attacks.
 - **API-004 NoErrorResponseSchema** — Add a responses={{404: {{'model': Error}}, ...}} kwarg so the OpenAPI document describes both the success and error shapes.
 - **ARCH-001 NoTenantIsolation** — Consider adding a tenant_id, organization_id, or account_id ForeignKey to models that store user data. Enforce filtering in all queries. Promote to warn with [gaudi.rules] "ARCH-001" = "warn" if multi-tenancy applies.
-- **ARCH-003 NullableForeignKeySprawl** — Review whether nullable ForeignKeys represent truly optional relationships or if the model is trying to handle multiple relationship types. Consider a join table or polymorphic pattern.
+- **ARCH-003 NullableForeignKeySprawl** — A model whose only fields are nullable ForeignKeys is a join table that can exist while recording no association. Make the ForeignKeys required, or model the optional relationships as a first-class entity with its own fields.
 - **ASYNC-004 NoGracefulShutdown** — Register a signal.signal(SIGTERM, ...) handler before asyncio.run() so the service can drain in-flight work on shutdown.
 - **CPLX-001 ShallowModule** — Deepen the module by combining trivial helpers or hiding them behind fewer, richer entry points. Ousterhout: 'modules should be deep' -- the cost of a public name is the documentation and cognitive load it imposes on every caller.
 - **CPLX-004 ConjoinedMethods** — Conjoined methods force callers to remember a specific call order. Combine '{setter}' and '{checker}' into one operation, use a context manager, or pass the state explicitly so the order is impossible to get wrong.

--- a/documentation/trajectories/2026-06-19-PR239.md
+++ b/documentation/trajectories/2026-06-19-PR239.md
@@ -1,0 +1,83 @@
+---
+date: 2026-06-19
+repo: gaudi
+pr: gaudi#239
+branch: session/gaudi239-precision
+issues:
+  - gaudi#239
+session_kind: in-session-pickup
+duration: ~2h
+---
+
+# Trajectory — rule-precision pass on the false-positive cluster (8 rules)
+
+## Context
+
+Eight rules each fired on a by-design pattern observed across the estate
+(evidence = repeated `# noqa` + PR rationales, esp. aigranthelper PR#832).
+Same class as the STAB-011 fix shipped in v0.2.1: the rule, not the consumers,
+needs to learn the legitimate pattern so repos can drop their noqa accretions.
+Scope was the whole cluster because it is one cohesive precision pass; each
+rule keeps catching genuine violations.
+
+## Trajectory
+
+Read all 8 rule implementations and the `ModelInfo`/`PythonContext`
+abstractions first, then fixed each in its pack file with a paired fixture
+(new pass for the by-design case + a fail proving genuine violations still
+fire). Order of difficulty:
+
+- **DOM-001 / SMELL-025 / SEC-003 / PYD-ARCH-001**: pure rule-side guards.
+  DOM-001 exempts telemetry/event/value tables by final-name-word; SMELL-025
+  exempts a version-suffixed constant whose string value pins that version
+  (a DB-pinned literal); SEC-003 distinguishes an env-var-NAME constant
+  (UPPER_SNAKE value or `_ENV`/`_VAR` holder suffix) from a literal secret;
+  PYD-ARCH-001 skips `ClassVar`-annotated attributes.
+- **ARCH-011 / STRUCT-010**: structural exemptions. ARCH-011 adds a
+  parse-dispatch guard (test sub-tree contains an XML/XPath parser call or a
+  parsed-element attribute like `.tag`/`.attrib`). STRUCT-010 exempts
+  executable entrypoints (scripts/bin/tools path, `manage.py`/`conftest.py`,
+  or an `if __name__ == "__main__":` guard).
+- **ARCH-003 / IDX-001**: needed parser/context extension. ARCH-003 now
+  requires the true join-table shape (every column is an FK); a model with
+  real fields + optional FKs is a first-class entity. The existing
+  `fail_nullable_fk_sprawl` fixture (which had a `name` field) was exactly the
+  by-design case — renamed it to a pass and added a pure-FK fail. IDX-001
+  gained covering-composite-index awareness: extended the parser to capture
+  `Meta.indexes` / `index_together` / `unique_together` column tuples into a
+  new `ModelInfo.composite_indexes`, and exempt a column that leads such an
+  index (B-tree prefix coverage). A trailing-column fail fixture guards the
+  boundary.
+
+## What worked
+
+- Reading `ModelInfo`/`parser.py` before touching ARCH-003 and IDX-001 — the
+  parser only stored `meta_options[name] = True`, so IDX-001's "covering
+  index" awareness was impossible without a parser extension. Catching that
+  at read-time avoided a dead-end rule-only patch.
+- The fixture-corpus convention (pass_/fail_ + expected.json, runner filters
+  to the rule under test) made each fix self-proving and cheap to add.
+
+## What didn't
+
+- The session worktree's venv resolves `gaudi` to the PRIMARY checkout's
+  `src/` (editable install + the `.envrc` PYTHONPATH only applies under
+  direnv, which isn't active in the tool shell). First test run exercised
+  stale code and all 9 new pass fixtures "failed". Fix: run pytest and the
+  `gaudi` console-script equivalents with `PYTHONPATH="$PWD/src"` and invoke
+  via `python -m gaudi.cli` / `python -m gaudi.tools.fixture_coverage`.
+
+## What was learned
+
+- In a gaudi session worktree, always run the suite as
+  `PYTHONPATH="$PWD/src" .venv/bin/python -m pytest` and the CLI gates as
+  `python -m gaudi.cli ...` — never the bare `gaudi`/`gaudi-fixture-coverage`
+  console scripts, which the editable install pins to the primary checkout.
+- Changing a rule's `recommendation_template` (done for ARCH-003) trips the
+  cheat-sheet drift guard; regenerate `docs/gaudi-rules.md`. Docstring and
+  `message_template` changes do not.
+
+## Open threads
+
+- Downstream: repos (esp. aigranthelper) can drop the corresponding noqas once
+  v0.2.2 lands. Release is cut separately by Nathan.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "gaudi-linter"
-version = "0.2.1"
+version = "0.2.2"
 description = "Not just structurally sound. Beautiful. An architecture linter for Python projects."
 readme = "README.md"
 license = "MIT"

--- a/src/gaudi/packs/python/context.py
+++ b/src/gaudi/packs/python/context.py
@@ -52,6 +52,11 @@ class ModelInfo:
     columns: list[ColumnInfo] = field(default_factory=list)
     has_meta: bool = False
     meta_options: dict = field(default_factory=dict)
+    # Composite indexes declared in Meta (Meta.indexes, index_together,
+    # unique_together). Each entry is the ordered tuple of column names the
+    # index covers. A query filtering on a leading column is served by the
+    # index, so these inform index-coverage rules.
+    composite_indexes: list[tuple[str, ...]] = field(default_factory=list)
     bases: list[str] = field(default_factory=list)
     framework: str = ""  # "django" or "sqlalchemy"
 
@@ -69,6 +74,17 @@ class ModelInfo:
     @property
     def nullable_foreign_keys(self) -> list[ColumnInfo]:
         return [c for c in self.foreign_keys if c.nullable]
+
+    @property
+    def composite_index_leading_columns(self) -> set[str]:
+        """Columns that lead a composite index.
+
+        A B-tree composite index on ``(a, b)`` serves queries that filter on
+        its leading column ``a`` (and prefixes thereof), so ``a`` is covered
+        without a standalone index. Trailing columns are not served on their
+        own and remain uncovered.
+        """
+        return {idx[0] for idx in self.composite_indexes if idx}
 
     @property
     def unindexed_columns(self) -> list[ColumnInfo]:

--- a/src/gaudi/packs/python/parser.py
+++ b/src/gaudi/packs/python/parser.py
@@ -317,10 +317,67 @@ def _extract_models(filepath: Path, root: Path, framework: str) -> list[ModelInf
                         for target in meta_item.targets:
                             if isinstance(target, ast.Name):
                                 model.meta_options[target.id] = True
+                                model.composite_indexes.extend(
+                                    _extract_composite_indexes(target.id, meta_item.value)
+                                )
 
         models.append(model)
 
     return models
+
+
+def _string_list(node: ast.expr) -> tuple[str, ...]:
+    """Extract a tuple of string constants from a list/tuple AST node."""
+    if not isinstance(node, (ast.List, ast.Tuple)):
+        return ()
+    names: list[str] = []
+    for elt in node.elts:
+        if isinstance(elt, ast.Constant) and isinstance(elt.value, str):
+            names.append(elt.value)
+    return tuple(names)
+
+
+def _index_fields_from_call(node: ast.Call) -> tuple[str, ...]:
+    """Extract the ``fields=[...]`` argument from a ``models.Index(...)`` call."""
+    for kw in node.keywords:
+        if kw.arg == "fields":
+            return _string_list(kw.value)
+    return ()
+
+
+def _extract_composite_indexes(meta_name: str, value: ast.expr) -> list[tuple[str, ...]]:
+    """Extract composite-index column tuples from a Meta assignment.
+
+    Recognizes ``indexes = [models.Index(fields=[...]), ...]`` and the legacy
+    ``index_together`` / ``unique_together`` (a list of field-name lists, or a
+    single flat field-name list).
+    """
+    if meta_name == "indexes":
+        if not isinstance(value, (ast.List, ast.Tuple)):
+            return []
+        result: list[tuple[str, ...]] = []
+        for elt in value.elts:
+            if isinstance(elt, ast.Call):
+                fields = _index_fields_from_call(elt)
+                if fields:
+                    result.append(fields)
+        return result
+
+    if meta_name in {"index_together", "unique_together"}:
+        if not isinstance(value, (ast.List, ast.Tuple)) or not value.elts:
+            return []
+        # Either a flat tuple of names, or a list of name-tuples.
+        if all(isinstance(elt, ast.Constant) for elt in value.elts):
+            flat = _string_list(value)
+            return [flat] if flat else []
+        result = []
+        for elt in value.elts:
+            fields = _string_list(elt)
+            if fields:
+                result.append(fields)
+        return result
+
+    return []
 
 
 def _parse_field_assignment(

--- a/src/gaudi/packs/python/rules/architecture.py
+++ b/src/gaudi/packs/python/rules/architecture.py
@@ -114,7 +114,19 @@ class GodModel(Rule):
 
 class NullableForeignKeySprawl(Rule):
     """
-    ARCH-003: Multiple nullable ForeignKeys suggest missing join table or polymorphism.
+    ARCH-003: A join-table-shaped model whose ForeignKeys are all nullable.
+
+    A model whose only fields are ForeignKeys is shaped like a join table —
+    it exists to associate other entities. When every one of those FKs is
+    nullable, the row can exist while pointing at nothing, which defeats the
+    join: the association it is meant to record may be absent. That is the
+    genuine smell (a malformed join table or a polymorphic relationship
+    smuggled in via optional FKs).
+
+    A model that ALSO carries real fields (a CharField, an amount, a
+    timestamp) is a first-class entity that happens to have optional
+    relationships — a by-design pattern, not a missing join table. Such
+    models are exempt.
 
     Principles: #1 (The structure tells the story).
     Source: FWDOCS Django relationship patterns — nullable FK sprawl signals a missing entity.
@@ -124,28 +136,34 @@ class NullableForeignKeySprawl(Rule):
     severity = Severity.INFO
     category = Category.ARCHITECTURE
     message_template = (
-        "Model '{model}' has {count} nullable ForeignKeys — "
-        "this may indicate an optional relationship better modeled as a join table"
+        "Join-table model '{model}' has {count} nullable ForeignKeys and no other fields — "
+        "a join row that points at nothing defeats the association"
     )
     recommendation_template = (
-        "Review whether nullable ForeignKeys represent truly optional relationships "
-        "or if the model is trying to handle multiple relationship types. "
-        "Consider a join table or polymorphic pattern."
+        "A model whose only fields are nullable ForeignKeys is a join table that "
+        "can exist while recording no association. Make the ForeignKeys required, "
+        "or model the optional relationships as a first-class entity with its own fields."
     )
 
     def check(self, context: PythonContext) -> list[Finding]:
         findings = []
         for model in context.models:
             nullable_fks = model.nullable_foreign_keys
-            if len(nullable_fks) >= 2:
-                findings.append(
-                    self.finding(
-                        file=model.source_file,
-                        line=model.source_line,
-                        model=model.name,
-                        count=len(nullable_fks),
-                    )
+            if len(nullable_fks) < 2:
+                continue
+            # Require the true join-table shape: every column is a ForeignKey.
+            # A model with non-FK fields is a first-class entity with optional
+            # relationships, not a missing join table.
+            if any(not col.is_foreign_key for col in model.columns):
+                continue
+            findings.append(
+                self.finding(
+                    file=model.source_file,
+                    line=model.source_line,
+                    model=model.name,
+                    count=len(nullable_fks),
                 )
+            )
         return findings
 
 
@@ -160,6 +178,10 @@ class MissingStringIndex(Rule):
 
     CharField fields with common lookup names (email, slug, username, code, etc.)
     should have db_index=True.
+
+    A field that leads a composite index (Meta.indexes, index_together, or
+    unique_together) is already served by that index for prefix lookups, so it
+    is exempt — adding a standalone index would duplicate coverage.
 
     Principles: #4 (Failure must be named).
     Source: FWDOCS Django query optimization — missing indexes fail under load.
@@ -188,11 +210,13 @@ class MissingStringIndex(Rule):
     def check(self, context: PythonContext) -> list[Finding]:
         findings = []
         for model in context.models:
+            covered = model.composite_index_leading_columns
             for col in model.columns:
                 if (
                     col.field_type in {"CharField", "SlugField", "EmailField"}
                     and not col.has_index
                     and not col.has_unique
+                    and col.name not in covered
                     and any(p in col.name.lower() for p in self.LOOKUP_PATTERNS)
                 ):
                     findings.append(

--- a/src/gaudi/packs/python/rules/dispensables.py
+++ b/src/gaudi/packs/python/rules/dispensables.py
@@ -389,6 +389,11 @@ class TemporalIdentifier(Rule):
     Python3) — these are part of the domain name, not change history.
     Allowlist: IP, IPv, OAuth, HTTP, TLS, H, Python, SSL, QUIC, USB,
     HDMI, MP, WebSocket, WS.
+
+    Also does NOT fire on a constant whose version-suffix marker pins its
+    string value (``SCHEMA_V1 = "v1"``): the literal is a persisted/DB-pinned
+    contract, and the ``_V1`` names the version the value encodes rather than
+    recording change history.
     """
 
     code = "SMELL-025"
@@ -415,16 +420,40 @@ class TemporalIdentifier(Rule):
                 names_and_lines = self._extract_names(node)
                 for name, line in names_and_lines:
                     marker = self._find_marker(name)
-                    if marker:
-                        findings.append(
-                            self.finding(
-                                file=f.relative_path,
-                                line=line,
-                                name=name,
-                                marker=marker,
-                            )
+                    if not marker:
+                        continue
+                    if self._is_pinned_version_literal(node, marker):
+                        continue
+                    findings.append(
+                        self.finding(
+                            file=f.relative_path,
+                            line=line,
+                            name=name,
+                            marker=marker,
                         )
+                    )
         return findings
+
+    @staticmethod
+    def _is_pinned_version_literal(node: ast.AST, marker: str) -> bool:
+        """Exempt a constant whose name's version marker pins its string value.
+
+        ``SCHEMA_V1 = "v1"`` / ``PROMPT_VERSION_V1 = "...v1"`` is a persisted,
+        DB-pinned literal: the ``_V1`` in the name is not change history, it
+        names the version the stored value encodes. The literal IS the
+        contract. Only a version-suffix marker (V\\d) whose digits appear in a
+        string-literal value qualifies — a temporal WORD ('old', 'legacy') or
+        a non-string value (``OLD_API_TIMEOUT = 30``) never does.
+        """
+        if not _VERSION_WORD.match(marker):
+            return False
+        if not isinstance(node, ast.Assign):
+            return False
+        value = node.value
+        if not (isinstance(value, ast.Constant) and isinstance(value.value, str)):
+            return False
+        version_digits = marker[1:]  # 'V1' -> '1'
+        return version_digits in value.value
 
     @staticmethod
     def _extract_names(node: ast.AST) -> list[tuple[str, int]]:

--- a/src/gaudi/packs/python/rules/domain.py
+++ b/src/gaudi/packs/python/rules/domain.py
@@ -6,6 +6,7 @@ ABOUTME: DOM-001 AnemicDomainModel, DOM-002 WrongLayerPlacement, DOM-003 ActiveR
 from __future__ import annotations
 
 import ast
+import re
 
 from gaudi.core import Category, Finding, Rule, Severity
 from gaudi.packs.python.context import PythonContext
@@ -27,6 +28,47 @@ _DOMAIN_BASE_HINTS = frozenset(
 )
 
 _MANAGER_BASE_HINTS = frozenset({"Manager", "BaseManager"})
+
+# Telemetry / event / value records are anemic by design: they are
+# immutable observations whose only job is to hold fields. Behavior would
+# belong to the aggregator that reads them, never to the record. Matched on
+# the final word of the class name, which is the by-design naming convention
+# for these tables (MatchImpression, FeedbackEvent, RequestLog, AuditEntry,
+# Feedback, ...).
+_TELEMETRY_NAME_WORDS = frozenset(
+    {
+        "event",
+        "impression",
+        "log",
+        "audit",
+        "metric",
+        "metrics",
+        "telemetry",
+        "snapshot",
+        "stat",
+        "stats",
+        "datapoint",
+        "measurement",
+        "sample",
+        "ping",
+        "heartbeat",
+        "feedback",
+        "view",
+        "click",
+    }
+)
+
+
+def _split_class_name(name: str) -> list[str]:
+    """Split a CamelCase class name into lowercase words."""
+    return [w.lower() for w in re.findall(r"[A-Z]+(?=[A-Z][a-z])|[A-Z]?[a-z]+|[A-Z]+", name)]
+
+
+def _is_telemetry_record(cls: ast.ClassDef) -> bool:
+    """An event/telemetry/value table whose final name word marks it anemic by design."""
+    words = _split_class_name(cls.name)
+    return bool(words) and words[-1] in _TELEMETRY_NAME_WORDS
+
 
 _NON_BEHAVIOR_DUNDERS = frozenset(
     {
@@ -140,6 +182,11 @@ class AnemicDomainModel(Rule):
     domain logic must live elsewhere. Plain ``@dataclass`` records are out
     of scope — see SMELL-022 for the general data-class smell.
 
+    Telemetry / event / value tables (names ending in event, impression, log,
+    audit, metric, snapshot, feedback, ...) are anemic by design: they are
+    immutable observations whose behavior belongs to the aggregator that reads
+    them. They are exempt.
+
     Principles: #1 (The structure tells the story), #9 (Dependencies flow
     toward stability — domain models should be the most-depended-upon code
     and therefore the place behavior lives).
@@ -175,6 +222,8 @@ class AnemicDomainModel(Rule):
                 if not isinstance(node, ast.ClassDef):
                     continue
                 if not _inherits_domain_base(node):
+                    continue
+                if _is_telemetry_record(node):
                     continue
                 field_count = max(
                     _count_django_fields(node),

--- a/src/gaudi/packs/python/rules/layers.py
+++ b/src/gaudi/packs/python/rules/layers.py
@@ -99,8 +99,57 @@ def _is_guard_pattern(node: ast.If) -> bool:
     return False
 
 
+# Parse-layer operations: when a connector branches on what it finds in a
+# parsed external payload (XML element shape, XPath hit, response format), the
+# branch is format translation, not a business decision. These are the method
+# and attribute names that mark a test as inspecting a parsed structure.
+_PARSE_METHOD_NAMES = frozenset(
+    {
+        "find",
+        "findall",
+        "findtext",
+        "iter",
+        "iterfind",
+        "xpath",
+        "getroot",
+        "match",
+        "search",
+        "fullmatch",
+        "select",
+        "select_one",
+        "css",
+    }
+)
+_PARSE_ATTR_NAMES = frozenset({"tag", "attrib", "text", "tail", "nodeName", "nodeType"})
+
+
+def _is_parse_dispatch(node: ast.If) -> bool:
+    """Return True if the if-test inspects a parsed payload (XML/XPath/format).
+
+    A connector that branches on the shape of an external response (an XML
+    element's tag, an XPath hit, a parser method result) is doing format
+    translation, not business decision-making. That is the connector's job.
+    Detected structurally: the test sub-tree contains a parse-layer method
+    call (.find/.findall/.xpath/.match/...) or a parsed-element attribute
+    access (.tag/.attrib/.text/...).
+    """
+    for child in ast.walk(node.test):
+        if isinstance(child, ast.Call) and isinstance(child.func, ast.Attribute):
+            if child.func.attr in _PARSE_METHOD_NAMES:
+                return True
+        if isinstance(child, ast.Attribute) and child.attr in _PARSE_ATTR_NAMES:
+            return True
+    return False
+
+
 class ConnectorLogicLeak(Rule):
     """Detect data-layer files containing business logic (connector logic leak).
+
+    Defensive guards (``is None``, ``not x``, ``isinstance``) and parse-layer
+    dispatch (branching on a parsed payload's shape — an XML element's tag, an
+    XPath hit, a parser method result) are format translation, not business
+    decisions, and do not fire. A genuine leak branches on a business value (a
+    mode parameter, a status string) to choose an outcome.
 
     Principles: #10 (Boundaries are real or fictional).
     Source: ARCH90 Day 3 — connectors translate, services decide.
@@ -131,6 +180,8 @@ class ConnectorLogicLeak(Rule):
                 for child in ast.walk(node):
                     if isinstance(child, ast.If) and child.orelse:
                         if _is_guard_pattern(child):
+                            continue
+                        if _is_parse_dispatch(child):
                             continue
                         findings.append(
                             self.finding(

--- a/src/gaudi/packs/python/rules/packaging.py
+++ b/src/gaudi/packs/python/rules/packaging.py
@@ -12,8 +12,50 @@ from gaudi.packs.python.context import PythonContext
 # ---------------------------------------------------------------
 
 
+_SCRIPT_DIR_KEYWORDS = ("scripts/", "/scripts/", "bin/", "/bin/", "tools/", "/tools/")
+# Standalone entrypoint files that are run directly, not imported as packages.
+_ENTRYPOINT_FILENAMES = frozenset({"manage.py", "conftest.py"})
+
+
+def _is_entrypoint_bootstrap(relative_path: str, tree: ast.Module) -> bool:
+    """True if the file is an executable entrypoint, where a sys.path bootstrap is expected.
+
+    Entrypoints are run directly (``python scripts/foo.py``) rather than
+    imported, so they can't rely on the package being installed and legitimately
+    prepend their own location to ``sys.path``. Detected by living under a
+    scripts/bin/tools directory, by a known entrypoint filename, or by carrying
+    an ``if __name__ == "__main__":`` guard.
+    """
+    norm = relative_path.replace("\\", "/").lower()
+    if any(kw in norm for kw in _SCRIPT_DIR_KEYWORDS):
+        return True
+    if norm.rsplit("/", 1)[-1] in _ENTRYPOINT_FILENAMES:
+        return True
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.If):
+            continue
+        test = node.test
+        if (
+            isinstance(test, ast.Compare)
+            and isinstance(test.left, ast.Name)
+            and test.left.id == "__name__"
+            and len(test.comparators) == 1
+            and isinstance(test.comparators[0], ast.Constant)
+            and test.comparators[0].value == "__main__"
+        ):
+            return True
+    return False
+
+
 class PathHacks(Rule):
     """Detect sys.path manipulation (path hacks).
+
+    Exempts executable entrypoints — files under scripts/bin/tools, known
+    entrypoint filenames (manage.py, conftest.py), or files with an
+    ``if __name__ == "__main__":`` guard. These are run directly rather than
+    imported, so a self-locating ``sys.path`` bootstrap is the by-design way to
+    find siblings before the package is installed. A library module that hacks
+    ``sys.path`` still fires.
 
     Principles: #1 (The structure tells the story), #9 (Dependencies flow toward stability).
     Source: ARCH90 Day 1 — proper packaging over sys.path hacks.
@@ -32,6 +74,8 @@ class PathHacks(Rule):
         for fi in context.files:
             tree = fi.ast_tree
             if tree is None:
+                continue
+            if _is_entrypoint_bootstrap(fi.relative_path, tree):
                 continue
             for node in ast.walk(tree):
                 if not isinstance(node, ast.Call):

--- a/src/gaudi/packs/python/rules/pydantic.py
+++ b/src/gaudi/packs/python/rules/pydantic.py
@@ -20,8 +20,29 @@ def _is_pydantic_class(cls: ast.ClassDef) -> bool:
     )
 
 
+def _is_classvar_annotation(annotation: ast.expr) -> bool:
+    """True if the annotation is ``ClassVar`` or ``ClassVar[...]``.
+
+    A ClassVar is a class attribute, not a Pydantic instance field, so a
+    mutable value there is shared by design — not the per-instance shared-state
+    trap the rule targets. Matched on ``ClassVar`` and ``typing.ClassVar``,
+    bare or subscripted.
+    """
+    if isinstance(annotation, ast.Subscript):
+        annotation = annotation.value
+    if isinstance(annotation, ast.Name):
+        return annotation.id == "ClassVar"
+    if isinstance(annotation, ast.Attribute):
+        return annotation.attr == "ClassVar"
+    return False
+
+
 class PydanticMutableDefault(Rule):
     """Detect mutable default values in Pydantic models.
+
+    ClassVar-annotated attributes are class attributes, not per-instance
+    fields, so a mutable value there is shared by design and is exempt. A bare
+    instance field with a mutable default (``items: list = []``) still fires.
 
     Principles: #5 (State must be visible).
     Source: FWDOCS Pydantic validators — mutable defaults are shared hidden state.
@@ -58,6 +79,11 @@ class PydanticMutableDefault(Rule):
                         isinstance(t, ast.Name) and t.id in _PYDANTIC_CLASS_VARS
                         for t in item.targets
                     ):
+                        continue
+                    # Skip ClassVar-annotated attributes — these are class
+                    # attributes, not per-instance fields, so a mutable value
+                    # is shared by design rather than a hidden-state trap.
+                    if isinstance(item, ast.AnnAssign) and _is_classvar_annotation(item.annotation):
                         continue
                     value = item.value if isinstance(item, ast.AnnAssign) else item.value
                     if value is None:

--- a/src/gaudi/packs/python/rules/security.py
+++ b/src/gaudi/packs/python/rules/security.py
@@ -137,6 +137,24 @@ def _looks_like_credential_name(name: str) -> bool:
 
 _TEST_PREFIXES = ("test-", "test_", "test.", "fake-", "fake_", "dummy-", "dummy_")
 
+# A constant that holds the NAME of an environment variable, not a secret.
+# Signalled either by the holder's name (an ``_env``-suffixed constant whose
+# value is a var name) or by the value's shape: an env-var name is a bare
+# UPPER_SNAKE_CASE identifier, whereas a real secret is mixed-case or carries
+# punctuation (an "sk-"/"ghp_" token, a "my-super-secret" phrase).
+_ENV_NAME_HOLDER_SUFFIXES = ("_env", "_var", "_env_var", "_name", "_key_name", "_envvar")
+_ENV_VAR_NAME_VALUE = re.compile(r"^[A-Z][A-Z0-9]*(?:_[A-Z0-9]+)+$")
+
+
+def _names_an_env_var(holder_name: str, value: str) -> bool:
+    """True if the assignment names an env var rather than carrying a secret."""
+    lowered = holder_name.lower()
+    if any(lowered.endswith(suffix) for suffix in _ENV_NAME_HOLDER_SUFFIXES):
+        return True
+    # An UPPER_SNAKE_CASE value is the conventional shape of an env-var name,
+    # not of an opaque secret token.
+    return bool(_ENV_VAR_NAME_VALUE.match(value))
+
 
 def _looks_like_placeholder_value(value: str) -> bool:
     if value.lower() in _PLACEHOLDER_VALUES:
@@ -151,6 +169,12 @@ def _looks_like_placeholder_value(value: str) -> bool:
 
 class HardcodedCredential(Rule):
     """SEC-003: Credential-named variable assigned to a string literal.
+
+    Distinguishes a literal secret from a constant naming an environment
+    variable. A constant whose value has UPPER_SNAKE env-var-name shape (or
+    whose holder carries an ``_env`` suffix) holds the var's NAME, not its
+    secret, and is exempt; a mixed-case or punctuated value (an "sk-"/"ghp_"
+    token) is a real secret and still fires.
 
     Principles: #5 (State must be visible), #4 (Failure must be named).
     Source: OWASP A07 — secrets are configuration, not code.
@@ -195,6 +219,8 @@ class HardcodedCredential(Rule):
                     elif isinstance(target, ast.Attribute):
                         name = target.attr
                     if name is None:
+                        continue
+                    if _names_an_env_var(name, value.value):
                         continue
                     if _looks_like_credential_name(name):
                         findings.append(

--- a/tests/fixtures/python/ARCH-003/expected.json
+++ b/tests/fixtures/python/ARCH-003/expected.json
@@ -1,14 +1,17 @@
 {
   "rule_id": "ARCH-003",
-  "description": "NullableForeignKeySprawl -- model with multiple nullable ForeignKeys",
+  "description": "NullableForeignKeySprawl -- a join-table-shaped model whose FKs are all nullable",
   "fixtures": {
-    "fail_nullable_fk_sprawl.py": {
+    "fail_join_table_nullable_fks.py": {
       "expected_findings": [
         {
           "severity": "info",
-          "message_contains": "Activity"
+          "message_contains": "Enrollment"
         }
       ]
+    },
+    "pass_entity_with_optional_relations.py": {
+      "expected_findings": []
     },
     "pass_required_fks.py": {
       "expected_findings": []

--- a/tests/fixtures/python/ARCH-003/fail_join_table_nullable_fks.py
+++ b/tests/fixtures/python/ARCH-003/fail_join_table_nullable_fks.py
@@ -1,0 +1,13 @@
+"""Fixture for ARCH-003: a join-table-shaped model with only nullable FKs.
+
+The model's only fields are ForeignKeys, so it is shaped like a join table —
+yet both are nullable, so a row can exist while recording no association. That
+is the genuine smell ARCH-003 names.
+"""
+
+from django.db import models
+
+
+class Enrollment(models.Model):
+    student = models.ForeignKey("Student", null=True, on_delete=models.SET_NULL)
+    course = models.ForeignKey("Course", null=True, on_delete=models.SET_NULL)

--- a/tests/fixtures/python/ARCH-003/fail_nullable_fk_sprawl.py
+++ b/tests/fixtures/python/ARCH-003/fail_nullable_fk_sprawl.py
@@ -1,9 +1,0 @@
-"""Fixture for ARCH-003: model with two nullable ForeignKeys."""
-
-from django.db import models
-
-
-class Activity(models.Model):
-    name = models.CharField(max_length=200)
-    user = models.ForeignKey("User", null=True, on_delete=models.SET_NULL)
-    order = models.ForeignKey("Order", null=True, on_delete=models.SET_NULL)

--- a/tests/fixtures/python/ARCH-003/pass_entity_with_optional_relations.py
+++ b/tests/fixtures/python/ARCH-003/pass_entity_with_optional_relations.py
@@ -1,0 +1,14 @@
+"""Fixture for ARCH-003: an entity with real fields and two optional FKs.
+
+A first-class entity (it carries its own ``name`` field) that happens to have
+two optional relationships is NOT a missing join table — it is a by-design
+model. ARCH-003 must not fire.
+"""
+
+from django.db import models
+
+
+class Activity(models.Model):
+    name = models.CharField(max_length=200)
+    user = models.ForeignKey("User", null=True, on_delete=models.SET_NULL)
+    order = models.ForeignKey("Order", null=True, on_delete=models.SET_NULL)

--- a/tests/fixtures/python/ARCH-011/expected.json
+++ b/tests/fixtures/python/ARCH-011/expected.json
@@ -15,6 +15,9 @@
     },
     "pass_service_with_branching.py": {
       "expected_findings": []
+    },
+    "pass_connector_xpath_dispatch.py": {
+      "expected_findings": []
     }
   }
 }

--- a/tests/fixtures/python/ARCH-011/pass_connector_xpath_dispatch.py
+++ b/tests/fixtures/python/ARCH-011/pass_connector_xpath_dispatch.py
@@ -1,0 +1,23 @@
+"""Fixture for ARCH-011: a connector branching on parsed XML shape.
+
+The branch inspects the parsed response (an XPath hit, an element tag) to
+choose how to translate it. That is format translation, the connector's job —
+not a business decision — so ARCH-011 must not fire.
+"""
+
+import xml.etree.ElementTree as ET
+
+
+def parse_grant(payload: str) -> dict:
+    root = ET.fromstring(payload)
+    if root.find("OpportunityID") is not None:
+        return {"id": root.findtext("OpportunityID")}
+    else:
+        return {"id": root.findtext("FundingOpportunityNumber")}
+
+
+def classify(element) -> str:
+    if element.tag == "Grant":
+        return "grant"
+    else:
+        return "other"

--- a/tests/fixtures/python/DOM-001/expected.json
+++ b/tests/fixtures/python/DOM-001/expected.json
@@ -40,6 +40,9 @@
     },
     "pass_manager_generic_type.py": {
       "expected_findings": []
+    },
+    "pass_telemetry_event_table.py": {
+      "expected_findings": []
     }
   }
 }

--- a/tests/fixtures/python/DOM-001/pass_telemetry_event_table.py
+++ b/tests/fixtures/python/DOM-001/pass_telemetry_event_table.py
@@ -1,0 +1,21 @@
+# Fixture for DOM-001: telemetry/event tables are anemic by design.
+# MatchImpression records an observation; behavior belongs to the aggregator.
+from django.db import models
+
+
+class MatchImpression(models.Model):
+    match_id = models.IntegerField()
+    user_id = models.IntegerField()
+    shown_at = models.DateTimeField()
+    position = models.IntegerField()
+    surface = models.CharField(max_length=50)
+    dwell_ms = models.IntegerField()
+
+
+class Feedback(models.Model):
+    user_id = models.IntegerField()
+    target_id = models.IntegerField()
+    rating = models.IntegerField()
+    comment = models.CharField(max_length=500)
+    created_at = models.DateTimeField()
+    source = models.CharField(max_length=50)

--- a/tests/fixtures/python/IDX-001/expected.json
+++ b/tests/fixtures/python/IDX-001/expected.json
@@ -26,6 +26,17 @@
     },
     "pass_non_lookup_charfields.py": {
       "expected_findings": []
+    },
+    "fail_trailing_composite_column.py": {
+      "expected_findings": [
+        {
+          "severity": "warn",
+          "message_contains": "code"
+        }
+      ]
+    },
+    "pass_covering_composite_index.py": {
+      "expected_findings": []
     }
   }
 }

--- a/tests/fixtures/python/IDX-001/fail_trailing_composite_column.py
+++ b/tests/fixtures/python/IDX-001/fail_trailing_composite_column.py
@@ -1,0 +1,18 @@
+"""Fixture for IDX-001: a trailing composite-index column is not covered.
+
+``code`` is the SECOND column of ``(tenant, code)``. A B-tree composite index
+serves prefix lookups on its leading column, not standalone lookups on a
+trailing column, so ``code`` still needs its own index — IDX-001 must fire.
+"""
+
+from django.db import models
+
+
+class Product(models.Model):
+    tenant = models.IntegerField()
+    code = models.CharField(max_length=64)
+
+    class Meta:
+        indexes = [
+            models.Index(fields=["tenant", "code"]),
+        ]

--- a/tests/fixtures/python/IDX-001/pass_covering_composite_index.py
+++ b/tests/fixtures/python/IDX-001/pass_covering_composite_index.py
@@ -1,0 +1,18 @@
+"""Fixture for IDX-001: a covering composite index serves the lookup column.
+
+``status`` leads the composite index ``(status, created_at)``, so a query
+filtering on ``status`` is already served. A standalone db_index would only
+duplicate coverage, so IDX-001 must not fire on ``status``.
+"""
+
+from django.db import models
+
+
+class Order(models.Model):
+    status = models.CharField(max_length=20)
+    created_at = models.DateTimeField()
+
+    class Meta:
+        indexes = [
+            models.Index(fields=["status", "created_at"]),
+        ]

--- a/tests/fixtures/python/PYD-ARCH-001/expected.json
+++ b/tests/fixtures/python/PYD-ARCH-001/expected.json
@@ -24,6 +24,9 @@
     },
     "pass_model_config.py": {
       "expected_findings": []
+    },
+    "pass_classvar_default.py": {
+      "expected_findings": []
     }
   }
 }

--- a/tests/fixtures/python/PYD-ARCH-001/pass_classvar_default.py
+++ b/tests/fixtures/python/PYD-ARCH-001/pass_classvar_default.py
@@ -1,0 +1,15 @@
+"""Fixture for PYD-ARCH-001: a ClassVar mutable value is not an instance field.
+
+A ClassVar is a class attribute shared by design, not a per-instance default,
+so a mutable value there is not the hidden-state trap the rule targets.
+"""
+
+from typing import ClassVar
+
+from pydantic import BaseModel
+
+
+class Order(BaseModel):
+    DEFAULTS: ClassVar[dict] = {"currency": "USD"}
+    ALLOWED: ClassVar[list] = ["a", "b"]
+    qty: int = 1

--- a/tests/fixtures/python/SEC-003/expected.json
+++ b/tests/fixtures/python/SEC-003/expected.json
@@ -34,6 +34,9 @@
     },
     "pass_test_prefix_values.py": {
       "expected_findings": []
+    },
+    "pass_env_var_name_constant.py": {
+      "expected_findings": []
     }
   }
 }

--- a/tests/fixtures/python/SEC-003/pass_env_var_name_constant.py
+++ b/tests/fixtures/python/SEC-003/pass_env_var_name_constant.py
@@ -1,0 +1,13 @@
+"""Fixture for SEC-003: constants naming env vars, not carrying secrets.
+
+Each holder has a credential-ish name (so the rule is consulted), but its
+value is an environment-variable NAME (UPPER_SNAKE_CASE), or the holder is
+suffixed to mark it as a name — so nothing here is a literal secret.
+"""
+
+# Holder-suffix path: the ``_env`` / ``_var`` suffix marks a var-name holder.
+AUTH_TOKEN_ENV = "MYAPP_AUTH_TOKEN"
+ACCESS_TOKEN_VAR = "SERVICE_ACCESS_TOKEN"
+
+# Value-shape path: a bare UPPER_SNAKE value is an env-var name, not a secret.
+auth_token = "DJANGO_AUTH_TOKEN"

--- a/tests/fixtures/python/SMELL-025/expected.json
+++ b/tests/fixtures/python/SMELL-025/expected.json
@@ -55,6 +55,9 @@
     },
     "pass_protocol_version.py": {
       "expected_findings": []
+    },
+    "pass_pinned_version_literal.py": {
+      "expected_findings": []
     }
   }
 }

--- a/tests/fixtures/python/SMELL-025/pass_pinned_version_literal.py
+++ b/tests/fixtures/python/SMELL-025/pass_pinned_version_literal.py
@@ -1,0 +1,5 @@
+# ABOUTME: Fixture for SMELL-025 — a constant whose _V1 name pins its stored value.
+# ABOUTME: The literal is a persisted/DB-pinned contract, not change-history naming.
+
+SCHEMA_V1 = "v1"
+PROMPT_VERSION_V2 = "prompt-v2"

--- a/tests/fixtures/python/STRUCT-010/expected.json
+++ b/tests/fixtures/python/STRUCT-010/expected.json
@@ -21,6 +21,12 @@
     },
     "pass_unrelated_append.py": {
       "expected_findings": []
+    },
+    "pass_entrypoint_bootstrap.py": {
+      "expected_findings": []
+    },
+    "pass_scripts_dir_bootstrap/": {
+      "expected_findings": []
     }
   }
 }

--- a/tests/fixtures/python/STRUCT-010/pass_entrypoint_bootstrap.py
+++ b/tests/fixtures/python/STRUCT-010/pass_entrypoint_bootstrap.py
@@ -1,0 +1,20 @@
+"""Fixture for STRUCT-010: an executable entrypoint bootstrapping sys.path.
+
+The file has an ``if __name__ == "__main__":`` guard, so it is run directly
+rather than imported. Prepending its own location to ``sys.path`` to find
+siblings before the package is installed is the by-design pattern — STRUCT-010
+must not fire.
+"""
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+
+def main() -> None:
+    pass
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/fixtures/python/STRUCT-010/pass_scripts_dir_bootstrap/pyproject.toml
+++ b/tests/fixtures/python/STRUCT-010/pass_scripts_dir_bootstrap/pyproject.toml
@@ -1,0 +1,3 @@
+[project]
+name = "fixture_project"
+version = "0.0.0"

--- a/tests/fixtures/python/STRUCT-010/pass_scripts_dir_bootstrap/scripts/run.py
+++ b/tests/fixtures/python/STRUCT-010/pass_scripts_dir_bootstrap/scripts/run.py
@@ -1,0 +1,6 @@
+# ABOUTME: Fixture for STRUCT-010 — a script under scripts/ bootstrapping sys.path.
+# ABOUTME: Files under scripts/ are entrypoints; a self-locating bootstrap is by design.
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))


### PR DESCRIPTION
Closes #239.

Rule-precision pass on the false-positive cluster — same class as the STAB-011 fix in v0.2.1. Each rule kept firing on a by-design pattern (evidence: repeated `# noqa` + PR rationales across the estate, esp. aigranthelper PR#832). Each is refined to keep catching genuine violations while stopping the false fire, so repos can drop the corresponding noqas.

## Per-rule precision fixes
- **DOM-001** — exempt telemetry/event/value tables (name's final word: event, impression, log, audit, metric, snapshot, feedback, ...). Their behavior belongs to the aggregator that reads them.
- **ARCH-003** — require the true join-table shape (every column an FK). A first-class entity with real fields + two optional FKs no longer fires; a pure-FK model whose FKs are all nullable still does.
- **IDX-001** — exempt a lookup column already served by a covering composite index. Parser now captures `Meta.indexes` / `index_together` / `unique_together` column tuples into `ModelInfo.composite_indexes`; a column leading such an index is covered (B-tree prefix). A trailing-column lookup still fires.
- **ARCH-011** — exempt connector parse-layer dispatch (the if-test contains an XML/XPath parser call or a parsed-element attribute like `.tag`/`.attrib`). Branching on a business value still fires.
- **SMELL-025** — exempt a version-suffixed constant whose string value pins that version (`SCHEMA_V1 = "v1"`): a persisted/DB-pinned literal, not change history.
- **SEC-003** — distinguish an env-var NAME constant (UPPER_SNAKE value or `_env` holder suffix) from a literal secret.
- **PYD-ARCH-001** — don't fire on `ClassVar`-annotated attributes (class attributes, not per-instance defaults).
- **STRUCT-010** — exempt executable-entrypoint `sys.path` bootstraps (scripts/bin/tools path, `manage.py`/`conftest.py`, or an `if __name__ == "__main__":` guard). A library module that hacks `sys.path` still fires.

## Tests
Each rule gains a pass fixture for the by-design case and keeps/adds a fail proving genuine violations still fire (ARCH-003 fail converted: the old fail had a real field, so it became a pass; a pure-FK fail was added). Full suite green: 1072 passed, fixture-coverage `--strict`, cheat-sheet drift, bandit, ruff, detect-secrets all clean.

## Version
Bumps 0.2.1 → 0.2.2 (carries STAB-011 from v0.2.1 plus this precision pass). **Release is a separate overseen step — not cut here.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)