### PR TITLE
security: Tier-1 secret-scan gate (OS#221 propagation)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,13 @@ jobs:
       - name: Install dependencies
         run: uv pip install --system -e ".[dev]"
 
+      # ruff is pinned: an unpinned ruff here reddened every PR when 0.16
+      # (new markdown formatting + new lint rules, 273 errors repo-wide)
+      # released between main runs. 0.15.0 is the newest version the tree is
+      # green under. Upgrade deliberately, together with the pre-commit pin.
+      - name: Pin ruff to the repo standard
+        run: uv pip install --system "ruff==0.15.0"
+
       - name: Check formatting
         run: ruff format --check .
 

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,9 @@
+# Repo-local gitleaks config for the estate secret-scan gate (OS#221).
+# .secrets.baseline is detect-secrets' hashed allowlist — its entries are
+# secret-shaped BY DESIGN and can never be live values. Same disposition as
+# the Tier-0 triage (OS#220).
+[extend]
+useDefault = true
+
+[allowlist]
+paths = ['''\.secrets\.baseline$''']

--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -1,0 +1,6 @@
+# gitleaks fingerprint allowlist (red-team Tier-1 baseline, OS#221).
+# One `commit:file:rule:startline` fingerprint per line = an accepted/inert
+# finding the continuous secret-scan gate must ignore. gaudi's two Tier-0
+# hits (OS#220) are gaudi's OWN SEC-003 secret-detector test fixtures.
+d4cf212b20e41bf5129ebc1ffb7aa37d8457ad43:tests/fixtures/python/SEC-003/fail_hardcoded_credentials.py:generic-api-key:4
+6d0e9b9f8aee9ad31d8fdad875cebf5b2998b462:tests/fixtures/sec_hardcoded_credential.py:generic-api-key:8

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,6 +21,12 @@ repos:
 
   - repo: local
     hooks:
+      - id: secret-scan
+        name: secret-scan gate (gitleaks, redacted)
+        entry: python3 scripts/dev/secret_scan.py --staged
+        language: system
+        pass_filenames: false
+        always_run: true
       - id: gaudi-cheat-sheet
         name: gaudi cheat-sheet drift guard
         entry: gaudi cheat-sheet --check -o docs/gaudi-rules.md

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1,42 +1,222 @@
 {
   "version": "1.5.0",
   "plugins_used": [
-    {"name": "ArtifactoryDetector"},
-    {"name": "AWSKeyDetector"},
-    {"name": "AzureStorageKeyDetector"},
-    {"name": "BasicAuthDetector"},
-    {"name": "CloudantDetector"},
-    {"name": "DiscordBotTokenDetector"},
-    {"name": "GitHubTokenDetector"},
-    {"name": "HexHighEntropyString", "limit": 3.0},
-    {"name": "IbmCloudIamDetector"},
-    {"name": "IbmCosHmacDetector"},
-    {"name": "JwtTokenDetector"},
-    {"name": "KeywordDetector"},
-    {"name": "MailchimpDetector"},
-    {"name": "NpmDetector"},
-    {"name": "PrivateKeyDetector"},
-    {"name": "SendGridDetector"},
-    {"name": "SlackDetector"},
-    {"name": "SoftlayerDetector"},
-    {"name": "SquareOAuthDetector"},
-    {"name": "StripeDetector"},
-    {"name": "TwilioKeyDetector"}
+    {
+      "name": "ArtifactoryDetector"
+    },
+    {
+      "name": "AWSKeyDetector"
+    },
+    {
+      "name": "AzureStorageKeyDetector"
+    },
+    {
+      "name": "BasicAuthDetector"
+    },
+    {
+      "name": "CloudantDetector"
+    },
+    {
+      "name": "DiscordBotTokenDetector"
+    },
+    {
+      "name": "GitHubTokenDetector"
+    },
+    {
+      "name": "HexHighEntropyString",
+      "limit": 3.0
+    },
+    {
+      "name": "IbmCloudIamDetector"
+    },
+    {
+      "name": "IbmCosHmacDetector"
+    },
+    {
+      "name": "JwtTokenDetector"
+    },
+    {
+      "name": "KeywordDetector",
+      "keyword_exclude": ""
+    },
+    {
+      "name": "MailchimpDetector"
+    },
+    {
+      "name": "NpmDetector"
+    },
+    {
+      "name": "PrivateKeyDetector"
+    },
+    {
+      "name": "SendGridDetector"
+    },
+    {
+      "name": "SlackDetector"
+    },
+    {
+      "name": "SoftlayerDetector"
+    },
+    {
+      "name": "SquareOAuthDetector"
+    },
+    {
+      "name": "StripeDetector"
+    },
+    {
+      "name": "TwilioKeyDetector"
+    }
   ],
   "filters_used": [
-    {"path": "detect_secrets.filters.allowlist.is_line_allowlist"},
-    {"path": "detect_secrets.filters.common.is_baseline_file", "filename": ".secrets.baseline"},
-    {"path": "detect_secrets.filters.common.is_ignored_due_to_verification_policies", "min_level": 2},
-    {"path": "detect_secrets.filters.heuristic.is_indirect_reference"},
-    {"path": "detect_secrets.filters.heuristic.is_likely_id_string"},
-    {"path": "detect_secrets.filters.heuristic.is_lock_file"},
-    {"path": "detect_secrets.filters.heuristic.is_not_alphanumeric_string"},
-    {"path": "detect_secrets.filters.heuristic.is_potential_uuid"},
-    {"path": "detect_secrets.filters.heuristic.is_prefixed_with_dollar_sign"},
-    {"path": "detect_secrets.filters.heuristic.is_sequential_string"},
-    {"path": "detect_secrets.filters.heuristic.is_swagger_file"},
-    {"path": "detect_secrets.filters.heuristic.is_templated_secret"}
+    {
+      "path": "detect_secrets.filters.allowlist.is_line_allowlist"
+    },
+    {
+      "path": "detect_secrets.filters.common.is_baseline_file",
+      "filename": ".secrets.baseline"
+    },
+    {
+      "path": "detect_secrets.filters.common.is_ignored_due_to_verification_policies",
+      "min_level": 2
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_indirect_reference"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_likely_id_string"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_lock_file"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_not_alphanumeric_string"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_potential_uuid"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_prefixed_with_dollar_sign"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_sequential_string"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_swagger_file"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_templated_secret"
+    }
   ],
-  "results": {},
-  "generated_at": "2025-04-05T00:00:00Z"
+  "results": {
+    "README.md": [
+      {
+        "type": "Secret Keyword",
+        "filename": "README.md",
+        "hashed_secret": "3a48b39bbae967950b2c192a8a1e7245df5e094c",
+        "is_verified": false,
+        "line_number": 195
+      }
+    ],
+    "tests/fixtures/python/DJ-SEC-001/fail_settings_hardcoded_secret.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/fixtures/python/DJ-SEC-001/fail_settings_hardcoded_secret.py",
+        "hashed_secret": "2757abfac3c9956cd341c0edd80784c30867366d",
+        "is_verified": false,
+        "line_number": 5
+      }
+    ],
+    "tests/fixtures/python/DJ-SEC-001/pass_models.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/fixtures/python/DJ-SEC-001/pass_models.py",
+        "hashed_secret": "9e7d29dc0214d75614b43a707df135b41823c839",
+        "is_verified": false,
+        "line_number": 9
+      }
+    ],
+    "tests/fixtures/python/DJ-SEC-001/pass_settings_test_placeholder.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/fixtures/python/DJ-SEC-001/pass_settings_test_placeholder.py",
+        "hashed_secret": "5929ea06942c2efb8052566dc8e6e3d0ce4fc2ce",
+        "is_verified": false,
+        "line_number": 9
+      }
+    ],
+    "tests/fixtures/python/SEC-003/fail_hardcoded_credentials.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/fixtures/python/SEC-003/fail_hardcoded_credentials.py",
+        "hashed_secret": "f3bbbd66a63d4bf1747940578ec3d0103530e21d",
+        "is_verified": false,
+        "line_number": 3
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/fixtures/python/SEC-003/fail_hardcoded_credentials.py",
+        "hashed_secret": "159920628cb789601a3ef7859918baa2e9ea7d15",
+        "is_verified": false,
+        "line_number": 4
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/fixtures/python/SEC-003/fail_hardcoded_credentials.py",
+        "hashed_secret": "7f6bfc6fa9989c139ce210658817f2b588dd5895",
+        "is_verified": false,
+        "line_number": 5
+      }
+    ],
+    "tests/fixtures/python/SEC-003/pass_placeholder_values.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/fixtures/python/SEC-003/pass_placeholder_values.py",
+        "hashed_secret": "aecdccc1cf64595b34e0cc152d238daabb32183a",
+        "is_verified": false,
+        "line_number": 3
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/fixtures/python/SEC-003/pass_placeholder_values.py",
+        "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
+        "is_verified": false,
+        "line_number": 4
+      }
+    ],
+    "tests/fixtures/python/SEC-003/pass_test_prefix_values.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/fixtures/python/SEC-003/pass_test_prefix_values.py",
+        "hashed_secret": "5929ea06942c2efb8052566dc8e6e3d0ce4fc2ce",
+        "is_verified": false,
+        "line_number": 7
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/fixtures/python/SEC-003/pass_test_prefix_values.py",
+        "hashed_secret": "a0650e20e864353c54208d05ecd7ba2609ee7acc",
+        "is_verified": false,
+        "line_number": 8
+      }
+    ],
+    "tests/philosophy/convention/canonical/README.md": [
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/philosophy/convention/canonical/README.md",
+        "hashed_secret": "0671f35ae55a8863bc115f938ddc832f49c3c88b",
+        "is_verified": false,
+        "line_number": 190
+      }
+    ],
+    "tests/philosophy/convention/canonical/settings.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/philosophy/convention/canonical/settings.py",
+        "hashed_secret": "5929ea06942c2efb8052566dc8e6e3d0ce4fc2ce",
+        "is_verified": false,
+        "line_number": 15
+      }
+    ]
+  },
+  "generated_at": "2026-07-23T20:45:32Z"
 }

--- a/README.md
+++ b/README.md
@@ -131,6 +131,7 @@ Every finding follows a consistent schema:
 ```python
 from gaudi import Rule, Severity, Category
 
+
 class CheckTenantIsolation(Rule):
     code = "ARCH-001"
     severity = Severity.ERROR
@@ -192,7 +193,7 @@ Suppress findings on a single line with `# noqa`:
 
 ```python
 SECRET_KEY = "test-only"  # noqa: DJ-SEC-001
-urlpatterns = [...]       # noqa
+urlpatterns = [...]  # noqa
 ```
 
 `# noqa` (bare) suppresses all findings on that line. `# noqa: CODE1, CODE2` suppresses only the listed rules.

--- a/docs/gaudi-rules.md
+++ b/docs/gaudi-rules.md
@@ -119,7 +119,7 @@
 - **API-003 LeakingInternalID** — Replace <int:pk> with <uuid:pk> or a slug. Sequential integer IDs leak row counts and enable BOLA-style enumeration attacks.
 - **API-004 NoErrorResponseSchema** — Add a responses={{404: {{'model': Error}}, ...}} kwarg so the OpenAPI document describes both the success and error shapes.
 - **ARCH-001 NoTenantIsolation** — Consider adding a tenant_id, organization_id, or account_id ForeignKey to models that store user data. Enforce filtering in all queries. Promote to warn with [gaudi.rules] "ARCH-001" = "warn" if multi-tenancy applies.
-- **ARCH-003 NullableForeignKeySprawl** — A model whose only fields are nullable ForeignKeys is a join table that can exist while recording no association. Make the ForeignKeys required, or model the optional relationships as a first-class entity with its own fields.
+- **ARCH-003 NullableForeignKeySprawl** — Review whether nullable ForeignKeys represent truly optional relationships or if the model is trying to handle multiple relationship types. Consider a join table or polymorphic pattern.
 - **ASYNC-004 NoGracefulShutdown** — Register a signal.signal(SIGTERM, ...) handler before asyncio.run() so the service can drain in-flight work on shutdown.
 - **CPLX-001 ShallowModule** — Deepen the module by combining trivial helpers or hiding them behind fewer, richer entry points. Ousterhout: 'modules should be deep' -- the cost of a public name is the documentation and cognitive load it imposes on every caller.
 - **CPLX-004 ConjoinedMethods** — Conjoined methods force callers to remember a specific call order. Combine '{setter}' and '{checker}' into one operation, use a context manager, or pass the state explicitly so the order is impossible to get wrong.

--- a/docs/gaudi-rules.md
+++ b/docs/gaudi-rules.md
@@ -119,7 +119,7 @@
 - **API-003 LeakingInternalID** — Replace <int:pk> with <uuid:pk> or a slug. Sequential integer IDs leak row counts and enable BOLA-style enumeration attacks.
 - **API-004 NoErrorResponseSchema** — Add a responses={{404: {{'model': Error}}, ...}} kwarg so the OpenAPI document describes both the success and error shapes.
 - **ARCH-001 NoTenantIsolation** — Consider adding a tenant_id, organization_id, or account_id ForeignKey to models that store user data. Enforce filtering in all queries. Promote to warn with [gaudi.rules] "ARCH-001" = "warn" if multi-tenancy applies.
-- **ARCH-003 NullableForeignKeySprawl** — Review whether nullable ForeignKeys represent truly optional relationships or if the model is trying to handle multiple relationship types. Consider a join table or polymorphic pattern.
+- **ARCH-003 NullableForeignKeySprawl** — A model whose only fields are nullable ForeignKeys is a join table that can exist while recording no association. Make the ForeignKeys required, or model the optional relationships as a first-class entity with its own fields.
 - **ASYNC-004 NoGracefulShutdown** — Register a signal.signal(SIGTERM, ...) handler before asyncio.run() so the service can drain in-flight work on shutdown.
 - **CPLX-001 ShallowModule** — Deepen the module by combining trivial helpers or hiding them behind fewer, richer entry points. Ousterhout: 'modules should be deep' -- the cost of a public name is the documentation and cognitive load it imposes on every caller.
 - **CPLX-004 ConjoinedMethods** — Conjoined methods force callers to remember a specific call order. Combine '{setter}' and '{checker}' into one operation, use a context manager, or pass the state explicitly so the order is impossible to get wrong.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,6 +84,9 @@ where = ["src"]
 [tool.ruff]
 target-version = "py310"
 line-length = 100
+# Vendored estate byte-copy (canonical: OverSteward shared/scripts/dev/) —
+# formatting it here would break the byte-identity /sync-status enforces.
+extend-exclude = ["scripts/dev/secret_scan.py"]
 
 [tool.ruff.lint.per-file-ignores]
 "tests/fixtures/*" = ["F401", "F841", "E402", "E722"]
@@ -93,7 +96,7 @@ testpaths = ["tests"]
 norecursedirs = ["fixtures"]
 
 [tool.bandit]
-# .claude/hooks holds the OverSteward-canonical worktree guard (dev tooling,
-# byte-identical across the estate — not shipped package code).
-exclude_dirs = ["tests", ".claude"]
+# .claude/hooks and scripts/dev hold OverSteward-canonical byte-copies (dev
+# tooling, byte-identical across the estate — not shipped package code).
+exclude_dirs = ["tests", ".claude", "scripts/dev"]
 skips = ["B101", "B110", "B112"]

--- a/scripts/dev/secret_scan.py
+++ b/scripts/dev/secret_scan.py
@@ -30,7 +30,8 @@ skips** by default (local gates are primary, CI is the watchdog — matching the
 estate's pre-launch posture). Set ``SECRET_SCAN_REQUIRED=1`` (CI does) to
 **fail closed** instead, so the watchdog cannot be silently no-op'd.
 
-Exit codes: ``0`` clean or skipped, ``1`` findings, ``2`` required-but-unavailable.
+Exit codes: ``0`` clean or skipped, ``1`` findings, ``2`` required-but-unavailable
+or the scan ran but could not see the diff (partial scan — always fail-closed).
 """
 
 from __future__ import annotations
@@ -98,6 +99,48 @@ def docker_available() -> bool:
     )
 
 
+class PartialScanError(RuntimeError):
+    """gitleaks ran but could not see the repo/diff — the report is not trustworthy."""
+
+
+# Marker strings gitleaks emits when a scan ran on incomplete data. A partial
+# scan writes an EMPTY report and exits 0, which the gate would otherwise read
+# as clean — the exact failure mode found in linked worktrees (2026-07-23).
+_INCOMPLETE_MARKERS = ("partial scan", "fatal:")
+
+
+def scan_incomplete(stderr_text: str) -> bool:
+    """True when gitleaks stderr shows the scan ran on incomplete data."""
+    low = stderr_text.lower()
+    return any(marker in low for marker in _INCOMPLETE_MARKERS)
+
+
+def git_mounts(repo: Path) -> list[str]:
+    """Docker ``-v`` args exposing everything git needs, at host-identical paths.
+
+    The repo mounts read-only at its own absolute path so every absolute path
+    git stores (the worktree ``.git`` pointer file, the admin back-pointer)
+    resolves identically inside the container. A linked worktree keeps its real
+    git dir under the main repo's ``.git/worktrees/<name>`` — outside the
+    worktree tree — so that common dir is mounted too, else gitleaks sees
+    ``fatal: not a git repository`` and silently produces an empty report.
+    """
+    mounts = ["-v", f"{repo}:{repo}:ro"]
+    probe = subprocess.run(
+        ["git", "-C", str(repo), "rev-parse", "--git-common-dir"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if probe.returncode == 0:
+        common = Path(probe.stdout.strip())
+        if not common.is_absolute():
+            common = (repo / common).resolve()
+        if not common.is_relative_to(repo):
+            mounts += ["-v", f"{common}:{common}:ro"]
+    return mounts
+
+
 def build_gitleaks_cmd(
     repo: Path, out_report: Path, image: str, *, staged: bool, rev_range: str | None
 ) -> list[str]:
@@ -112,18 +155,16 @@ def build_gitleaks_cmd(
         "docker",
         "run",
         "--rm",
-        "-v",
-        f"{repo}:/repo:ro",
+        *git_mounts(repo),
         "-v",
         f"{out_report.parent}:/out",
         image,
         sub,
-        "--source=/repo",
+        f"--source={repo}",
         "--redact",
         "--report-format=json",
         f"--report-path=/out/{out_report.name}",
         "--exit-code=0",
-        "--log-level=error",
     ]
     if staged:
         cmd.append("--staged")
@@ -148,6 +189,15 @@ def run_scan(
             # here are config/plumbing) and treat as a scan failure.
             msg = proc.stderr.decode("utf-8", "replace").strip()
             raise RuntimeError(f"gitleaks produced no report: {msg or 'unknown error'}")
+        stderr_text = proc.stderr.decode("utf-8", "replace")
+        if scan_incomplete(stderr_text):
+            # An empty report from a partial scan is indistinguishable from a
+            # clean one — never trust it (gitleaks logs carry no secret values;
+            # findings details live only in the redacted report).
+            raise PartialScanError(
+                "gitleaks partial scan — git metadata not fully visible to the "
+                "container (linked worktree?); refusing to treat as clean"
+            )
         return parse_report(report.read_text(encoding="utf-8"))
 
 
@@ -179,6 +229,13 @@ def main(argv: list[str] | None = None) -> int:
     repo = Path(args.repo).resolve()
     try:
         findings = run_scan(repo, args.image, staged=staged, rev_range=args.rev_range)
+    except PartialScanError as exc:
+        # The scan RAN but could not see the diff; an empty report proves
+        # nothing. Fail closed regardless of SECRET_SCAN_REQUIRED — unlike
+        # docker-unavailable, this is a live misconfiguration, not missing
+        # tooling.
+        print(f"secret-scan: {exc} — failing closed.", file=sys.stderr)
+        return 2
     except (RuntimeError, json.JSONDecodeError) as exc:
         print(f"secret-scan: scan failed — {exc}", file=sys.stderr)
         return 2 if required else 0

--- a/scripts/dev/secret_scan.py
+++ b/scripts/dev/secret_scan.py
@@ -1,0 +1,201 @@
+#!/usr/bin/env python3
+# ABOUTME: Tier-1 secret-scan gate — gitleaks (redacted) over staged/pushed diff; never prints a secret value.
+# ABOUTME: Canonical (OverSteward shared/scripts/dev/); deployed byte-identical to every repo's scripts/dev/.
+"""Continuous secret-scanning gate for the estate red-team process (OS#219 Tier 1).
+
+Tier 0 (the one-time history excavation, OS#220) established the baseline; this
+is the *ongoing* floor — it scans only what a commit/push actually adds, so it
+stays fast and quiet. It runs ``gitleaks`` through its official docker image (no
+host install, so the same byte-identical script works in every repo), always
+with ``--redact`` so a found secret's **value never touches stdout, stderr, a
+report file, or the agent transcript** — only its rule, file, and line, which is
+what a developer needs to fix it. That redaction is the whole point: a
+secret-scanner that prints the secret it found is itself a leak (credential
+hygiene, the same law that blocks ``source .env``).
+
+Modes:
+
+``--staged`` (default; pre-commit use)
+    Scan the staged index — blocks a secret before it is ever committed.
+
+``--range A..B`` (pre-push / CI use)
+    Scan the commits in a revision range — catches anything a local pre-commit
+    was bypassed on.
+
+A repo-local ``.gitleaksignore`` (fingerprints of the Tier-0 inert findings) is
+read automatically by gitleaks, so baselined noise never trips the gate.
+
+Fail-open vs fail-closed: if docker/gitleaks is unavailable the gate **warns and
+skips** by default (local gates are primary, CI is the watchdog — matching the
+estate's pre-launch posture). Set ``SECRET_SCAN_REQUIRED=1`` (CI does) to
+**fail closed** instead, so the watchdog cannot be silently no-op'd.
+
+Exit codes: ``0`` clean or skipped, ``1`` findings, ``2`` required-but-unavailable.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+DEFAULT_IMAGE = "ghcr.io/gitleaks/gitleaks:v8.18.4"
+
+
+class Finding:
+    """One gitleaks hit, reduced to non-sensitive fields only (never the value)."""
+
+    __slots__ = ("rule", "file", "line")
+
+    def __init__(self, rule: str, file: str, line: int) -> None:
+        self.rule = rule
+        self.file = file
+        self.line = line
+
+    def render(self) -> str:
+        return f"  {self.file}:{self.line}  [{self.rule}]"
+
+
+def parse_report(report_json: str) -> list[Finding]:
+    """Reduce a gitleaks JSON report to non-sensitive findings.
+
+    Deliberately reads only ``RuleID`` / ``File`` / ``StartLine`` — never
+    ``Secret`` or ``Match`` — so no value can escape even if ``--redact`` were
+    ever dropped upstream.
+    """
+    if not report_json.strip():
+        return []
+    data = json.loads(report_json)
+    findings: list[Finding] = []
+    for row in data:
+        findings.append(
+            Finding(
+                rule=str(row.get("RuleID", "unknown")),
+                file=str(row.get("File", "?")),
+                line=int(row.get("StartLine", 0) or 0),
+            )
+        )
+    return findings
+
+
+def docker_available() -> bool:
+    """True when a docker CLI is present and its daemon answers."""
+    if shutil.which("docker") is None:
+        return False
+    return (
+        subprocess.run(
+            ["docker", "info"],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            check=False,
+        ).returncode
+        == 0
+    )
+
+
+def build_gitleaks_cmd(
+    repo: Path, out_report: Path, image: str, *, staged: bool, rev_range: str | None
+) -> list[str]:
+    """Assemble the docker gitleaks invocation for the requested mode.
+
+    Always ``--redact`` and ``--exit-code=0`` (we derive the gate result from the
+    report, not gitleaks' own exit, so a scan error is distinguishable from a
+    clean scan).
+    """
+    sub = "protect" if staged else "detect"
+    cmd = [
+        "docker",
+        "run",
+        "--rm",
+        "-v",
+        f"{repo}:/repo:ro",
+        "-v",
+        f"{out_report.parent}:/out",
+        image,
+        sub,
+        "--source=/repo",
+        "--redact",
+        "--report-format=json",
+        f"--report-path=/out/{out_report.name}",
+        "--exit-code=0",
+        "--log-level=error",
+    ]
+    if staged:
+        cmd.append("--staged")
+    elif rev_range:
+        cmd.append(f"--log-opts={rev_range}")
+    return cmd
+
+
+def run_scan(
+    repo: Path, image: str, *, staged: bool, rev_range: str | None
+) -> list[Finding]:
+    """Run gitleaks in a container and return the reduced findings."""
+    with tempfile.TemporaryDirectory() as td:
+        report = Path(td) / "report.json"
+        cmd = build_gitleaks_cmd(
+            repo, report, image, staged=staged, rev_range=rev_range
+        )
+        proc = subprocess.run(cmd, stdout=subprocess.DEVNULL, stderr=subprocess.PIPE, check=False)
+        if not report.exists():
+            # gitleaks writes no report only when it never ran — surface stderr
+            # (which carries no secret; --redact governs the report, and errors
+            # here are config/plumbing) and treat as a scan failure.
+            msg = proc.stderr.decode("utf-8", "replace").strip()
+            raise RuntimeError(f"gitleaks produced no report: {msg or 'unknown error'}")
+        return parse_report(report.read_text(encoding="utf-8"))
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Tier-1 secret-scan gate (redacted).")
+    mode = parser.add_mutually_exclusive_group()
+    mode.add_argument(
+        "--staged", action="store_true", help="Scan the staged index (default; pre-commit)."
+    )
+    mode.add_argument(
+        "--range", dest="rev_range", metavar="A..B", help="Scan a commit range (pre-push/CI)."
+    )
+    parser.add_argument("--repo", default=".", help="Repo root to scan (default: cwd).")
+    parser.add_argument(
+        "--image", default=os.environ.get("SECRET_SCAN_IMAGE", DEFAULT_IMAGE),
+        help="gitleaks docker image.",
+    )
+    args = parser.parse_args(argv)
+    staged = args.rev_range is None  # default mode is staged
+
+    required = os.environ.get("SECRET_SCAN_REQUIRED") == "1"
+    if not docker_available():
+        if required:
+            print("secret-scan: docker/gitleaks unavailable and SECRET_SCAN_REQUIRED=1 — failing closed.", file=sys.stderr)
+            return 2
+        print("secret-scan: docker/gitleaks unavailable — skipping (CI is the watchdog).", file=sys.stderr)
+        return 0
+
+    repo = Path(args.repo).resolve()
+    try:
+        findings = run_scan(repo, args.image, staged=staged, rev_range=args.rev_range)
+    except (RuntimeError, json.JSONDecodeError) as exc:
+        print(f"secret-scan: scan failed — {exc}", file=sys.stderr)
+        return 2 if required else 0
+
+    if findings:
+        scope = "staged changes" if staged else f"range {args.rev_range}"
+        print(f"secret-scan: {len(findings)} potential secret(s) in {scope}:", file=sys.stderr)
+        for f in findings:
+            print(f.render(), file=sys.stderr)
+        print(
+            "\nIf a hit is a false positive or an accepted/rotated value, add its gitleaks "
+            "fingerprint to .gitleaksignore. Never commit a live secret.",
+            file=sys.stderr,
+        )
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Scope
Estate secret-scan gate propagation (OverSteward OS#221):
- `scripts/dev/secret_scan.py` — byte-identical to the post-PR226 canonical (worktree git-dir mounts + partial-scan fail-closed).
- `.gitleaksignore` — gitleaks-generated baseline: the two Tier-0 hits are gaudi's own SEC-003 secret-detector test fixtures.
- Pre-commit hook entry + ruff/bandit vendored-file exclusions (formatting or flagging the byte-copy would break the byte-identity `/sync-status` enforces).
- `docs/gaudi-rules.md` regenerated — the cheat-sheet drift guard was failing on main (pre-existing stale ARCH-003 text).

## Verification
Red/green live in a linked worktree (the post-fix canonical makes that topology work): clean stage exit 0; planted AWS documentation-example key exit 1, redacted. The gate hook passed on this PR's own commits. Full pre-commit matrix green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)